### PR TITLE
feat: add environment config, typed errors, useVanaData hook, and config helper

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,71 @@
+# @opendatalabs/connect
+
+SDK for integrating Vana Data Portability "Connect data" flows into web applications.
+
+## Architecture
+
+```
+src/
+├── core/           # Universal (browser + Node.js)
+│   ├── constants.ts    # Environment URLs, getEnvConfig()
+│   ├── errors.ts       # ConnectError, ConnectErrorCode
+│   ├── grants.ts       # isValidGrant() type guard
+│   ├── types.ts        # All shared TypeScript interfaces
+│   └── index.ts        # Re-exports
+├── server/         # Node.js only (requires viem)
+│   ├── connect.ts      # High-level connect() and getData()
+│   ├── session-relay.ts # Session Relay HTTP client
+│   ├── data-client.ts  # Data Gateway / Personal Server client
+│   ├── request-signer.ts # Web3Signed auth header generation
+│   ├── manifest-signer.ts # Web app manifest signing
+│   ├── config.ts       # createVanaConfig() configuration helper
+│   ├── webhook.ts      # verifyWebhook() stub
+│   └── index.ts        # Re-exports
+├── react/          # Browser only (requires react)
+│   ├── useVanaConnect.ts # Polling hook
+│   ├── useVanaData.ts    # Full-flow hook (init + poll + fetch)
+│   ├── ConnectButton.tsx # Pre-built UI component
+│   └── index.ts        # Re-exports
+└── index.ts        # Re-exports core
+```
+
+### Entry points
+
+| Import path                    | Environment | Key exports                                                                   |
+| ------------------------------ | ----------- | ----------------------------------------------------------------------------- |
+| `@opendatalabs/connect/server` | Node.js     | `connect`, `getData`, `createVanaConfig`, `signVanaManifest`, `verifyWebhook` |
+| `@opendatalabs/connect/react`  | Browser     | `useVanaConnect`, `useVanaData`, `ConnectButton`                              |
+| `@opendatalabs/connect/core`   | Universal   | `ConnectError`, `ConnectErrorCode`, `isValidGrant`, types                     |
+| `@opendatalabs/connect`        | Universal   | Re-exports core                                                               |
+
+### Core flow
+
+1. **Server**: `connect({ privateKey, scopes })` creates a session on the Session Relay
+2. **Client**: `useVanaConnect().connect({ sessionId })` polls until user approves in the Vana Desktop App
+3. **Server**: `getData({ privateKey, grant })` fetches user data from their Personal Server
+
+## Build & test
+
+```bash
+pnpm build        # tsc --build
+pnpm test         # vitest run
+pnpm validate     # lint + format check + test
+pnpm test:watch   # vitest in watch mode
+```
+
+## Conventions
+
+- **ESM-only** — `"type": "module"` in package.json
+- **Zero runtime dependencies** — viem and react are optional peer dependencies
+- **Factory pattern** for low-level clients (`createSessionRelay`, `createDataClient`, `createRequestSigner`)
+- **TSDoc** on all public exports with `@param`, `@returns`, `@throws`, `@example`
+- **Error handling** via `ConnectError` with typed `ConnectErrorCode` constants
+- **Test framework**: vitest with `vi.stubGlobal("fetch", mockFetch)` pattern for HTTP mocking
+- **Commit messages**: conventional commits (`feat:`, `fix:`, `docs:`, `refactor:`)
+
+## Environment variables (for examples/nextjs-starter)
+
+| Variable           | Required | Description                       |
+| ------------------ | -------- | --------------------------------- |
+| `VANA_PRIVATE_KEY` | Yes      | Builder private key (0x-prefixed) |
+| `APP_URL`          | Yes      | Public URL of your deployed app   |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/README.md
+++ b/README.md
@@ -109,8 +109,8 @@ const data = await getData({
   grant, // GrantPayload from step 2
 });
 
-// Map<string, unknown> keyed by scope
-const conversations = data.get("chatgpt.conversations");
+// Record<string, unknown> keyed by scope
+const conversations = data["chatgpt.conversations"];
 ```
 
 ### Web App Manifest
@@ -148,7 +148,7 @@ Make sure your HTML includes `<link rel="manifest" href="/manifest.json">`.
 | Import                         | Environment | Exports                                                           |
 | ------------------------------ | ----------- | ----------------------------------------------------------------- |
 | `@opendatalabs/connect/server` | Node.js     | `connect()`, `getData()`, `signVanaManifest()`, low-level clients |
-| `@opendatalabs/connect/react`  | Browser     | `useVanaConnect()`, `ConnectButton`                               |
+| `@opendatalabs/connect/react`  | Browser     | `useVanaConnect()`, `useVanaData()`, `ConnectButton`              |
 | `@opendatalabs/connect/core`   | Universal   | Types, `ConnectError`, constants                                  |
 
 ### `connect(config): Promise<SessionInitResult>`
@@ -162,7 +162,7 @@ Creates a session on the Session Relay. Returns `sessionId`, `deepLinkUrl`, and 
 | `webhookUrl` | `string`            | No       | Public HTTPS URL for grant event notifications (localhost is rejected) |
 | `appUserId`  | `string`            | No       | Your app's user ID for correlation                                     |
 
-### `getData(config): Promise<Map<string, unknown>>`
+### `getData(config): Promise<Record<string, unknown>>`
 
 Fetches user data from their Personal Server using a signed grant.
 

--- a/examples/nextjs-starter/.env.local.example
+++ b/examples/nextjs-starter/.env.local.example
@@ -1,3 +1,2 @@
-VANA_PRIVATE_KEY=0x...        # Must be registered on-chain
-SCOPES=test.dpv1.260130       # Comma-separated scopes to request
-APP_URL=https://your-app.example.com   # Public URL of your deployed app
+VANA_PRIVATE_KEY=0x...              # Builder key, must be registered on-chain
+APP_URL=http://localhost:3001       # Public URL of your deployed app

--- a/examples/nextjs-starter/README.md
+++ b/examples/nextjs-starter/README.md
@@ -1,6 +1,6 @@
 # Next.js Starter
 
-Minimal Next.js app demonstrating the Vana Connect flow. Shows the server-side SDK (`connect()` + `getData()`) and client-side polling via `useVanaConnect()`.
+Minimal Next.js app demonstrating the Vana Connect flow. Shows the server-side SDK (`connect()` + `getData()`) and client-side polling via `useVanaData()`.
 
 ## Prerequisites
 
@@ -18,11 +18,12 @@ pnpm dev   # Opens on http://localhost:3001
 
 ## Environment Variables
 
-| Variable           | Required | Description                                                        |
-| ------------------ | -------- | ------------------------------------------------------------------ |
-| `VANA_PRIVATE_KEY` | Yes      | Builder private key registered on-chain                            |
-| `SCOPES`           | No       | Comma-separated scopes                                             |
-| `APP_URL`          | No       | Public URL of your deployed app (default: `http://localhost:3001`) |
+| Variable           | Required | Description                             |
+| ------------------ | -------- | --------------------------------------- |
+| `VANA_PRIVATE_KEY` | Yes      | Builder private key registered on-chain |
+| `APP_URL`          | Yes      | Public URL of your deployed app         |
+
+> Scopes are configured in `src/config.ts`. Edit the `SCOPES` array to change which user data your app requests.
 
 ## Web App Manifest
 

--- a/examples/nextjs-starter/next.config.js
+++ b/examples/nextjs-starter/next.config.js
@@ -1,4 +1,4 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = { reactStrictMode: true };
 
 export default nextConfig;

--- a/examples/nextjs-starter/src/app/api/connect/route.ts
+++ b/examples/nextjs-starter/src/app/api/connect/route.ts
@@ -1,25 +1,19 @@
+// Creates a session to connect data from dataConnect into your app.
+// Returns a deep link for the user to approve in the dataConnect Desktop App.
+
 import { NextResponse } from "next/server";
 import { connect } from "@opendatalabs/connect/server";
