### PR TITLE
feat: support HTTPS OAuth redirects for MCP auth flow

### DIFF
--- a/connect/src/app/(handoff)/connect/_components/connect-page-ui.tsx
+++ b/connect/src/app/(handoff)/connect/_components/connect-page-ui.tsx
@@ -8,7 +8,7 @@ import {
   XIcon,
 } from "lucide-react";
 import Link from "next/link";
-import { type ReactNode, useState } from "react";
+import { type ReactNode, useEffect, useState } from "react";
 import { APP_ROUTES } from "@/app/routes";
 import { Spinner } from "@/components/elements/spinner";
 import { DcIcon } from "@/components/icons/dc-icon2";
@@ -140,6 +140,34 @@ export function ConnectReadyState({
   deepLinkUrl: string;
   downloadDataConnectHref: string;
 }) {
+  const isHttpsRedirect = deepLinkUrl.startsWith("https://");
+
+  // Auto-redirect for OAuth HTTPS callbacks (e.g., MCP auth flow)
+  useEffect(() => {
+    if (isHttpsRedirect) {
+      window.location.assign(deepLinkUrl);
+    }
+  }, [isHttpsRedirect, deepLinkUrl]);
+
+  if (isHttpsRedirect) {
+    return (
+      <ConnectStateFrame
+        app={app}
+        title={
+          <Text as="h1" intent="title" withIcon align="center">
+            <Spinner />
+            Authorizing...
+          </Text>
+        }
+        subtitle={
+          <Text as="h1" intent="xlarge" dim>
+            Redirecting back to your application.
+          </Text>
+        }
+      />
+    );
+  }
+
   return (
     <ConnectStateFrame
       app={app}

--- a/connect/src/app/(handoff)/connect/_lib/launch-url.ts
+++ b/connect/src/app/(handoff)/connect/_lib/launch-url.ts
@@ -2,10 +2,15 @@ type ResolveConnectLaunchUrlOptions = {
   sessionId?: string | null;
   secret?: string | null;
   masterKeySig?: string | null;
+  redirectUri?: string | null;
+  oauthState?: string | null;
 };
 
 /**
  * Build the Data Connect launch URL for the authenticated web flow.
+ *
+ * When `redirectUri` is an HTTPS URL, returns an HTTPS callback URL
+ * (for OAuth flows like MCP auth). Otherwise returns a `vana://` deep link.
  */
 export function resolveConnectLaunchUrl(
   options: ResolveConnectLaunchUrlOptions,
@@ -17,6 +22,19 @@ export function resolveConnectLaunchUrl(
     return null;
   }
 
+  // OAuth redirect: return HTTPS callback URL with masterKeySig
+  const redirectUri = options.redirectUri?.trim();
+  if (redirectUri && redirectUri.startsWith("https://")) {
+    const url = new URL(redirectUri);
+    url.searchParams.set("masterKeySig", masterKeySig);
+    const oauthState = options.oauthState?.trim();
+    if (oauthState) {
+      url.searchParams.set("oauth_state", oauthState);
+    }
+    return url.toString();
+  }
+
+  // Default: vana:// deep link for DataConnect
   const params = new URLSearchParams({
     sessionId,
     masterKeySig,

--- a/connect/src/app/(handoff)/connect/use-connect-page.ts
+++ b/connect/src/app/(handoff)/connect/use-connect-page.ts
@@ -281,10 +281,15 @@ export function useConnectPage() {
       });
   }, [phase, signMessage, view, embeddedWalletAddress]);
 
+  const redirectUri = handoffContext?.redirectUri ?? null;
+  const oauthState = handoffContext?.oauthState ?? null;
+
   const deepLinkUrl = resolveConnectLaunchUrl({
     sessionId,
     secret,
     masterKeySig,
+    redirectUri,
+    oauthState,
   });
 
   const ui = resolveConnectPageUiDebugState({

--- a/connect/src/app/_lib/handoff-contract.test.ts
+++ b/connect/src/app/_lib/handoff-contract.test.ts
@@ -31,6 +31,8 @@ function createContext(
     app: "discover-me",
     appId: "app-1",
     appName: "Discover Me",
+    redirectUri: null,
+    oauthState: null,
     returnTo: "/connect",
     createdAt: NOW,
     ...overrides,

--- a/connect/src/app/_lib/handoff-contract.ts
+++ b/connect/src/app/_lib/handoff-contract.ts
@@ -24,6 +24,8 @@ export type ConnectHandoffContext = {
   app: string | null;
   appId: string | null;
   appName: string | null;
+  redirectUri: string | null;
+  oauthState: string | null;
   returnTo: string;
   createdAt: number;
 };
@@ -37,6 +39,8 @@ type NormalizableInput = {
   app: unknown;
   appId: unknown;
   appName: unknown;
+  redirectUri: unknown;
+  oauthState: unknown;
   returnTo: unknown;
   createdAt: unknown;
 };
@@ -77,6 +81,8 @@ function normalizeContext(
   const app = readNonEmptyString(input.app);
   const appId = readNonEmptyString(input.appId);
   const appName = readNonEmptyString(input.appName);
+  const redirectUri = readNonEmptyString(input.redirectUri);
+  const oauthState = readNonEmptyString(input.oauthState);
 
   return {
     version: HANDOFF_CONTEXT_VERSION,
@@ -86,6 +92,8 @@ function normalizeContext(
     app,
     appId,
     appName,
+    redirectUri,
+    oauthState,
     returnTo: normalizeReturnTo(input.returnTo),
     createdAt: coerceCreatedAt(input.createdAt, now),
   };
@@ -103,6 +111,8 @@ export function parseFromSearchParams(
       app: searchParams.get("app"),
       appId: searchParams.get("appId"),
       appName: searchParams.get("appName"),
+      redirectUri: searchParams.get("redirect_uri"),
+      oauthState: searchParams.get("oauth_state"),
       returnTo: searchParams.get("returnTo"),
       createdAt: now,
     },
@@ -124,6 +134,8 @@ function parseContextJsonPayload(
         app: parsed.app,
         appId: parsed.appId,
         appName: parsed.appName,
+        redirectUri: parsed.redirectUri,
+        oauthState: parsed.oauthState,
         returnTo: parsed.returnTo,
         createdAt: parsed.createdAt,
       },
@@ -388,7 +400,14 @@ export function resolvePostAuthDestination(
 function createHandoffQueryParams(
   context: Pick<
     ConnectHandoffContext,
-    "sessionId" | "secret" | "appUrl" | "app" | "appId" | "appName"
+    | "sessionId"
+    | "secret"
+    | "appUrl"
+    | "app"
+    | "appId"
+    | "appName"
+    | "redirectUri"
+    | "oauthState"
   >,
 ): URLSearchParams {
   const params = new URLSearchParams();
@@ -407,6 +426,12 @@ function createHandoffQueryParams(
   }
   if (context.appName) {
     params.set("appName", context.appName);
+  }
+  if (context.redirectUri) {
+    params.set("redirect_uri", context.redirectUri);
+  }
+  if (context.oauthState) {
+    params.set("oauth_state", context.oauthState);
   }
   return params;
 }


### PR DESCRIPTION
## Summary
- Adds `redirectUri` and `oauthState` to the connect handoff context
- When a Personal Server's OAuth flow redirects to Account Portal with `redirect_uri` + `oauth_state`, the connect page auto-redirects back with `masterKeySig` instead of showing "Launch DataConnect"
- Existing `vana://` deep link flow is completely unchanged

## Changes
- `handoff-contract.ts` — new `redirectUri` and `oauthState` fields in context type, parsing, and query params
- `launch-url.ts` — builds HTTPS callback URL when `redirectUri` starts with `https://`
- `use-connect-page.ts` — passes new fields through
- `connect-page-ui.tsx` — auto-redirects for HTTPS URLs with "Authorizing..." spinner

## Test plan
- [x] All 61 existing tests pass
- [x] Manual: existing DataConnect deep link flow still works
- [x] Manual: OAuth redirect flow from Personal Server MCP auth

Related to: vana-com/personal-server PR #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)