### PR TITLE
feat(admin): register builders with Data Gateway

### DIFF
--- a/connect/src/app/admin/_lib/admin-apps-storage.ts
+++ b/connect/src/app/admin/_lib/admin-apps-storage.ts
@@ -5,6 +5,8 @@ export type RegisteredAdminApp = {
   name: string;
   url: string;
   createdAt: string;
+  builderId?: string;
+  ownerAddress?: string;
 };
 
 const ADMIN_APPS_STORAGE_KEY = "vana.connect.admin.apps";

--- a/connect/src/app/admin/_lib/register-builder.ts
+++ b/connect/src/app/admin/_lib/register-builder.ts
@@ -1,0 +1,163 @@
+import { generatePrivateKey, privateKeyToAccount } from "viem/accounts";
+import type { Address, Hex } from "viem";
+
+// ---------------------------------------------------------------------------
+// EIP-712 constants (mirrors scripts/register-builder.ts)
+// ---------------------------------------------------------------------------
+
+const BUILDERS_DOMAIN = {
+  name: "Vana Data Portability",
+  version: "1",
+  chainId: BigInt(1480),
+  verifyingContract: "0x8325C0A0948483EdA023A1A2Fd895e62C5131234" as Address,
+} as const;
+
+const BUILDER_REGISTRATION_TYPES = {
+  BuilderRegistration: [
+    { name: "ownerAddress", type: "address" },
+    { name: "granteeAddress", type: "address" },
+    { name: "publicKey", type: "string" },
+    { name: "appUrl", type: "string" },
+  ],
+} as const;
+
+const GATEWAY_URL = "https://data-gateway.vana.org";
+
+// ---------------------------------------------------------------------------
+// Result types
+// ---------------------------------------------------------------------------
+
+type RegisterBuilderErrorCode =
+  | "ALREADY_REGISTERED"
+  | "VALIDATION_ERROR"
+  | "NETWORK_ERROR"
+  | "UNEXPECTED_ERROR";
+
+type RegisterBuilderSuccess = {
+  ok: true;
+  data: {
+    privateKey: Hex;
+    builderId: string;
+    ownerAddress: string;
+  };
+};
+
+type RegisterBuilderFailure = {
+  ok: false;
+  error: {
+    code: RegisterBuilderErrorCode;
+    message: string;
+  };
+};
+
+export type RegisterBuilderResult =
+  | RegisterBuilderSuccess
+  | RegisterBuilderFailure;
+
+// ---------------------------------------------------------------------------
+// registerBuilder
+// ---------------------------------------------------------------------------
+
+export async function registerBuilder(
+  appUrl: string,
+): Promise<RegisterBuilderResult> {
+  try {
+    // 1. Generate a fresh private key and derive account
+    const privateKey = generatePrivateKey();
+    const account = privateKeyToAccount(privateKey);
+
+    // account.publicKey is already uncompressed (0x04 + 128 hex chars)
+    const publicKey = account.publicKey;
+    const ownerAddress = account.address;
+    const granteeAddress = account.address;
+
+    // 2. Sign EIP-712 BuilderRegistration
+    const signature = await account.signTypedData({
+      domain: BUILDERS_DOMAIN,
+      types: BUILDER_REGISTRATION_TYPES,
+      primaryType: "BuilderRegistration",
+      message: {
+        ownerAddress,
+        granteeAddress,
+        publicKey,
+        appUrl,
+      },
+    });
+
+    // 3. POST to gateway
+    const response = await fetch(`${GATEWAY_URL}/v1/builders`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Web3Signed ${signature}`,
+      },
+      body: JSON.stringify({
+        ownerAddress,
+        granteeAddress,
+        publicKey,
+        appUrl,
+      }),
+    });
+
+    // 4. Handle response
+    if (response.status === 201) {
+      const data = (await response.json()) as { builderId?: string };
+      return {
+        ok: true,
+        data: {
+          privateKey,
+          builderId: data.builderId ?? "",
+          ownerAddress,
+        },
+      };
+    }
+
+    if (response.status === 409) {
+      return {
+        ok: false,
+        error: {
+          code: "ALREADY_REGISTERED",
+          message:
+            "A builder is already registered for this URL. A new key pair was generated — try again to register with the new key.",
+        },
+      };
+    }
+
+    if (response.status === 400) {
+      const data = (await response.json().catch(() => ({}))) as {
+        message?: string;
+      };
+      return {
+        ok: false,
+        error: {
+          code: "VALIDATION_ERROR",
+          message: data.message ?? "The gateway rejected the request.",
+        },
+      };
+    }
+
+    // Any other non-success status
+    return {
+      ok: false,
+      error: {
+        code: "UNEXPECTED_ERROR",
+        message: `Gateway returned status ${response.status}.`,
+      },
+    };
+  } catch (error) {
+    const isNetworkError =
+      error instanceof TypeError && /fetch|network/i.test(error.message);
+
+    return {
+      ok: false,
+      error: {
+        code: isNetworkError ? "NETWORK_ERROR" : "UNEXPECTED_ERROR",
+        message: isNetworkError
+          ? "Could not reach the gateway. Check your network connection and try again."
+          : error instanceof Error
+            ? error.message
+            : "An unexpected error occurred.",
+      },
+    };
+  }
+}

--- a/connect/src/app/admin/admin-page.ui-debug.ts
+++ b/connect/src/app/admin/admin-page.ui-debug.ts
@@ -2,17 +2,19 @@
 // - Enable: /admin?adminDebug=1&adminScenario=form
 // - Enable: /admin?adminDebug=1&adminScenario=loading
 // - Enable: /admin?adminDebug=1&adminScenario=result
+// - Enable: /admin?adminDebug=1&adminScenario=error
 // - No adminDebug/adminScenario => no debug override (real state only).
 
-type AdminState = "form" | "loading" | "result";
+type AdminState = "form" | "loading" | "result" | "error";
 
 type AdminPageUiState = {
   state: AdminState;
   appUrl: string;
   privateKey: `0x${string}` | "";
+  errorMessage: string;
 };
 
-type AdminPageUiDebugScenario = "form" | "loading" | "result";
+type AdminPageUiDebugScenario = "form" | "loading" | "result" | "error";
 
 const ADMIN_PAGE_UI_DEBUG_SCENARIOS: Record<
   AdminPageUiDebugScenario,
@@ -22,17 +24,27 @@ const ADMIN_PAGE_UI_DEBUG_SCENARIOS: Record<
     state: "form",
     appUrl: "",
     privateKey: "",
+    errorMessage: "",
   },
   loading: {
     state: "loading",
     appUrl: "https://promptgallery.org",
     privateKey: "",
+    errorMessage: "",
   },
   result: {
     state: "result",
     appUrl: "https://promptgallery.org",
     privateKey:
       "0x442ada486a9385ebd6e14ecd7a21a96a0d45303cf6f2f9115cab9ea69e47c2fa",
+    errorMessage: "",
+  },
+  error: {
+    state: "error",
+    appUrl: "https://promptgallery.org",
+    privateKey: "",
+    errorMessage:
+      "A builder is already registered for this URL. A new key pair was generated — try again to register with the new key.",
   },
 };
 
@@ -61,5 +73,10 @@ function resolveAdminDebugScenario(): AdminPageUiDebugScenario | null {
     return null;
   }
   const raw = search.get("adminScenario");
-  return raw === "loading" || raw === "result" || raw === "form" ? raw : null;
+  return raw === "loading" ||
+    raw === "result" ||
+    raw === "form" ||
+    raw === "error"
+    ? raw
+    : null;
 }

--- a/connect/src/app/admin/page.tsx
+++ b/connect/src/app/admin/page.tsx
@@ -13,38 +13,32 @@ import { cn } from "@/lib/classes";
 import { AdminFooterLinks } from "./_components/admin-footer-links";
 import { RegisterAnotherAppButton } from "./_components/register-another-app-button";
 import { saveRegisteredAdminApp } from "./_lib/admin-apps-storage";
+import { registerBuilder } from "./_lib/register-builder";
 import { resolveAdminPageUiDebugState } from "./admin-page.ui-debug";
 
-type AdminState = "form" | "loading" | "result";
+type AdminState = "form" | "loading" | "result" | "error";
 
 const DEFAULT_APP_URL = "";
-const REGISTER_DELAY_MS = 900;
 const SITE_METADATA_TIMEOUT_MS = 3500;
-
-function randomPrivateKey(): `0x${string}` {
-  const bytes = new Uint8Array(32);
-  crypto.getRandomValues(bytes);
-  const hex = Array.from(bytes, (byte) =>
-    byte.toString(16).padStart(2, "0"),
-  ).join("");
-  return `0x${hex}`;
-}
 
 export default function AdminPage() {
   const [state, setState] = useState<AdminState>("form");
   const [appUrl, setAppUrl] = useState(DEFAULT_APP_URL);
   const [privateKey, setPrivateKey] = useState<`0x${string}` | "">("");
   const [copied, setCopied] = useState(false);
+  const [errorMessage, setErrorMessage] = useState("");
 
   // UI debug quick usage (dev only):
   // - /admin?adminDebug=1&adminScenario=form
   // - /admin?adminDebug=1&adminScenario=loading
   // - /admin?adminDebug=1&adminScenario=result
+  // - /admin?adminDebug=1&adminScenario=error
   // - No adminDebug/adminScenario => real state (no debug override).
   const ui = resolveAdminPageUiDebugState({
     state,
     appUrl,
     privateKey,
+    errorMessage,
   });
 
   const envText = useMemo(() => {
@@ -60,20 +54,30 @@ export default function AdminPage() {
 
     setAppUrl(trimmedUrl);
     setCopied(false);
+    setErrorMessage("");
     setState("loading");
 
-    await new Promise((resolve) => {
-      window.setTimeout(resolve, REGISTER_DELAY_MS);
-    });
+    const [result, appName] = await Promise.all([
+      registerBuilder(trimmedUrl),
+      resolveRegisteredAppName(trimmedUrl),
+    ]);
+
+    if (!result.ok) {
+      setErrorMessage(result.error.message);
+      setState("error");
+      return;
+    }
 
     saveRegisteredAdminApp({
       id: crypto.randomUUID(),
-      name: await resolveRegisteredAppName(trimmedUrl),
+      name: appName,
       url: trimmedUrl,
       createdAt: new Date().toISOString(),
+      builderId: result.data.builderId,
+      ownerAddress: result.data.ownerAddress,
     });
 
-    setPrivateKey(randomPrivateKey());
+    setPrivateKey(result.data.privateKey);
     setState("result");
   }
 
@@ -143,6 +147,12 @@ export default function AdminPage() {
     setCopied(false);
     setAppUrl(DEFAULT_APP_URL);
     setPrivateKey("");
+    setErrorMessage("");
+    setState("form");
+  }
+
+  function handleRetry() {
+    setErrorMessage("");
     setState("form");
   }
 
@@ -163,6 +173,12 @@ export default function AdminPage() {
 
         {ui.state === "loading" ? (
           <PageLoadingState message="Generating keys and registering with gateway…" />
+        ) : ui.state === "error" ? (
+          <AdminErrorState
+            errorMessage={ui.errorMessage}
+            onRetry={handleRetry}
+            onReset={handleReset}
+          />
         ) : ui.state !== "result" ? (
           <AdminFormState
             appUrl={ui.appUrl}
@@ -232,6 +248,53 @@ function AdminFormState({
             Generating keys and registering with gateway…
           </Text>
         )}
+      </div>
+    </div>
+  );
+}
+
+type AdminErrorStateProps = {
+  errorMessage: string;
+  onRetry: () => void;
+  onReset: () => void;
+};
+
+function AdminErrorState({
+  errorMessage,
+  onRetry,
+  onReset,
+}: AdminErrorStateProps) {
+  return (
+    <div className="space-y-small flex-1 flex flex-col">
+      <PageHeader
+        showVanaLogotype
+        heading="Registration failed"
+        color="iris"
+        description={
+          <Text>
+            {errorMessage ||
+              "Something went wrong while registering your app. Please try again."}
+          </Text>
+        }
+      />
+
+      <div className="space-y-gap -mx-1.5">
+        <Button
+          type="button"
+          variant="default"
+          fullWidth
+          size="sm"
+          className="h-tab bg-iris"
+          onClick={onRetry}
+        >
+          Try again
+        </Button>
+      </div>
+
+      <div className="mt-auto flex justify-end">
+        <RegisterAnotherAppButton type="button" onClick={onReset}>
+          Start over
+        </RegisterAnotherAppButton>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

- **Wire real builder registration**: Replace the fake delay + localStorage-only flow with actual EIP-712 signed POST to `data-gateway.vana.org/v1/builders`. Key generation, signing, and submission all run client-side via `viem`.
- **Add error state**: New `AdminErrorState` component with "Try again" / "Start over" actions, handling 409 (already registered), 400 (validation), network errors, and unexpected failures.
- **Extend storage type**: `RegisteredAdminApp` now carries optional `builderId` and `ownerAddress` from the gateway response (backward compatible).
- **Update debug system**: Added `"error"` scenario to the admin page UI debug module (`/admin?adminDebug=1&adminScenario=error`).

## Files changed

| File | Change |
|------|--------|
| `connect/src/app/admin/_lib/register-builder.ts` | **New** -- key gen + EIP-712 sign + POST utility |
| `connect/src/app/admin/_lib/admin-apps-storage.ts` | Add `builderId?`, `ownerAddress?` to type |
| `connect/src/app/admin/page.tsx` | Replace fake delay with `registerBuilder()`, add error state |
| `connect/src/app/admin/admin-page.ui-debug.ts` | Add `"error"` to types, scenarios, resolver |

## Test plan

- [x] `pnpm --filter connect build` passes (verified locally)
- [x] Navigate to `/admin`, enter a URL, submit -- Network tab shows POST to `data-gateway.vana.org/v1/builders`
- [x] On 201: result screen shows `VANA_APP_PRIVATE_KEY=0x...` and `APP_URL=...`
- [x] On 409 / network error: error screen shows message with "Try again" button
- [x] Debug: `/admin?adminDebug=1&adminScenario=error` renders the error state
- [x] Existing apps in `/admin/apps` still load (backward compatible storage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)