+import { ConnectError } from "@opendatalabs/connect/core";
+import { config } from "@/config";
 
 export async function POST() {
-  const privateKey = process.env.VANA_PRIVATE_KEY as `0x${string}`;
-
-  if (!privateKey) {
-    return NextResponse.json(
-      { error: "Missing env var: VANA_PRIVATE_KEY" },
-      { status: 500 },
-    );
+  try {
+    const result = await connect(config);
+    return NextResponse.json(result);
+  } catch (err) {
+    const message =
+      err instanceof ConnectError ? err.message : "Failed to create session";
+    const status = err instanceof ConnectError ? (err.statusCode ?? 500) : 500;
+    return NextResponse.json({ error: message }, { status });
   }
-
-  const scopes = process.env.SCOPES?.split(",").map((s) => s.trim());
-  if (!scopes || !scopes.length) {
-    return NextResponse.json(
-      { error: "Missing env var: SCOPES" },
-      { status: 500 },
-    );
-  }
-
-  const result = await connect({ privateKey, scopes });
-
-  return NextResponse.json(result);
 }

--- a/examples/nextjs-starter/src/app/globals.css
+++ b/examples/nextjs-starter/src/app/globals.css
@@ -1,0 +1,143 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+}
+
+body {
+  font-family:
+    system-ui,
+    -apple-system,
+    sans-serif;
+  background: #09090b;
+  color: #e4e4e7;
+  min-height: 100vh;
+}
+
+.card {
+  background: #0f0f12;
+  border: 1px solid #27272a;
+  border-radius: 8px;
+  padding: 20px;
+  margin-bottom: 12px;
+}
+
+.card-approved {
+  border-color: #22c55e33;
+}
+
+.card-error {
+  border-color: #ef444444;
+}
+
+.btn-primary {
+  font-size: 14px;
+  font-weight: 500;
+  padding: 10px 20px;
+  border: none;
+  border-radius: 6px;
+  background: #22c55e;
+  color: #09090b;
+  cursor: pointer;
+}
+
+.btn-primary:disabled {
+  opacity: 0.7;
+  cursor: not-allowed;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.spinner {
+  display: inline-block;
+  width: 14px;
+  height: 14px;
+  border: 2px solid currentColor;
+  border-right-color: transparent;
+  border-radius: 50%;
+  animation: spin 0.6s linear infinite;
+  vertical-align: middle;
+}
+
+.btn-ghost {
+  font-family: monospace;
+  font-size: 12px;
+  padding: 8px 12px;
+  border: 1px solid #27272a;
+  border-radius: 6px;
+  background: transparent;
+  color: #71717a;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.label {
+  font-family: monospace;
+  font-size: 11px;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 1.5px;
+  color: #52525b;
+  margin-bottom: 6px;
+}
+
+.mono {
+  font-family: monospace;
+  font-size: 13px;
+  color: #a1a1aa;
+}
+
+.field-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.code-block {
+  font-family: monospace;
+  font-size: 12px;
+  background: #18181b;
+  border: 1px solid #27272a;
+  border-radius: 6px;
+  padding: 8px 10px;
+  color: #d4d4d8;
+  display: block;
+}
+
+.pre-block {
+  font-family: monospace;
+  font-size: 12px;
+  line-height: 1.6;
+  background: #18181b;
+  border: 1px solid #27272a;
+  border-radius: 6px;
+  padding: 12px;
+  color: #d4d4d8;
+  overflow: auto;
+  margin: 0;
+}
+
+.status-waiting {
+  color: #eab308;
+}
+.status-approved {
+  color: #22c55e;
+}
+.status-denied,
+.status-expired,
+.status-error {
+  color: #ef4444;
+}
+.status-default {
+  color: #71717a;
+}
+
+.text-error {
+  color: #ef4444;
+  font-size: 13px;
+}

--- a/examples/nextjs-starter/src/app/layout.tsx
+++ b/examples/nextjs-starter/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import "./globals.css";
 
 export const metadata: Metadata = {
   title: "Vana Connect — Next.js Starter",
@@ -13,23 +14,7 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
-      <head>
-        <link
-          href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap"
-          rel="stylesheet"
-        />
-      </head>
-      <body
-        style={{
-          margin: 0,
-          fontFamily: '"DM Sans", sans-serif',
-          background: "#09090b",
-          color: "#e4e4e7",
-          minHeight: "100vh",
-        }}
-      >
-        {children}
-      </body>
+      <body>{children}</body>
     </html>
   );
 }

--- a/examples/nextjs-starter/src/app/page.tsx
+++ b/examples/nextjs-starter/src/app/page.tsx
@@ -2,67 +2,14 @@ import ConnectFlow from "@/components/ConnectFlow";
 
 export default function Home() {
   return (
-    <main
-      style={{
-        maxWidth: 540,
-        margin: "0 auto",
-        padding: "64px 24px",
-      }}
-    >
-      <div style={{ marginBottom: 40 }}>
-        <div
-          style={{
-            display: "flex",
-            alignItems: "center",
-            gap: 10,
-            marginBottom: 12,
-          }}
-        >
-          <div
-            style={{
-              width: 8,
-              height: 8,
-              borderRadius: "50%",
-              background: "#22c55e",
-              boxShadow: "0 0 8px #22c55e66",
-            }}
-          />
-          <span
-            style={{
-              fontFamily: '"JetBrains Mono", monospace',
-              fontSize: 11,
-              fontWeight: 500,
-              color: "#71717a",
-              textTransform: "uppercase",
-              letterSpacing: 2,
-            }}
-          >
-            Vana Connect
-          </span>
-        </div>
-        <h1
-          style={{
-            fontSize: 22,
-            fontWeight: 600,
-            color: "#fafafa",
-            margin: 0,
-            lineHeight: 1.3,
-          }}
-        >
-          Next.js Starter
-        </h1>
-        <p
-          style={{
-            fontSize: 14,
-            color: "#71717a",
-            margin: "8px 0 0",
-            lineHeight: 1.5,
-          }}
-        >
-          Initiate a session, approve it from the Personal Server Dev UI, then
-          fetch your data.
-        </p>
-      </div>
+    <main style={{ maxWidth: 540, margin: "0 auto", padding: "64px 24px" }}>
+      <h1 style={{ fontSize: 22, fontWeight: 600, marginBottom: 8 }}>
+        Vana Connect — Next.js Starter
+      </h1>
+      <p style={{ fontSize: 14, color: "#71717a", marginBottom: 40 }}>
+        This app demonstrates how to get data from dataConnect into a Next.js
+        app.
+      </p>
       <ConnectFlow />
     </main>
   );

--- a/examples/nextjs-starter/src/config.ts
+++ b/examples/nextjs-starter/src/config.ts
@@ -1,0 +1,10 @@
+import { createVanaConfig } from "@opendatalabs/connect/server";
+
+// Scopes define what user data your app requests.
+const SCOPES = ["chatgpt.conversations"];
+
+export const config = createVanaConfig({
+  privateKey: process.env.VANA_PRIVATE_KEY as `0x${string}`,
+  scopes: SCOPES,
+  appUrl: process.env.APP_URL!,
+});

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "url": "https://github.com/vana-com/vana-connect/issues"
   },
   "type": "module",
+  "sideEffects": false,
   "publishConfig": {
     "access": "public"
   },
@@ -68,9 +69,6 @@
   },
   "peerDependenciesMeta": {
     "react": {
-      "optional": true
-    },
-    "viem": {
       "optional": true
     }
   },

--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -1,4 +1,28 @@
-export const SESSION_RELAY_URL =
-  "https://session-relay-git-dev-opendatalabs.vercel.app";
-export const GATEWAY_URL =
-  "https://data-gateway-env-dev-opendatalabs.vercel.app";
+/** SDK environment selector. */
+export type VanaEnvironment = "dev" | "prod";
+
+/** URL configuration for each SDK environment. */
+export const ENV_CONFIG = {
+  dev: {
+    sessionRelayUrl: "https://session-relay-git-dev-opendatalabs.vercel.app",
+    gatewayUrl: "https://data-gateway-env-dev-opendatalabs.vercel.app",
+  },
+  prod: {
+    // TODO: Replace with actual production URLs
+    sessionRelayUrl: "https://session-relay-git-dev-opendatalabs.vercel.app",
+    gatewayUrl: "https://data-gateway-env-dev-opendatalabs.vercel.app",
+  },
+} as const;
+
+/** Default environment used when none is specified. */
+export const DEFAULT_ENVIRONMENT: VanaEnvironment = "prod";
+
+/**
+ * Returns the URL configuration for the given environment.
+ *
+ * @param environment - `"dev"` or `"prod"`. Defaults to {@link DEFAULT_ENVIRONMENT}.
+ * @returns An object with `sessionRelayUrl` and `gatewayUrl`.
+ */
+export function getEnvConfig(environment?: VanaEnvironment) {
+  return ENV_CONFIG[environment ?? DEFAULT_ENVIRONMENT];
+}

