### PR TITLE
ci(connect): sync DataConnect download version

### DIFF
--- a/connect/src/config/config.ts
+++ b/connect/src/config/config.ts
@@ -8,7 +8,7 @@ export type DownloadAsset = {
   comingSoon?: boolean;
 };
 
-const DOWNLOAD_VERSION = "0.7.29";
+const DOWNLOAD_VERSION = "0.7.32";
 const DATA_CONNECT_GITHUB_RELEASES_URL =
   "https://github.com/vana-com/data-connect/releases";
 


### PR DESCRIPTION
## Summary
- sync `DOWNLOAD_VERSION` in `connect/src/config/config.ts` to the latest `vana-com/data-connect` release tag
- keep `/download-data-connect` asset links current without manual edits

## Test plan
- [ ] Run this workflow via workflow_dispatch
- [ ] Confirm PR is created only when latest tag differs
- [ ] Verify generated URLs on `/download-data-connect` point to the new release

Made with [Cursor](https://cursor.com)