### PR TITLE
fix(connect): route root visits to login server-side

### DIFF
--- a/connect/src/app/page.tsx
+++ b/connect/src/app/page.tsx
@@ -1,35 +1,23 @@
-"use client";
+import { redirect } from "next/navigation";
 
-import { useRouter, useSearchParams } from "next/navigation";
-import { Suspense, useEffect } from "react";
+type PageProps = {
+  searchParams: Promise<{
+    sessionId?: string;
+    secret?: string;
+  }>;
+};
 
-function PageContent() {
-  const router = useRouter();
-  const searchParams = useSearchParams();
-  const sessionId = searchParams.get("sessionId");
-  const secret = searchParams.get("secret");
+export default async function Page({ searchParams }: PageProps) {
+  const { sessionId, secret } = await searchParams;
 
-  useEffect(() => {
-    // Entry routing policy:
-    // 1) External app handoff includes session params -> continue connect flow.
-    // 2) Direct visits without a session -> go to download page until index/home ships.
-    if (sessionId) {
-      const qs = new URLSearchParams();
-      qs.set("sessionId", sessionId);
-      if (secret) qs.set("secret", secret);
-      router.replace(`/connect?${qs.toString()}`);
-      return;
-    }
-    router.replace("/download-data-connect");
-  }, [router, sessionId, secret]);
+  // Entry routing policy:
+  // 1) External app handoff includes session params -> continue connect flow.
+  // 2) Direct visits without a session -> go to login.
+  if (sessionId) {
+    const qs = new URLSearchParams({ sessionId });
+    if (secret) qs.set("secret", secret);
+    redirect(`/connect?${qs.toString()}`);
+  }
 
-  return null;
-}
-
-export default function Page() {
-  return (
-    <Suspense fallback={null}>
-      <PageContent />
-    </Suspense>
-  );
+  redirect("/login");
 }


### PR DESCRIPTION
Move root routing from client useEffect redirects to server redirects. Direct `/` visits now go to `/login`, while session handoff still goes to `/connect`.