### PR TITLE
fix: accept both primaryType and primary_type in sign validation

### DIFF
--- a/connect/src/app/api/sign/sign-validation.ts
+++ b/connect/src/app/api/sign/sign-validation.ts
@@ -12,7 +12,7 @@ type ValidationResult = { valid: true } | { valid: false; reason: string };
 export function validateSignRequest(body: {
   type?: string;
   message?: string;
-  typedData?: { primaryType?: string };
+  typedData?: { primaryType?: string; primary_type?: string };
 }): ValidationResult {
   const { type, message, typedData } = body;
 
@@ -27,10 +27,9 @@ export function validateSignRequest(body: {
   }
 
   if (type === "eth_signTypedData_v4") {
-    if (
-      !typedData?.primaryType ||
-      !ALLOWED_TYPED_DATA_PRIMARY_TYPES.includes(typedData.primaryType)
-    ) {
+    // Accept both EIP-712 standard `primaryType` and Privy's `primary_type`
+    const pt = typedData?.primaryType ?? typedData?.primary_type;
+    if (!pt || !ALLOWED_TYPED_DATA_PRIMARY_TYPES.includes(pt)) {
       return {
         valid: false,
         reason: "Typed data primaryType not in allowlist",


### PR DESCRIPTION
## Summary
- Privy's server wallet API uses snake_case `primary_type` and strictly rejects `primaryType` as an unrecognized key
- The sign validation layer now accepts both `primaryType` (EIP-712 standard) and `primary_type` (Privy format) for the typed data primary type check
- Without this fix, DataConnect's server registration fails because it must send `primary_type` to satisfy Privy but the validation rejects it

## Test plan
- [ ] Verify `/api/sign` accepts requests with `primary_type: "ServerRegistration"` (Privy-compatible format)
- [ ] Verify `/api/sign` still accepts requests with `primaryType: "ServerRegistration"` (standard format)
- [ ] Verify requests with unlisted primary types are still rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)