### PR TITLE
chore(examples): make nextjs-starter environment configurable via env…

### DIFF
--- a/examples/nextjs-starter/.env.local.example
+++ b/examples/nextjs-starter/.env.local.example
@@ -1,3 +1,5 @@
 VANA_PRIVATE_KEY=0x...              # Builder key, must be registered on-chain
 APP_URL=http://localhost:3001       # Public URL of your deployed app
 VANA_SCOPES=chatgpt.conversations   # Comma-separated scopes
+VANA_ENV=dev
+NEXT_PUBLIC_VANA_ENV=dev

--- a/examples/nextjs-starter/src/components/ConnectFlow.tsx
+++ b/examples/nextjs-starter/src/components/ConnectFlow.tsx
@@ -39,7 +39,9 @@ export default function ConnectFlow() {
     initConnect,
     fetchData,
     isLoading,
-  } = useVanaData({ environment: "dev" });
+  } = useVanaData({
+    environment: (process.env.NEXT_PUBLIC_VANA_ENV as "dev" | "prod") ?? "dev",
+  });
 
   const initRef = useRef(false);
   useEffect(() => {

--- a/examples/nextjs-starter/src/config.ts
+++ b/examples/nextjs-starter/src/config.ts
@@ -8,5 +8,5 @@ export const config = createVanaConfig({
     process.env.VANA_APP_PRIVATE_KEY) as `0x${string}`,
   scopes: SCOPES,
   appUrl: process.env.APP_URL ?? "",
-  environment: "dev",
+  environment: (process.env.VANA_ENV as "dev" | "prod") ?? "dev",
 });


### PR DESCRIPTION
… vars

Replace hardcoded "dev" environment with VANA_ENV and NEXT_PUBLIC_VANA_ENV env vars so the example can run in both dev and prod environments.