### PR TITLE
ci(connect): sync DataConnect download version to v0.7.35

### DIFF
--- a/connect/src/config/config.ts
+++ b/connect/src/config/config.ts
@@ -8,7 +8,7 @@ export type DownloadAsset = {
   comingSoon?: boolean;
 };
 
-const DOWNLOAD_VERSION = "0.7.33";
+const DOWNLOAD_VERSION = "0.7.35";
 const DATA_CONNECT_GITHUB_RELEASES_URL =
   "https://github.com/vana-com/data-connect/releases";
 


### PR DESCRIPTION
## Summary
- Sync `DOWNLOAD_VERSION` in `connect/src/config/config.ts` from v0.7.33 to v0.7.35
- Keeps `/download-data-connect` asset links current with latest DataConnect release

## Test plan
- [ ] Verify generated URLs on `/download-data-connect` point to v0.7.35 release

Made with [Cursor](https://cursor.com)