### PR TITLE
chore: remove dev environment mode from SDK

### DIFF
--- a/examples/nextjs-starter/.env.local.example
+++ b/examples/nextjs-starter/.env.local.example
@@ -1,5 +1,3 @@
 VANA_PRIVATE_KEY=0x...              # Builder key, must be registered on-chain
 APP_URL=http://localhost:3001       # Public URL of your deployed app
 VANA_SCOPES=chatgpt.conversations   # Comma-separated scopes
-VANA_ENV=dev
-NEXT_PUBLIC_VANA_ENV=dev

--- a/examples/nextjs-starter/src/app/api/data/route.ts
+++ b/examples/nextjs-starter/src/app/api/data/route.ts
@@ -19,7 +19,6 @@ export async function POST(request: Request) {
     const data = await getData({
       privateKey: config.privateKey,
       grant,
-      environment: config.environment,
     });
 
     return NextResponse.json({ data });

--- a/examples/nextjs-starter/src/components/ConnectFlow.tsx
+++ b/examples/nextjs-starter/src/components/ConnectFlow.tsx
@@ -39,9 +39,7 @@ export default function ConnectFlow() {
     initConnect,
     fetchData,
     isLoading,
-  } = useVanaData({
-    environment: (process.env.NEXT_PUBLIC_VANA_ENV as "dev" | "prod") ?? "dev",
-  });
+  } = useVanaData();
 
   const initRef = useRef(false);
   useEffect(() => {

--- a/examples/nextjs-starter/src/config.ts
+++ b/examples/nextjs-starter/src/config.ts
@@ -8,5 +8,4 @@ export const config = createVanaConfig({
     process.env.VANA_APP_PRIVATE_KEY) as `0x${string}`,
   scopes: SCOPES,
   appUrl: process.env.APP_URL ?? "",
-  environment: (process.env.VANA_ENV as "dev" | "prod") ?? "dev",
 });

--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -1,29 +1,15 @@
-/** SDK environment selector. */
-export type VanaEnvironment = "dev" | "prod";
-
-/** URL configuration for each SDK environment. */
+/** URL configuration for the SDK. */
 export const ENV_CONFIG = {
-  dev: {
-    sessionRelayUrl: "https://dev.session-relay.vana.org",
-    gatewayUrl: "https://dev.data-gateway.vana.org",
-    accountUrl: "https://account-dev.vana.org",
-  },
-  prod: {
-    sessionRelayUrl: "https://session-relay.vana.org",
-    gatewayUrl: "https://data-gateway.vana.org",
-    accountUrl: "https://account.vana.org",
-  },
+  sessionRelayUrl: "https://session-relay.vana.org",
+  gatewayUrl: "https://data-gateway.vana.org",
+  accountUrl: "https://account.vana.org",
 } as const;
 
-/** Default environment used when none is specified. */
-export const DEFAULT_ENVIRONMENT: VanaEnvironment = "prod";
-
 /**
- * Returns the URL configuration for the given environment.
+ * Returns the SDK URL configuration.
  *
- * @param environment - `"dev"` or `"prod"`. Defaults to {@link DEFAULT_ENVIRONMENT}.
- * @returns An object with `sessionRelayUrl` and `gatewayUrl`.
+ * @returns An object with `sessionRelayUrl`, `gatewayUrl`, and `accountUrl`.
  */
-export function getEnvConfig(environment?: VanaEnvironment) {
-  return ENV_CONFIG[environment ?? DEFAULT_ENVIRONMENT];
+export function getEnvConfig() {
+  return ENV_CONFIG;
 }

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,11 +1,6 @@
 export { ConnectError, ConnectErrorCode } from "./errors.js";
 export { isValidGrant } from "./grants.js";
-export {
-  getEnvConfig,
-  ENV_CONFIG,
-  DEFAULT_ENVIRONMENT,
-  type VanaEnvironment,
-} from "./constants.js";
+export { getEnvConfig, ENV_CONFIG } from "./constants.js";
 export type {
   ConnectionStatus,
   SessionInitParams,

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -104,8 +104,6 @@ export interface ConnectConfig {
   webhookUrl?: string;
   /** Your app's user ID for correlation. */
   appUserId?: string;
-  /** SDK environment (`"dev"` or `"prod"`). Defaults to `"prod"`. */
-  environment?: "dev" | "prod";
 }
 
 /** Configuration for the high-level {@link getData} function. */
@@ -114,8 +112,6 @@ export interface GetDataConfig {
   privateKey: `0x${string}`;
   /** Grant from the approval step. */
   grant: GrantPayload;
-  /** SDK environment (`"dev"` or `"prod"`). Defaults to `"prod"`. */
-  environment?: "dev" | "prod";
 }
 
 /** Configuration for {@link signVanaManifest}. */

--- a/src/react/useVanaConnect.ts
+++ b/src/react/useVanaConnect.ts
@@ -10,8 +10,6 @@ import type {
 export interface UseVanaConnectConfig {
   /** Polling interval in milliseconds (default: 2000). */
   pollingInterval?: number;
-  /** SDK environment (`"dev"` or `"prod"`). Defaults to `"prod"`. */
-  environment?: "dev" | "prod";
 }
 
 /** Return value of the {@link useVanaConnect} hook. */
@@ -55,7 +53,7 @@ export interface UseVanaConnectResult {
 export function useVanaConnect(
   config?: UseVanaConnectConfig,
 ): UseVanaConnectResult {
-  const envConfig = getEnvConfig(config?.environment);
+  const envConfig = getEnvConfig();
   const baseUrl = envConfig.sessionRelayUrl;
   const accountUrl = envConfig.accountUrl;
   const interval = config?.pollingInterval ?? 2000;

--- a/src/react/useVanaData.ts
+++ b/src/react/useVanaData.ts
@@ -24,8 +24,6 @@ export interface UseVanaDataConfig {
   dataUrl?: string;
   /** Polling interval in ms passed to {@link useVanaConnect} (default: 2000). */
   pollingInterval?: number;
-  /** SDK environment passed through to {@link useVanaConnect}. */
-  environment?: "dev" | "prod";
   /** When true, automatically fetches data after grant approval (default: `true`). */
   autoFetch?: boolean;
 }
@@ -96,7 +94,6 @@ export function useVanaData(config?: UseVanaDataConfig): UseVanaDataResult {
     reset: resetPoll,
   } = useVanaConnect({
     pollingInterval: config?.pollingInterval,
-    environment: config?.environment,
   });
 
   const [data, setData] = useState<unknown>(null);

--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -1,11 +1,9 @@
-import type { VanaEnvironment } from "../core/constants.js";
 import { ConnectError, ConnectErrorCode } from "../core/errors.js";
 
 export interface VanaConfig {
   privateKey: `0x${string}`;
   scopes: string[];
   appUrl: string;
-  environment?: VanaEnvironment;
 }
 
 /**
@@ -34,7 +32,6 @@ export function createVanaConfig(config: {
   privateKey: `0x${string}`;
   scopes: string[];
   appUrl: string;
-  environment?: VanaEnvironment;
 }): VanaConfig {
   if (!config.privateKey) {
     throw new ConnectError(
@@ -68,6 +65,5 @@ export function createVanaConfig(config: {
     privateKey: config.privateKey,
     scopes: config.scopes,
     appUrl: config.appUrl,
-    environment: config.environment,
   };
 }

--- a/src/server/connect.ts
+++ b/src/server/connect.ts
@@ -30,7 +30,7 @@ import { createDataClient } from "./data-client.js";
 export async function connect(
   config: ConnectConfig,
 ): Promise<SessionInitResult> {
-  const { sessionRelayUrl, accountUrl } = getEnvConfig(config.environment);
+  const { sessionRelayUrl, accountUrl } = getEnvConfig();
   const signer = createRequestSigner({ privateKey: config.privateKey });
   const granteeAddress = signer.address;
 
@@ -90,7 +90,7 @@ export async function connect(
 export async function getData(
   config: GetDataConfig,
 ): Promise<Record<string, unknown>> {
-  const { gatewayUrl } = getEnvConfig(config.environment);
+  const { gatewayUrl } = getEnvConfig();
   const { grant } = config;
 
   const dataClient = createDataClient({

--- a/test/core/constants.test.ts
+++ b/test/core/constants.test.ts
@@ -1,28 +1,12 @@
 import { describe, it, expect } from "vitest";
-import {
-  getEnvConfig,
-  ENV_CONFIG,
-  DEFAULT_ENVIRONMENT,
-} from "../../src/core/constants.js";
+import { getEnvConfig, ENV_CONFIG } from "../../src/core/constants.js";
 
 describe("getEnvConfig", () => {
-  it("returns dev config for 'dev'", () => {
-    const config = getEnvConfig("dev");
-    expect(config).toBe(ENV_CONFIG.dev);
+  it("returns the SDK URL configuration", () => {
+    const config = getEnvConfig();
+    expect(config).toBe(ENV_CONFIG);
     expect(config.sessionRelayUrl).toContain("session-relay");
     expect(config.gatewayUrl).toContain("data-gateway");
-    expect(config.accountUrl).toBe("https://account-dev.vana.org");
-  });
-
-  it("returns prod config for 'prod'", () => {
-    const config = getEnvConfig("prod");
-    expect(config).toBe(ENV_CONFIG.prod);
     expect(config.accountUrl).toBe("https://account.vana.org");
-  });
-
-  it("defaults to prod when no environment is specified", () => {
-    const config = getEnvConfig();
-    expect(config).toBe(ENV_CONFIG[DEFAULT_ENVIRONMENT]);
-    expect(config).toBe(ENV_CONFIG.prod);
   });
 });

--- a/test/server/config.test.ts
+++ b/test/server/config.test.ts
@@ -17,12 +17,6 @@ describe("createVanaConfig", () => {
     expect(config.privateKey).toBe(VALID_KEY);
     expect(config.scopes).toEqual(["instagram.dpv1", "twitter.dpv1"]);
     expect(config.appUrl).toBe("https://myapp.com");
-    expect(config.environment).toBeUndefined();
-  });
-
-  it("includes optional environment field", () => {
-    const config = createVanaConfig({ ...VALID_CONFIG, environment: "dev" });
-    expect(config.environment).toBe("dev");
   });
 
   it("throws CONFIG_INVALID when privateKey is missing", () => {

--- a/test/server/connect.test.ts
+++ b/test/server/connect.test.ts
@@ -102,22 +102,6 @@ describe("connect", () => {
     expect(url.searchParams.get("secret")).toBe("abc");
   });
 
-  it("returns connectUrl with dev accountUrl when environment is dev", async () => {
-    mockInitSession();
-
-    const result = await connect({
-      privateKey: TEST_PRIVATE_KEY,
-      scopes: ["instagram.dpv1"],
-      environment: "dev",
-    });
-
-    const { accountUrl } = getEnvConfig("dev");
-    const url = new URL(result.connectUrl);
-    expect(url.origin).toBe(accountUrl);
-    expect(url.searchParams.get("sessionId")).toBe("sess-123");
-    expect(url.searchParams.get("secret")).toBe("abc");
-  });
-
   it("includes appUrl in connectUrl when provided", async () => {
     mockInitSession();
 
@@ -176,20 +160,6 @@ describe("connect", () => {
     });
 
     expect(mockFetch).toHaveBeenCalledTimes(1);
-  });
-
-  it("uses environment config URL when environment is specified", async () => {
-    mockInitSession();
-
-    await connect({
-      privateKey: TEST_PRIVATE_KEY,
-      scopes: ["instagram.dpv1"],
-      environment: "dev",
-    });
-
-    const initUrl = mockFetch.mock.calls[0][0] as string;
-    const { sessionRelayUrl } = getEnvConfig("dev");
-    expect(initUrl).toBe(`${sessionRelayUrl}/v1/session/init`);
   });
 });
 


### PR DESCRIPTION
Remove VanaEnvironment type, dev URL config, and all environment parameters from SDK core, server, React hooks, examples, and tests. The SDK now uses production URLs exclusively.