### PR TITLE
feat(connect): disable Windows download with Coming soon label

### DIFF
--- a/connect/src/app/download-data-connect/page.tsx
+++ b/connect/src/app/download-data-connect/page.tsx
@@ -84,7 +84,9 @@ function DownloadDataConnectPageContent() {
   );
 
   const primaryHref = primaryAsset ? getAssetUrl(primaryAsset.filename) : "#";
-  const canPrimaryDownload = !isUnknown && primaryAsset !== null;
+  const isPrimaryComingSoon = primaryAsset?.comingSoon === true;
+  const canPrimaryDownload =
+    !isUnknown && primaryAsset !== null && !isPrimaryComingSoon;
   const shellActions = authenticated
     ? (["yourApps", "logout"] as const)
     : (["yourApps"] as const);
@@ -163,6 +165,19 @@ function DownloadDataConnectPageContent() {
                 downloadPlatformLabel={downloadPlatformLabel}
               />
             </a>
+          ) : isPrimaryComingSoon ? (
+            <div
+              className={cn(
+                contentStyle,
+                "flex flex-col items-center rounded-card px-w6",
+                "border border-foreground/30 opacity-60",
+              )}
+            >
+              <DownloadDataConnectCardContent
+                downloadPlatformLabel={downloadPlatformLabel}
+                comingSoon
+              />
+            </div>
           ) : (
             <div className="h-[173px]" aria-hidden />
           )}
@@ -287,8 +302,10 @@ export default function DownloadDataConnectPage() {
 
 function DownloadDataConnectCardContent({
   downloadPlatformLabel,
+  comingSoon,
 }: {
   downloadPlatformLabel: string;
+  comingSoon?: boolean;
 }) {
   return (
     <>
@@ -306,10 +323,20 @@ function DownloadDataConnectCardContent({
         <DcLogotype height={16} role="img" aria-label="DataConnect" />
       </div>
       <hr className="w-full border-ring/30" />
-      <Text intent="button" weight="medium" withIcon className="h-12">
-        <ImportIcon className="size-[1.25em]" />
-        Download for {downloadPlatformLabel}
-      </Text>
+      {comingSoon ? (
+        <Text
+          intent="button"
+          weight="medium"
+          className="h-12 flex items-center"
+        >
+          {downloadPlatformLabel} — Coming soon
+        </Text>
+      ) : (
+        <Text intent="button" weight="medium" withIcon className="h-12">
+          <ImportIcon className="size-[1.25em]" />
+          Download for {downloadPlatformLabel}
+        </Text>
+      )}
     </>
   );
 }
@@ -325,6 +352,31 @@ function AssetRow({
   ) => void;
 }) {
   const href = getAssetUrl(asset.filename);
+
+  if (asset.comingSoon) {
+    return (
+      <div
+        className={cn(
+          "flex items-center justify-between gap-2 px-2 py-2.5",
+          "opacity-60",
+        )}
+      >
+        <div className="pl-1 flex-1">
+          <Text as="span" intent="small" weight="medium">
+            {asset.label}
+          </Text>
+        </div>
+        <div
+          className={cn(
+            buttonVariants({ variant: "outline", size: "xs" }),
+            "pointer-events-none",
+          )}
+        >
+          Coming soon
+        </div>
+      </div>
+    );
+  }
 
   return (
     <a

--- a/connect/src/config/config.ts
+++ b/connect/src/config/config.ts
@@ -5,6 +5,7 @@ export type DownloadAsset = {
   filename: string;
   description: string;
   isDefault?: boolean;
+  comingSoon?: boolean;
 };
 
 const DOWNLOAD_VERSION = "0.7.23";
@@ -32,6 +33,7 @@ const downloadAssets: Record<
       filename: `DataConnect_${DOWNLOAD_VERSION}_x64-setup.exe`,
       description: "64-bit installer",
       isDefault: true,
+      comingSoon: true,
     },
   ],
   Linux: [


### PR DESCRIPTION
## Summary
- Adds `comingSoon` flag to `DownloadAsset` type and sets it on the Windows asset
- Windows users visiting the download page see a dimmed card with "Windows — Coming soon" instead of a download button
- The Windows tab in "Other downloads" shows a "Coming soon" badge instead of a clickable download link
- To re-enable, remove `comingSoon: true` from the Windows entry in `config.ts`

## Test plan
- [ ] Visit `/download-data-connect` on a Windows browser (or spoof UA) — primary card shows "Windows — Coming soon"
- [ ] Click the Windows tab in "Other downloads" — row shows "Coming soon" badge, not clickable
- [ ] macOS and Linux downloads remain fully functional

🤖 Generated with [Claude Code](https://claude.com/claude-code)