### PR TITLE
fix(connect): wrap download page search params in suspense

### DIFF
--- a/connect/src/app/download-data-connect/page.tsx
+++ b/connect/src/app/download-data-connect/page.tsx
@@ -3,7 +3,7 @@
 import { usePrivy } from "@privy-io/react-auth";
 import { GithubIcon, ImportIcon, LaptopIcon } from "lucide-react";
 import { useSearchParams } from "next/navigation";
-import { useId, useMemo, useState } from "react";
+import { Suspense, useId, useMemo, useState } from "react";
 import { LegalAcceptance } from "@/app/_components/legal-acceptance";
 import { PagePanel } from "@/app/_components/page-panel";
 import { PageShell } from "@/app/_components/page-shell";
@@ -278,7 +278,11 @@ const downloadButtonStyle = [
 ];
 
 export default function DownloadDataConnectPage() {
-  return <DownloadDataConnectPageContent />;
+  return (
+    <Suspense fallback={null}>
+      <DownloadDataConnectPageContent />
+    </Suspense>
+  );
 }
 
 function DownloadDataConnectCardContent({


### PR DESCRIPTION
## Summary
- Fixes Next prerender/build failure on `/download-data-connect` caused by `useSearchParams()` without a Suspense boundary.
- Wraps `DownloadDataConnectPageContent` in `<Suspense>` while preserving URL-driven handoff/back-link behavior.
- Keeps direct `/download-data-connect` behavior unchanged (no handoff params => no in-app back button).

## Error fixed
`useSearchParams() should be wrapped in a suspense boundary at page \"/download-data-connect\"`

## Test plan
- [x] `pnpm --dir connect build`
- [x] Verify `/download-data-connect` renders with handoff params and in-app back-link
- [x] Verify direct `/download-data-connect` still hides in-app back-link


Made with [Cursor](https://cursor.com)