--- a/src/core/errors.ts
+++ b/src/core/errors.ts
@@ -1,8 +1,56 @@
+/**
+ * Known error codes thrown by the SDK.
+ *
+ * Use these constants for typed `catch` handling instead of comparing raw strings.
+ *
+ * @example
+ * ```typescript
+ * import { ConnectError, ConnectErrorCode } from "@opendatalabs/connect/core";
+ *
+ * try {
+ *   await getData({ privateKey, grant });
+ * } catch (err) {
+ *   if (err instanceof ConnectError && err.code === ConnectErrorCode.SERVER_NOT_FOUND) {
+ *     // handle missing server
+ *   }
+ * }
+ * ```
+ */
+export const ConnectErrorCode = {
+  SESSION_INIT_FAILED: "SESSION_INIT_FAILED",
+  SESSION_EXPIRED: "SESSION_EXPIRED",
+  POLL_FAILED: "POLL_FAILED",
+  POLL_TIMEOUT: "POLL_TIMEOUT",
+  SERVER_NOT_FOUND: "SERVER_NOT_FOUND",
+  GATEWAY_ERROR: "GATEWAY_ERROR",
+  DATA_FETCH_FAILED: "DATA_FETCH_FAILED",
+  LIST_SCOPES_FAILED: "LIST_SCOPES_FAILED",
+  LIST_VERSIONS_FAILED: "LIST_VERSIONS_FAILED",
+  CONFIG_INVALID: "CONFIG_INVALID",
+  WEBHOOK_INVALID: "WEBHOOK_INVALID",
+} as const;
+
+/** Union type of all known error code string values. */
+export type ConnectErrorCode =
+  (typeof ConnectErrorCode)[keyof typeof ConnectErrorCode];
+
+/**
+ * Error class thrown by all SDK operations.
+ *
+ * Includes a typed {@link code} for programmatic handling and an optional
+ * {@link statusCode} from HTTP responses.
+ */
 export class ConnectError extends Error {
-  readonly code: string;
+  /** Machine-readable error code. One of {@link ConnectErrorCode} or an arbitrary server-returned string. */
+  readonly code: ConnectErrorCode | (string & {});
+  /** HTTP status code from the upstream response, if applicable. */
   readonly statusCode?: number;
 
-  constructor(message: string, code: string, statusCode?: number) {
+  constructor(
+    message: string,
+    code: ConnectErrorCode | (string & {}),
+    statusCode?: number,
+  ) {
     super(message);
     this.name = "ConnectError";
     this.code = code;

--- a/src/core/grants.ts
+++ b/src/core/grants.ts
@@ -1,0 +1,35 @@
+import type { GrantPayload } from "./types.js";
+
+/**
+ * Type guard that checks whether an unknown value has the shape of a {@link GrantPayload}.
+ *
+ * Validates the presence and types of required fields: `grantId`, `userAddress`,
+ * `builderAddress`, and `scopes` (non-empty string array).
+ *
+ * @example
+ * ```typescript
+ * const body = await request.json();
+ * if (!isValidGrant(body.grant)) {
+ *   return NextResponse.json({ error: "Invalid grant" }, { status: 400 });
+ * }
+ * // body.grant is now typed as GrantPayload
+ * const data = await getData({ privateKey, grant: body.grant });
+ * ```
+ */
+export function isValidGrant(value: unknown): value is GrantPayload {
+  if (value === null || typeof value !== "object") return false;
+
+  const obj = value as Record<string, unknown>;
+
+  return (
+    typeof obj.grantId === "string" &&
+    obj.grantId.length > 0 &&
+    typeof obj.userAddress === "string" &&
+    obj.userAddress.length > 0 &&
+    typeof obj.builderAddress === "string" &&
+    obj.builderAddress.length > 0 &&
+    Array.isArray(obj.scopes) &&
+    obj.scopes.length > 0 &&
+    obj.scopes.every((s: unknown) => typeof s === "string" && s.length > 0)
+  );
+}

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,5 +1,11 @@
-export { ConnectError } from "./errors.js";
-export { SESSION_RELAY_URL, GATEWAY_URL } from "./constants.js";
+export { ConnectError, ConnectErrorCode } from "./errors.js";
+export { isValidGrant } from "./grants.js";
+export {
+  getEnvConfig,
+  ENV_CONFIG,
+  DEFAULT_ENVIRONMENT,
+  type VanaEnvironment,
+} from "./constants.js";
 export type {
   ConnectionStatus,
   SessionInitParams,

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1,3 +1,4 @@
+/** Possible states of a Vana Connect session from the client's perspective. */
 export type ConnectionStatus =
   | "idle"
   | "connecting"
@@ -7,82 +8,142 @@ export type ConnectionStatus =
   | "expired"
   | "error";
 
+/** Parameters for creating a new session on the Session Relay. */
 export interface SessionInitParams {
+  /** Data scopes to request (e.g. `["chatgpt.conversations"]`). */
   scopes: string[];
+  /** Public HTTPS URL for grant event notifications. Localhost is rejected. */
   webhookUrl?: string;
+  /** Your app's user ID for correlation. */
   appUserId?: string;
 }
 
+/** Result returned by {@link SessionRelay.initSession}. */
 export interface SessionInitResult {
+  /** Unique session identifier used for polling. */
   sessionId: string;
+  /** Deep link URL that opens the Vana Desktop App. */
   deepLinkUrl: string;
+  /** ISO 8601 expiration timestamp for the session. */
   expiresAt: string;
 }
 
+/** Result returned by {@link SessionRelay.pollSession}. */
 export interface SessionPollResult {
+  /** Current session status. */
   status: "pending" | "claimed" | "approved" | "denied" | "expired";
+  /** Grant payload, present when status is `"approved"`. */
   grant?: GrantPayload;
+  /** Reason for denial, present when status is `"denied"`. */
   reason?: string;
 }
 
+/** Payload describing a user's approved data grant. */
 export interface GrantPayload {
+  /** On-chain permission ID. */
   grantId: string;
+  /** User's wallet address. */
   userAddress: string;
+  /** Builder's registered wallet address. */
   builderAddress: string;
+  /** Approved data scopes. */
   scopes: string[];
+  /** User's Personal Server address, if known. */
   serverAddress?: string;
+  /** Your app's user ID, if provided during session init. */
   appUserId?: string;
 }
 
+/** Parameters for fetching data from a Personal Server. */
 export interface DataFetchParams {
+  /** Base URL of the user's Personal Server. */
   serverUrl: string;
+  /** Data scope to fetch (e.g. `"instagram.profile"`). */
   scope: string;
+  /** Grant ID authorizing the data access. */
   grantId: string;
+  /** Optional file ID for a specific file within the scope. */
   fileId?: string;
+  /** Optional ISO 8601 timestamp to fetch data at a specific point in time. */
   at?: string;
 }
 
+/** Configuration for {@link createRequestSigner}. */
 export interface RequestSignerConfig {
+  /** Builder private key in hex format. */
   privateKey: `0x${string}`;
 }
 
+/** Configuration for {@link createSessionRelay}. */
 export interface SessionRelayConfig {
+  /** Builder private key in hex format. */
   privateKey: `0x${string}`;
+  /** Builder's wallet address derived from the private key. */
   granteeAddress: `0x${string}`;
+  /** Base URL of the Session Relay service. */
   sessionRelayUrl: string;
 }
 
+/** Configuration for {@link createDataClient}. */
 export interface DataClientConfig {
+  /** Builder private key in hex format. */
   privateKey: `0x${string}`;
+  /** Base URL of the Data Portability Gateway. */
   gatewayUrl: string;
 }
 
+/** Configuration for the high-level {@link connect} function. */
 export interface ConnectConfig {
+  /** Builder private key in hex format. */
   privateKey: `0x${string}`;
+  /** Data scopes to request. */
   scopes: string[];
+  /** Public HTTPS URL for grant event notifications. */
   webhookUrl?: string;
+  /** Your app's user ID for correlation. */
   appUserId?: string;
+  /** SDK environment (`"dev"` or `"prod"`). Defaults to `"prod"`. */
+  environment?: "dev" | "prod";
 }
 
+/** Configuration for the high-level {@link getData} function. */
 export interface GetDataConfig {
+  /** Builder private key in hex format. */
   privateKey: `0x${string}`;
+  /** Grant from the approval step. */
   grant: GrantPayload;
+  /** SDK environment (`"dev"` or `"prod"`). Defaults to `"prod"`. */
+  environment?: "dev" | "prod";
 }
 
+/** Configuration for {@link signVanaManifest}. */
 export interface VanaManifestConfig {
+  /** Builder private key in hex format. */
   privateKey: `0x${string}`;
+  /** Canonical URL of your application. */
   appUrl: string;
+  /** URL to your privacy policy. */
   privacyPolicyUrl: string;
+  /** URL to your terms of service. */
   termsUrl: string;
+  /** URL for user support. */
   supportUrl: string;
+  /** Public webhook URL for grant notifications. */
   webhookUrl: string;
 }
 
+/** Signed manifest block included in your web app manifest under the `vana` key. */
 export interface VanaManifestBlock {
+  /** Canonical URL of your application. */
   appUrl: string;
+  /** URL to your privacy policy. */
   privacyPolicyUrl: string;
+  /** URL to your terms of service. */
   termsUrl: string;
+  /** URL for user support. */
   supportUrl: string;
+  /** Public webhook URL for grant notifications. */
   webhookUrl: string;
+  /** Cryptographic signature of the manifest block. */
   signature: string;
 }

--- a/src/react/ConnectButton.tsx
+++ b/src/react/ConnectButton.tsx
@@ -2,16 +2,31 @@ import { useEffect } from "react";
 import type { GrantPayload } from "../core/types.js";
 import { useVanaConnect } from "./useVanaConnect.js";
 
+/** Props for the {@link ConnectButton} component. */
 export interface ConnectButtonProps {
+  /** Session ID from the server-side `connect()` call. */
   sessionId: string;
+  /** Optional deep link URL override. */
   deepLinkUrl?: string;
+  /** Called when the user approves the grant. */
   onComplete?: (grant: GrantPayload) => void;
+  /** Called on polling errors. */
   onError?: (error: string) => void;
+  /** Called when the user denies the request. */
   onDenied?: (reason: string) => void;
+  /** CSS class name for the wrapper element. */
   className?: string;
+  /** Label for the deep link anchor (default: `"Open Vana Desktop App"`). */
   label?: string;
 }
 
+/**
+ * Pre-built React component that displays connection status and a deep link.
+ *
+ * For full control over the UI, use {@link useVanaConnect} or {@link useVanaData} directly.
+ *
+ * @param props - Component props.
+ */
 export function ConnectButton(props: ConnectButtonProps) {
   const {
     sessionId,
@@ -55,7 +70,7 @@ export function ConnectButton(props: ConnectButtonProps) {
     <div className={className}>
       <p>{statusText[status] ?? status}</p>
       {deepLinkUrl && status === "waiting" && (
-        <a href={deepLinkUrl}>{label ?? "Open Vana Desktop App"}</a>
+        <a href={deepLinkUrl}>{label ?? "Open dataConnect Desktop App"}</a>
       )}
     </div>
   );

--- a/src/react/index.ts
+++ b/src/react/index.ts
@@ -4,3 +4,8 @@ export {
   type UseVanaConnectResult,
 } from "./useVanaConnect.js";
 export { ConnectButton, type ConnectButtonProps } from "./ConnectButton.js";
+export {
+  useVanaData,
+  type UseVanaDataConfig,
+  type UseVanaDataResult,
+} from "./useVanaData.js";

--- a/src/react/useVanaConnect.ts
+++ b/src/react/useVanaConnect.ts
@@ -1,28 +1,62 @@
 import { useState, useCallback, useRef, useEffect } from "react";
-import { SESSION_RELAY_URL } from "../core/constants.js";
+import { getEnvConfig } from "../core/constants.js";
 import type {
   ConnectionStatus,
   GrantPayload,
   SessionPollResult,
 } from "../core/types.js";
 
+/** Configuration for the {@link useVanaConnect} hook. */
 export interface UseVanaConnectConfig {
+  /** Polling interval in milliseconds (default: 2000). */
   pollingInterval?: number;
+  /** SDK environment (`"dev"` or `"prod"`). Defaults to `"prod"`. */
+  environment?: "dev" | "prod";
 }
 
+/** Return value of the {@link useVanaConnect} hook. */
 export interface UseVanaConnectResult {
+  /** Starts polling the Session Relay for the given session. */
   connect: (params: { sessionId: string; deepLinkUrl?: string }) => void;
+  /** Current connection status. */
   status: ConnectionStatus;
+  /** Grant payload after user approval, or `null`. */
   grant: GrantPayload | null;
+  /** Error message, or `null`. */
   error: string | null;
+  /** Deep link URL to open the Vana Desktop App, or `null`. */
   deepLinkUrl: string | null;
+  /** Resets all state back to idle and stops polling. */
   reset: () => void;
 }
 
+/**
+ * React hook that polls the Session Relay and manages connection state.
+ *
+ * Call `connect()` with a session ID (from your server's `/api/connect` route)
+ * to begin polling. The hook will update `status` through the lifecycle:
+ * `idle` -> `connecting` -> `waiting` -> `approved` | `denied` | `expired` | `error`.
+ *
+ * @param config - Optional configuration for polling interval and environment.
+ * @returns A {@link UseVanaConnectResult} with state and actions.
+ *
+ * @example
+ * ```tsx
+ * const { connect, status, grant, deepLinkUrl } = useVanaConnect();
+ *
+ * useEffect(() => {
+ *   connect({ sessionId: "sess-123" });
+ * }, []);
+ *
+ * if (status === "waiting") return <a href={deepLinkUrl!}>Open Vana</a>;
+ * if (status === "approved") return <p>Connected! Grant: {grant!.grantId}</p>;
+ * ```
+ */
 export function useVanaConnect(
   config?: UseVanaConnectConfig,
 ): UseVanaConnectResult {
-  const baseUrl = SESSION_RELAY_URL;
+  const { sessionRelayUrl } = getEnvConfig(config?.environment);
+  const baseUrl = sessionRelayUrl;
   const interval = config?.pollingInterval ?? 2000;
 
   const [status, setStatus] = useState<ConnectionStatus>("idle");
@@ -64,7 +98,11 @@ export function useVanaConnect(
           if (!res.ok) {
             // Try to extract structured error from response body
             const body = await res.json().catch(() => null);
-            const errorCode = (body as any)?.error?.errorCode;
+            const errorCode =
+              body && typeof body === "object"
+                ? (body as Record<string, Record<string, unknown>>).error
+                    ?.errorCode
+                : undefined;
 
             if (res.status === 410 || errorCode === "SESSION_EXPIRED") {
               setStatus("expired");

--- a/src/react/useVanaData.ts
+++ b/src/react/useVanaData.ts
@@ -1,0 +1,188 @@
+import { useState, useCallback, useRef, useEffect } from "react";
+import type { GrantPayload, ConnectionStatus } from "../core/types.js";
+import { useVanaConnect } from "./useVanaConnect.js";
+
+/**
+ * Configuration for the {@link useVanaData} hook.
+ */
+export interface UseVanaDataConfig {
+  /** URL of the connect API route (default: `"/api/connect"`). */
+  connectUrl?: string;
+  /** URL of the data API route (default: `"/api/data"`). */
+  dataUrl?: string;
+  /** Polling interval in ms passed to {@link useVanaConnect} (default: 2000). */
+  pollingInterval?: number;
+  /** SDK environment passed through to {@link useVanaConnect}. */
+  environment?: "dev" | "prod";
+  /** When true, automatically fetches data after grant approval (default: `true`). */
+  autoFetch?: boolean;
+}
+
+/**
+ * Return value of the {@link useVanaData} hook.
+ */
+export interface UseVanaDataResult {
+  /** Current connection status. */
+  status: ConnectionStatus;
+  /** Grant payload after user approval, or `null`. */
+  grant: GrantPayload | null;
+  /** Fetched data after calling the data route, or `null`. */
+  data: unknown;
+  /** Error message, or `null`. */
+  error: string | null;
+  /** Deep link URL to open the Vana Desktop App, or `null`. */
+  deepLinkUrl: string | null;
+  /** Starts the connect flow by calling the connect API route. */
+  initConnect: () => Promise<void>;
+  /** Manually fetches data using the current grant. */
+  fetchData: () => Promise<void>;
+  /** Resets all state back to idle. */
+  reset: () => void;
+  /** `true` while any async operation is in progress. */
+  isLoading: boolean;
+  /** `true` when status is `"approved"`. */
+  isConnected: boolean;
+}
+
+/**
+ * Full-flow hook that orchestrates the entire Vana Connect lifecycle:
+ * session init, polling, and data fetching.
+ *
+ * Composes {@link useVanaConnect} internally and adds automatic
+ * calls to your app's `/api/connect` and `/api/data` routes.
+ *
+ * @param config - Optional configuration.
+ * @returns A {@link UseVanaDataResult} with state and actions.
+ *
+ * @example
+ * ```tsx
+ * import { useVanaData } from "@opendatalabs/connect/react";
+ *
+ * function MyComponent() {
+ *   const { status, data, deepLinkUrl, initConnect, isLoading } = useVanaData();
+ *
+ *   if (status === "idle") return <button onClick={initConnect}>Connect</button>;
+ *   if (status === "waiting") return <a href={deepLinkUrl!}>Open Vana</a>;
+ *   if (data) return <pre>{JSON.stringify(data, null, 2)}</pre>;
+ *   return <p>{isLoading ? "Loading..." : status}</p>;
+ * }
+ * ```
+ */
+export function useVanaData(config?: UseVanaDataConfig): UseVanaDataResult {
+  const connectUrl = config?.connectUrl ?? "/api/connect";
+  const dataUrl = config?.dataUrl ?? "/api/data";
+  const autoFetch = config?.autoFetch ?? true;
+
+  const {
+    connect,
+    status: pollStatus,
+    grant: pollGrant,
+    error: pollError,
+    deepLinkUrl,
+    reset: resetPoll,
+  } = useVanaConnect({
+    pollingInterval: config?.pollingInterval,
+    environment: config?.environment,
+  });
+
+  const [data, setData] = useState<unknown>(null);
+  const [fetchError, setFetchError] = useState<string | null>(null);
+  const [fetching, setFetching] = useState(false);
+  const [initLoading, setInitLoading] = useState(false);
+  const autoFetchedRef = useRef(false);
+
+  const fetchData = useCallback(async () => {
+    if (!pollGrant) return;
+    setFetching(true);
+    setFetchError(null);
+    try {
+      const res = await fetch(dataUrl, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ grant: pollGrant }),
+      });
+      const json = await res.json();
+      if (!res.ok) {
+        setFetchError(
+          (json as Record<string, unknown>).error
+            ? String((json as Record<string, unknown>).error)
+            : `Data fetch failed: ${res.status}`,
+        );
+        return;
+      }
+      setData(json);
+    } catch (err) {
+      setFetchError(
+        err instanceof Error ? err.message : "Unknown data fetch error",
+      );
+    } finally {
+      setFetching(false);
+    }
+  }, [pollGrant, dataUrl]);
+
+  // Auto-fetch on approval
+  useEffect(() => {
+    if (
+      pollStatus === "approved" &&
+      pollGrant &&
+      autoFetch &&
+      !autoFetchedRef.current
+    ) {
+      autoFetchedRef.current = true;
+      void fetchData();
+    }
+  }, [pollStatus, pollGrant, autoFetch, fetchData]);
+
+  const initConnect = useCallback(async () => {
+    setData(null);
+    setFetchError(null);
+    autoFetchedRef.current = false;
+    setInitLoading(true);
+    try {
+      const res = await fetch(connectUrl, { method: "POST" });
+      const json = (await res.json()) as Record<string, unknown>;
+      if (!res.ok) {
+        setFetchError(
+          json.error ? String(json.error) : `Connect failed: ${res.status}`,
+        );
+        return;
+      }
+      connect({
+        sessionId: json.sessionId as string,
+        deepLinkUrl: json.deepLinkUrl as string,
+      });
+    } catch (err) {
+      setFetchError(
+        err instanceof Error ? err.message : "Unknown connect error",
+      );
+    } finally {
+      setInitLoading(false);
+    }
+  }, [connectUrl, connect]);
+
+  const reset = useCallback(() => {
+    resetPoll();
+    setData(null);
+    setFetchError(null);
+    setFetching(false);
+    setInitLoading(false);
+    autoFetchedRef.current = false;
+  }, [resetPoll]);
+
+  const error = pollError ?? fetchError;
+  const isLoading = initLoading || fetching || pollStatus === "connecting";
+  const isConnected = pollStatus === "approved";
+
+  return {
+    status: pollStatus,
+    grant: pollGrant,
+    data,
+    error,
+    deepLinkUrl,
+    initConnect,
+    fetchData,
+    reset,
+    isLoading,
+    isConnected,
+  };
+}

--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -1,0 +1,73 @@
+import { ConnectError, ConnectErrorCode } from "../core/errors.js";
+import type { VanaEnvironment } from "../core/constants.js";
+
+export interface VanaConfig {
+  privateKey: `0x${string}`;
+  scopes: string[];
+  appUrl: string;
+  environment?: VanaEnvironment;
+}
+
+/**
+ * Creates a validated SDK configuration.
+ *
+ * All values must be passed explicitly — the SDK does not read
+ * environment variables. The calling application is responsible
+ * for sourcing config values (e.g. from `process.env`).
+ *
+ * @param config - Required configuration fields.
+ * @returns A validated {@link VanaConfig} object.
+ * @throws {@link ConnectError} with code `CONFIG_INVALID` if any required field is missing or invalid.
+ *
+ * @example
+ * ```typescript
+ * import { createVanaConfig } from "@opendatalabs/connect/server";
+ *
+ * const config = createVanaConfig({
+ *   privateKey: process.env.VANA_PRIVATE_KEY as `0x${string}`,
+ *   scopes: ["chatgpt.conversations"],
+ *   appUrl: process.env.APP_URL!,
+ * });
+ * ```
+ */
+export function createVanaConfig(config: {
+  privateKey: `0x${string}`;
+  scopes: string[];
+  appUrl: string;
+  environment?: VanaEnvironment;
+}): VanaConfig {
+  if (!config.privateKey) {
+    throw new ConnectError(
+      "Missing privateKey. Pass a 0x-prefixed private key.",
+      ConnectErrorCode.CONFIG_INVALID,
+    );
+  }
+
+  if (!config.privateKey.startsWith("0x")) {
+    throw new ConnectError(
+      "privateKey must start with 0x.",
+      ConnectErrorCode.CONFIG_INVALID,
+    );
+  }
+
+  if (!Array.isArray(config.scopes) || config.scopes.length === 0) {
+    throw new ConnectError(
+      "Missing scopes. Pass a non-empty array of scope strings.",
+      ConnectErrorCode.CONFIG_INVALID,
+    );
+  }
+
+  if (!config.appUrl) {
+    throw new ConnectError(
+      "Missing appUrl. Pass the public URL of your deployed app.",
+      ConnectErrorCode.CONFIG_INVALID,
+    );
+  }
+
+  return {
+    privateKey: config.privateKey,
+    scopes: config.scopes,
+    appUrl: config.appUrl,
+    environment: config.environment,
+  };
+}

--- a/src/server/connect.ts
+++ b/src/server/connect.ts
@@ -1,4 +1,4 @@
-import { SESSION_RELAY_URL, GATEWAY_URL } from "../core/constants.js";
+import { getEnvConfig } from "../core/constants.js";
 import type {
   ConnectConfig,
   GetDataConfig,
@@ -8,16 +8,36 @@ import { createRequestSigner } from "./request-signer.js";
 import { createSessionRelay } from "./session-relay.js";
 import { createDataClient } from "./data-client.js";
 
+/**
+ * Creates a session on the Session Relay and returns the session ID and deep link URL.
+ *
+ * This is the entry point for the Vana Connect flow. The returned `deepLinkUrl`
+ * should be presented to the user to open the Vana Desktop App.
+ *
+ * @param config - Connection configuration including private key and scopes.
+ * @returns Session ID, deep link URL, and expiration timestamp.
+ * @throws {@link ConnectError} with code `SESSION_INIT_FAILED` if the relay rejects the request.
+ *
+ * @example
+ * ```typescript
+ * const session = await connect({
+ *   privateKey: process.env.VANA_PRIVATE_KEY as `0x${string}`,
+ *   scopes: ["chatgpt.conversations"],
+ * });
+ * // session.sessionId, session.deepLinkUrl, session.expiresAt
+ * ```
+ */
 export async function connect(
   config: ConnectConfig,
 ): Promise<SessionInitResult> {
+  const { sessionRelayUrl } = getEnvConfig(config.environment);
   const signer = createRequestSigner({ privateKey: config.privateKey });
   const granteeAddress = signer.address;
 
   const relay = createSessionRelay({
     privateKey: config.privateKey,
     granteeAddress,
-    sessionRelayUrl: SESSION_RELAY_URL,
+    sessionRelayUrl,
   });
 
   return relay.initSession({
@@ -27,14 +47,35 @@ export async function connect(
   });
 }
 
+/**
+ * Fetches user data from their Personal Server using a signed grant.
+ *
+ * Resolves the server URL via the Data Portability Gateway, then fetches
+ * data for each scope in the grant concurrently.
+ *
+ * @param config - Data fetch configuration including private key and grant.
+ * @returns A `Record` keyed by scope name with the fetched data as values.
+ * @throws {@link ConnectError} with code `SERVER_NOT_FOUND` if no server is registered.
+ * @throws {@link ConnectError} with code `DATA_FETCH_FAILED` if a scope fetch fails.
+ *
+ * @example
+ * ```typescript
+ * const data = await getData({
+ *   privateKey: process.env.VANA_PRIVATE_KEY as `0x${string}`,
+ *   grant,
+ * });
+ * const conversations = data["chatgpt.conversations"];
+ * ```
+ */
 export async function getData(
   config: GetDataConfig,
-): Promise<Map<string, unknown>> {
+): Promise<Record<string, unknown>> {
+  const { gatewayUrl } = getEnvConfig(config.environment);
   const { grant } = config;
 
   const dataClient = createDataClient({
     privateKey: config.privateKey,
-    gatewayUrl: GATEWAY_URL,
+    gatewayUrl,
   });
 
   const serverUrl = await dataClient.resolveServerUrl(
@@ -52,9 +93,9 @@ export async function getData(
     }),
   );
 
-  const data = new Map<string, unknown>();
+  const data: Record<string, unknown> = {};
   for (const [scope, result] of results) {
-    data.set(scope, result);
+    data[scope] = result;
   }
 
   return data;

--- a/src/server/data-client.ts
+++ b/src/server/data-client.ts
@@ -1,14 +1,31 @@
-import { ConnectError } from "../core/errors.js";
+import { ConnectError, ConnectErrorCode } from "../core/errors.js";
 import type { DataClientConfig, DataFetchParams } from "../core/types.js";
 import { createRequestSigner } from "./request-signer.js";
 
+/**
+ * Low-level client for the Data Portability Gateway and Personal Servers.
+ *
+ * @see {@link createDataClient} to create an instance.
+ */
 export interface DataClient {
+  /** Resolves a user's Personal Server URL via the gateway. */
   resolveServerUrl(userAddress: string): Promise<string>;
+  /** Fetches data for a single scope from a Personal Server. */
   fetchData(params: DataFetchParams): Promise<unknown>;
+  /** Lists available scopes on a Personal Server. */
   listScopes(params: { serverUrl: string }): Promise<unknown>;
+  /** Lists available versions for a scope on a Personal Server. */
   listVersions(params: { serverUrl: string; scope: string }): Promise<unknown>;
 }
 
+/**
+ * Creates a low-level Data Gateway / Personal Server client.
+ *
+ * Prefer the high-level {@link getData} function for most use cases.
+ *
+ * @param config - Data client configuration.
+ * @returns A {@link DataClient} instance.
+ */
 export function createDataClient(config: DataClientConfig): DataClient {
   const gatewayBase = config.gatewayUrl.replace(/\/+$/, "");
   const signer = createRequestSigner({ privateKey: config.privateKey });
@@ -20,7 +37,7 @@ export function createDataClient(config: DataClientConfig): DataClient {
       if (res.status === 404) {
         throw new ConnectError(
           `No server registered for ${userAddress}`,
-          "SERVER_NOT_FOUND",
+          ConnectErrorCode.SERVER_NOT_FOUND,
           404,
         );
       }
@@ -28,7 +45,7 @@ export function createDataClient(config: DataClientConfig): DataClient {
       if (!res.ok) {
         throw new ConnectError(
           `Gateway error: ${res.status}`,
-          "GATEWAY_ERROR",
+          ConnectErrorCode.GATEWAY_ERROR,
           res.status,
         );
       }
@@ -54,14 +71,23 @@ export function createDataClient(config: DataClientConfig): DataClient {
         grantId: params.grantId,
       });
 
-      const res = await fetch(`${base}${uri}`, {
+      const url = `${base}${uri}`;
+      const res = await fetch(url, {
         headers: { Authorization: authHeader },
       });
 
       if (!res.ok) {
+        const body = await res.text().catch(() => "(unreadable)");
+        console.error("[data-client] fetchData failed", {
+          status: res.status,
+          url,
+          scope: params.scope,
+          grantId: params.grantId,
+          body,
+        });
         throw new ConnectError(
           `Data fetch failed: ${res.status}`,
-          "DATA_FETCH_FAILED",
+          ConnectErrorCode.DATA_FETCH_FAILED,
           res.status,
         );
       }
@@ -86,7 +112,7 @@ export function createDataClient(config: DataClientConfig): DataClient {
       if (!res.ok) {
         throw new ConnectError(
           `List scopes failed: ${res.status}`,
-          "LIST_SCOPES_FAILED",
+          ConnectErrorCode.LIST_SCOPES_FAILED,
           res.status,
         );
       }
@@ -114,7 +140,7 @@ export function createDataClient(config: DataClientConfig): DataClient {
       if (!res.ok) {
         throw new ConnectError(
           `List versions failed: ${res.status}`,
-          "LIST_VERSIONS_FAILED",
+          ConnectErrorCode.LIST_VERSIONS_FAILED,
           res.status,
         );
       }

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -3,3 +3,5 @@ export { createSessionRelay, type SessionRelay } from "./session-relay.js";
 export { createDataClient, type DataClient } from "./data-client.js";
 export { connect, getData } from "./connect.js";
 export { signVanaManifest } from "./manifest-signer.js";
+export { createVanaConfig, type VanaConfig } from "./config.js";
+export { verifyWebhook } from "./webhook.js";

--- a/src/server/manifest-signer.ts
+++ b/src/server/manifest-signer.ts
@@ -12,6 +12,28 @@ function canonicalizeJson(obj: unknown): unknown {
   return sorted;
 }
 
+/**
+ * Signs a web app manifest block for Vana Desktop App identity verification.
+ *
+ * Include the returned block under the `vana` key in your web app manifest JSON,
+ * and make sure your HTML has `<link rel="manifest" href="/manifest.json">`.
+ *
+ * @param config - Manifest configuration including private key and app URLs.
+ * @returns A signed {@link VanaManifestBlock}.
+ *
+ * @example
+ * ```typescript
+ * const vanaBlock = await signVanaManifest({
+ *   privateKey: process.env.VANA_PRIVATE_KEY as `0x${string}`,
+ *   appUrl: "https://yourapp.com",
+ *   privacyPolicyUrl: "https://yourapp.com/privacy",
+ *   termsUrl: "https://yourapp.com/terms",
+ *   supportUrl: "https://yourapp.com/support",
+ *   webhookUrl: "https://yourapp.com/api/webhook",
+ * });
+ * const manifest = { name: "Your App", vana: vanaBlock };
+ * ```
+ */
 export async function signVanaManifest(
   config: VanaManifestConfig,
 ): Promise<VanaManifestBlock> {

--- a/src/server/request-signer.ts
+++ b/src/server/request-signer.ts
@@ -31,7 +31,18 @@ function computeBodyHash(body?: string): string {
   return createHash("sha256").update(canonicalStr).digest("hex");
 }
 
+/**
+ * Generates `Web3Signed` authorization headers for protocol requests.
+ *
+ * @see {@link createRequestSigner} to create an instance.
+ */
 export interface RequestSigner {
+  /**
+   * Signs a request and returns the `Authorization` header value.
+   *
+   * @param params - Request metadata (audience, method, URI, optional body and grantId).
+   * @returns A `Web3Signed <payload>.<signature>` header string.
+   */
   signRequest(params: {
     aud: string;
     method: string;
@@ -39,9 +50,16 @@ export interface RequestSigner {
     body?: string;
     grantId?: string;
   }): Promise<string>;
+  /** The wallet address derived from the private key. */
   readonly address: `0x${string}`;
 }
 
+/**
+ * Creates a request signer that generates `Web3Signed` authorization headers.
+ *
+ * @param config - Configuration containing the builder's private key.
+ * @returns A {@link RequestSigner} instance.
+ */
 export function createRequestSigner(
   config: RequestSignerConfig,
 ): RequestSigner {

--- a/src/server/session-relay.ts
+++ b/src/server/session-relay.ts
@@ -1,4 +1,4 @@
-import { ConnectError } from "../core/errors.js";
+import { ConnectError, ConnectErrorCode } from "../core/errors.js";
 import type {
   SessionRelayConfig,
   SessionInitParams,
@@ -7,15 +7,37 @@ import type {
 } from "../core/types.js";
 import { createRequestSigner } from "./request-signer.js";
 
+/**
+ * Low-level client for the Session Relay service.
+ *
+ * @see {@link createSessionRelay} to create an instance.
+ */
 export interface SessionRelay {
+  /** Creates a new session and returns the session ID and deep link URL. */
   initSession(params: SessionInitParams): Promise<SessionInitResult>;
+  /** Polls the session status once. */
   pollSession(sessionId: string): Promise<SessionPollResult>;
+  /**
+   * Polls until the session reaches a terminal state (`approved`, `denied`, or `expired`).
+   *
+   * @param sessionId - The session to poll.
+   * @param opts - Optional polling interval (default 2 s) and timeout (default 15 min).
+   * @throws {@link ConnectError} with code `POLL_TIMEOUT` if the timeout is exceeded.
+   */
   pollUntilComplete(
     sessionId: string,
     opts?: { interval?: number; timeout?: number },
   ): Promise<SessionPollResult>;
 }
 
+/**
+ * Creates a low-level Session Relay client.
+ *
+ * Prefer the high-level {@link connect} function for most use cases.
+ *
+ * @param config - Session Relay configuration.
+ * @returns A {@link SessionRelay} instance.
+ */
 export function createSessionRelay(config: SessionRelayConfig): SessionRelay {
   const baseUrl = config.sessionRelayUrl.replace(/\/+$/, "");
   const signer = createRequestSigner({ privateKey: config.privateKey });
@@ -56,7 +78,7 @@ export function createSessionRelay(config: SessionRelayConfig): SessionRelay {
         throw new ConnectError(
           errorMsg,
           ((errorBody as Record<string, Record<string, unknown>>).error
-            ?.errorCode as string) ?? "SESSION_INIT_FAILED",
+            ?.errorCode as string) ?? ConnectErrorCode.SESSION_INIT_FAILED,
           res.status,
         );
       }
@@ -72,7 +94,7 @@ export function createSessionRelay(config: SessionRelayConfig): SessionRelay {
         throw new ConnectError(
           `Poll failed: ${res.status}`,
           ((errorBody as Record<string, Record<string, unknown>>).error
-            ?.errorCode as string) ?? "POLL_FAILED",
+            ?.errorCode as string) ?? ConnectErrorCode.POLL_FAILED,
           res.status,
         );
       }
@@ -102,7 +124,10 @@ export function createSessionRelay(config: SessionRelayConfig): SessionRelay {
         await new Promise((resolve) => setTimeout(resolve, interval));
       }
 
-      throw new ConnectError("Polling timed out", "POLL_TIMEOUT");
+      throw new ConnectError(
+        "Polling timed out",
+        ConnectErrorCode.POLL_TIMEOUT,
+      );
     },
   };
 }

--- a/src/server/webhook.ts
+++ b/src/server/webhook.ts
@@ -1,0 +1,26 @@
+import { ConnectError, ConnectErrorCode } from "../core/errors.js";
+
+/**
+ * Verifies a webhook payload signature.
+ *
+ * @param payload - The raw request body as a string or Buffer.
+ * @param signature - The signature from the webhook request header.
+ * @param secret - The shared secret used to verify the signature.
+ * @returns The verified payload.
+ * @throws {@link ConnectError} with code `WEBHOOK_INVALID` — this function is not yet implemented.
+ */
+export function verifyWebhook(
+  payload: string | Buffer,
+  signature: string,
+  secret: string,
+): unknown {
+  void payload;
+  void signature;
+  void secret;
+
+  // TODO: Implement when Data Portability Protocol webhook signing spec is available
+  throw new ConnectError(
+    "verifyWebhook() is not yet implemented. Webhook signing scheme is pending protocol specification.",
+    ConnectErrorCode.WEBHOOK_INVALID,
+  );
+}

--- a/test/core/constants.test.ts
+++ b/test/core/constants.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from "vitest";
+import {
+  getEnvConfig,
+  ENV_CONFIG,
+  DEFAULT_ENVIRONMENT,
+} from "../../src/core/constants.js";
+
+describe("getEnvConfig", () => {
+  it("returns dev config for 'dev'", () => {
+    const config = getEnvConfig("dev");
+    expect(config).toBe(ENV_CONFIG.dev);
+    expect(config.sessionRelayUrl).toContain("session-relay");
+    expect(config.gatewayUrl).toContain("data-gateway");
+  });
+
+  it("returns prod config for 'prod'", () => {
+    const config = getEnvConfig("prod");
+    expect(config).toBe(ENV_CONFIG.prod);
+  });
+
+  it("defaults to prod when no environment is specified", () => {
+    const config = getEnvConfig();
+    expect(config).toBe(ENV_CONFIG[DEFAULT_ENVIRONMENT]);
+    expect(config).toBe(ENV_CONFIG.prod);
+  });
+});

--- a/test/core/errors.test.ts
+++ b/test/core/errors.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "vitest";
+import { ConnectError, ConnectErrorCode } from "../../src/core/errors.js";
+
+describe("ConnectErrorCode", () => {
+  it("contains all expected error codes", () => {
+    expect(ConnectErrorCode.SESSION_INIT_FAILED).toBe("SESSION_INIT_FAILED");
+    expect(ConnectErrorCode.SESSION_EXPIRED).toBe("SESSION_EXPIRED");
+    expect(ConnectErrorCode.POLL_FAILED).toBe("POLL_FAILED");
+    expect(ConnectErrorCode.POLL_TIMEOUT).toBe("POLL_TIMEOUT");
+    expect(ConnectErrorCode.SERVER_NOT_FOUND).toBe("SERVER_NOT_FOUND");
+    expect(ConnectErrorCode.GATEWAY_ERROR).toBe("GATEWAY_ERROR");
+    expect(ConnectErrorCode.DATA_FETCH_FAILED).toBe("DATA_FETCH_FAILED");
+    expect(ConnectErrorCode.LIST_SCOPES_FAILED).toBe("LIST_SCOPES_FAILED");
+    expect(ConnectErrorCode.LIST_VERSIONS_FAILED).toBe("LIST_VERSIONS_FAILED");
+    expect(ConnectErrorCode.CONFIG_INVALID).toBe("CONFIG_INVALID");
+    expect(ConnectErrorCode.WEBHOOK_INVALID).toBe("WEBHOOK_INVALID");
+  });
+
+  it("has 11 error codes", () => {
+    expect(Object.keys(ConnectErrorCode)).toHaveLength(11);
+  });
+});
+
+describe("ConnectError", () => {
+  it("accepts ConnectErrorCode values", () => {
+    const error = new ConnectError(
+      "test",
+      ConnectErrorCode.SESSION_INIT_FAILED,
+    );
+    expect(error.code).toBe("SESSION_INIT_FAILED");
+    expect(error.message).toBe("test");
+    expect(error.name).toBe("ConnectError");
+  });
+
+  it("accepts arbitrary string codes for backward compat", () => {
+    const error = new ConnectError("test", "CUSTOM_CODE");
+    expect(error.code).toBe("CUSTOM_CODE");
+  });
+
+  it("includes statusCode when provided", () => {
+    const error = new ConnectError("test", ConnectErrorCode.GATEWAY_ERROR, 502);
+    expect(error.statusCode).toBe(502);
+  });
+});

--- a/test/core/grants.test.ts
+++ b/test/core/grants.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from "vitest";
+import { isValidGrant } from "../../src/core/grants.js";
+
+const VALID_GRANT = {
+  grantId: "grant-1",
+  userAddress: "0xuser",
+  builderAddress: "0xbuilder",
+  scopes: ["instagram.dpv1"],
+};
+
+describe("isValidGrant", () => {
+  it("returns true for a valid grant", () => {
+    expect(isValidGrant(VALID_GRANT)).toBe(true);
+  });
+
+  it("returns true when optional fields are present", () => {
+    expect(
+      isValidGrant({
+        ...VALID_GRANT,
+        serverAddress: "0xserver",
+        appUserId: "user-42",
+      }),
+    ).toBe(true);
+  });
+
+  it("returns false for null", () => {
+    expect(isValidGrant(null)).toBe(false);
+  });
+
+  it("returns false for undefined", () => {
+    expect(isValidGrant(undefined)).toBe(false);
+  });
+
+  it("returns false for a string", () => {
+    expect(isValidGrant("not a grant")).toBe(false);
+  });
+
+  it("returns false when grantId is missing", () => {
+    expect(
+      isValidGrant({
+        userAddress: "0xuser",
+        builderAddress: "0xbuilder",
+        scopes: ["instagram.dpv1"],
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false when userAddress is missing", () => {
+    expect(
+      isValidGrant({
+        grantId: "grant-1",
+        builderAddress: "0xbuilder",
+        scopes: ["instagram.dpv1"],
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false when builderAddress is missing", () => {
+    expect(
+      isValidGrant({
+        grantId: "grant-1",
+        userAddress: "0xuser",
+        scopes: ["instagram.dpv1"],
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false when scopes is missing", () => {
+    expect(
+      isValidGrant({
+        grantId: "grant-1",
+        userAddress: "0xuser",
+        builderAddress: "0xbuilder",
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false when scopes is empty", () => {
+    expect(isValidGrant({ ...VALID_GRANT, scopes: [] })).toBe(false);
+  });
+
+  it("returns false when scopes contains non-strings", () => {
+    expect(isValidGrant({ ...VALID_GRANT, scopes: [123] })).toBe(false);
+  });
+
+  it("returns false when grantId is empty string", () => {
+    expect(isValidGrant({ ...VALID_GRANT, grantId: "" })).toBe(false);
+  });
+
+  it("returns false when scopes contains empty strings", () => {
+    expect(
+      isValidGrant({ ...VALID_GRANT, scopes: ["", "instagram.dpv1"] }),
+    ).toBe(false);
+  });
+});

--- a/test/server/config.test.ts
+++ b/test/server/config.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from "vitest";
+import { createVanaConfig } from "../../src/server/config.js";
+import { ConnectError } from "../../src/core/errors.js";
+
+const VALID_KEY =
+  "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80" as `0x${string}`;
+
+const VALID_CONFIG = {
+  privateKey: VALID_KEY,
+  scopes: ["instagram.dpv1", "twitter.dpv1"],
+  appUrl: "https://myapp.com",
+};
+
+describe("createVanaConfig", () => {
+  it("returns correct config when all valid fields are passed", () => {
+    const config = createVanaConfig(VALID_CONFIG);
+    expect(config.privateKey).toBe(VALID_KEY);
+    expect(config.scopes).toEqual(["instagram.dpv1", "twitter.dpv1"]);
+    expect(config.appUrl).toBe("https://myapp.com");
+    expect(config.environment).toBeUndefined();
+  });
+
+  it("includes optional environment field", () => {
+    const config = createVanaConfig({ ...VALID_CONFIG, environment: "dev" });
+    expect(config.environment).toBe("dev");
+  });
+
+  it("throws CONFIG_INVALID when privateKey is missing", () => {
+    expect(() =>
+      createVanaConfig({ ...VALID_CONFIG, privateKey: "" as `0x${string}` }),
+    ).toThrow(expect.objectContaining({ code: "CONFIG_INVALID" }));
+  });
+
+  it("throws CONFIG_INVALID when privateKey lacks 0x prefix", () => {
+    expect(() =>
+      createVanaConfig({
+        ...VALID_CONFIG,
+        privateKey:
+          "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80" as `0x${string}`,
+      }),
+    ).toThrow(ConnectError);
+  });
+
+  it("throws CONFIG_INVALID when scopes is empty", () => {
+    expect(() => createVanaConfig({ ...VALID_CONFIG, scopes: [] })).toThrow(
+      expect.objectContaining({ code: "CONFIG_INVALID" }),
+    );
+  });
+
+  it("throws CONFIG_INVALID when appUrl is missing", () => {
+    expect(() => createVanaConfig({ ...VALID_CONFIG, appUrl: "" })).toThrow(
+      expect.objectContaining({ code: "CONFIG_INVALID" }),
+    );
+  });
+});

--- a/test/server/connect.test.ts
+++ b/test/server/connect.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { connect, getData } from "../../src/server/connect.js";
-import { SESSION_RELAY_URL, GATEWAY_URL } from "../../src/core/constants.js";
+import { getEnvConfig } from "../../src/core/constants.js";
 import type { GrantPayload } from "../../src/core/types.js";
 
 const TEST_PRIVATE_KEY =
@@ -69,7 +69,7 @@ describe("connect", () => {
     expect(body.granteeAddress).toBe(TEST_GRANTEE);
   });
 
-  it("uses SESSION_RELAY_URL", async () => {
+  it("uses default session relay URL", async () => {
     mockInitSession();
 
     await connect({
@@ -78,7 +78,8 @@ describe("connect", () => {
     });
 
     const initUrl = mockFetch.mock.calls[0][0] as string;
-    expect(initUrl).toBe(`${SESSION_RELAY_URL}/v1/session/init`);
+    const { sessionRelayUrl } = getEnvConfig();
+    expect(initUrl).toBe(`${sessionRelayUrl}/v1/session/init`);
   });
 
   it("returns session init result", async () => {
@@ -121,10 +122,24 @@ describe("connect", () => {
 
     expect(mockFetch).toHaveBeenCalledTimes(1);
   });
+
+  it("uses environment config URL when environment is specified", async () => {
+    mockInitSession();
+
+    await connect({
+      privateKey: TEST_PRIVATE_KEY,
+      scopes: ["instagram.dpv1"],
+      environment: "dev",
+    });
+
+    const initUrl = mockFetch.mock.calls[0][0] as string;
+    const { sessionRelayUrl } = getEnvConfig("dev");
+    expect(initUrl).toBe(`${sessionRelayUrl}/v1/session/init`);
+  });
 });
 
 describe("getData", () => {
-  it("uses GATEWAY_URL to resolve server URL", async () => {
+  it("uses default gateway URL to resolve server URL", async () => {
     mockResolveServerUrl();
     mockFetchData("instagram.dpv1");
 
@@ -133,8 +148,9 @@ describe("getData", () => {
       grant: TEST_GRANT,
     });
 
-    const gatewayUrl = mockFetch.mock.calls[0][0] as string;
-    expect(gatewayUrl).toContain(GATEWAY_URL);
+    const fetchedUrl = mockFetch.mock.calls[0][0] as string;
+    const { gatewayUrl } = getEnvConfig();
+    expect(fetchedUrl).toContain(gatewayUrl);
   });
 
   it("resolves server URL from grant.serverAddress", async () => {
@@ -165,7 +181,7 @@ describe("getData", () => {
     expect(resolveUrl).toContain("0xuser");
   });
 
-  it("fetches data for all scopes and returns a Map", async () => {
+  it("fetches data for all scopes and returns a Record", async () => {
     const multiScopeGrant: GrantPayload = {
       ...TEST_GRANT,
       scopes: ["instagram.dpv1", "twitter.dpv1"],
@@ -180,12 +196,12 @@ describe("getData", () => {
       grant: multiScopeGrant,
     });
 
-    expect(data).toBeInstanceOf(Map);
-    expect(data.size).toBe(2);
-    expect(data.get("instagram.dpv1")).toEqual({
+    expect(typeof data).toBe("object");
+    expect(Object.keys(data)).toHaveLength(2);
+    expect(data["instagram.dpv1"]).toEqual({
       data: { scope: "instagram.dpv1", username: "alice" },
     });
-    expect(data.get("twitter.dpv1")).toEqual({
+    expect(data["twitter.dpv1"]).toEqual({
       data: { scope: "twitter.dpv1", username: "alice" },
     });
   });
@@ -199,7 +215,7 @@ describe("getData", () => {
       grant: TEST_GRANT,
     });
 
-    expect(data.size).toBe(1);
-    expect(data.has("instagram.dpv1")).toBe(true);
+    expect(Object.keys(data)).toHaveLength(1);
+    expect("instagram.dpv1" in data).toBe(true);
   });
 });

--- a/test/server/data-client.test.ts
+++ b/test/server/data-client.test.ts
@@ -131,6 +131,7 @@ describe("createDataClient", () => {
       mockFetch.mockResolvedValueOnce({
         ok: false,
         status: 403,
+        text: async () => "Forbidden",
       });
 
       const client = createDataClient({


### PR DESCRIPTION
## Summary

This PR introduces several improvements to the SDK API surface, developer experience, and the Next.js starter example:

**Core**
- **Environment configuration**: New `VanaEnvironment` type (`"dev"` | `"prod"`) with `getEnvConfig()` replacing hardcoded URL constants. All server functions and React hooks now accept an optional `environment` parameter.
- **Typed error codes**: `ConnectErrorCode` enum-like const object with 11 named error codes (`SESSION_INIT_FAILED`, `POLL_TIMEOUT`, `CONFIG_INVALID`, etc.) replacing raw string literals throughout the codebase.
- **Grant validation**: `isValidGrant()` type guard for safely narrowing unknown values to `GrantPayload` at API boundaries.

**Server**
- `createVanaConfig()` — validates and bundles `privateKey`, `scopes`, `appUrl`, and `environment` into a single reusable config object, throwing `ConnectError` with `CONFIG_INVALID` on bad input.
- `verifyWebhook()` — placeholder for future webhook signature verification (throws `WEBHOOK_INVALID` until the protocol spec is finalized).
- `getData()` now returns `Record<string, unknown>` instead of `Map<string, unknown>` for simpler JSON serialization.

**React**
- `useVanaData()` — full-flow hook that orchestrates session init → polling → data fetch, composing `useVanaConnect` internally. Supports `autoFetch`, configurable API routes, and exposes `isLoading`/`isConnected` helpers.
- `useVanaConnect()` now accepts an `environment` option.

**Next.js Starter**
- Refactored to use `useVanaData()` — the `ConnectFlow` component dropped from ~330 lines to ~150 lines.
- Centralized app config in `src/config.ts` using `createVanaConfig()`.
- Moved inline styles to `globals.css`, removed external Google Fonts dependency.
- All API routes now use structured `ConnectError` handling.

**Tests & Docs**
- New test suites: `constants.test.ts`, `errors.test.ts`, `grants.test.ts`, `config.test.ts` (24 new tests, 66 total passing).
- TSDoc comments on all public exports.
- Added `AGENTS.md` with architecture overview and conventions.

## Test plan

- [x] `pnpm validate` passes (lint + format + 66/66 tests)
- [ ] Manual test: run `pnpm dev` in `examples/nextjs-starter` and verify the connect flow works end-to-end
- [ ] Verify `getData()` consumers handle the `Record` return type (breaking change from `Map`)
