### PR TITLE
fix(nextjs-starter): restore icon.png path in manifest

### DIFF
--- a/examples/nextjs-starter/src/app/manifest.json/route.ts
+++ b/examples/nextjs-starter/src/app/manifest.json/route.ts
@@ -26,7 +26,7 @@ export async function GET() {
       theme_color: "#09090b",
       icons: [
         {
-          src: "/icon",
+          src: "/icon.png",
           sizes: "192x192",
           type: "image/png",
         },


### PR DESCRIPTION
## Summary
- The manifest icon `src` was changed from `"/icon.png"` to `"/icon"` in c39f09d, but Next.js App Router serves a static `icon.png` at `/icon.png` (not `/icon`), causing a 404
- This results in a broken icon (blue `?` box) on the DataConnect consent screen when granting access to the starter app

## Test plan
- [ ] Deploy to Vercel preview and verify `https://<preview>/icon.png` returns the PNG
- [ ] Verify `https://<preview>/manifest.json` has `"src": "/icon.png"` in the icons array
- [ ] Trigger a grant flow from DataConnect pointing at the preview URL and confirm the app icon renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)