### PR TITLE
feat: embrowse web flow on account.vana.org

### DIFF
--- a/connect/public/mock-embrowse.html
+++ b/connect/public/mock-embrowse.html
@@ -1,0 +1,152 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Mock Embrowse</title>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body { font-family: system-ui, sans-serif; padding: 24px; background: #fafafa; color: #111; }
+    h2 { font-size: 18px; margin-bottom: 12px; }
+    .status { font-size: 13px; color: #666; margin-bottom: 16px; }
+    button { padding: 10px 20px; border: 1px solid #ddd; border-radius: 6px; background: #fff; cursor: pointer; font-size: 14px; }
+    button:hover { background: #f0f0f0; }
+    button.primary { background: #0066ff; color: #fff; border-color: #0066ff; }
+    button.primary:hover { background: #0052cc; }
+    button.cancel { color: #666; }
+    .actions { display: flex; gap: 8px; margin-top: 16px; }
+    pre { background: #f5f5f5; padding: 12px; border-radius: 6px; font-size: 12px; overflow: auto; max-height: 400px; margin-top: 16px; }
+  </style>
+</head>
+<body>
+  <h2>Mock Embrowse</h2>
+  <div class="status" id="status">Waiting for config...</div>
+  <div class="actions">
+    <button class="primary" id="btn-scrape" disabled>Simulate scrape</button>
+    <button class="cancel" id="btn-cancel">Cancel</button>
+  </div>
+  <pre id="output"></pre>
+
+  <script>
+    // -- Mock Instagram data (matches instagram.ads + instagram.profile schemas) --
+    const MOCK_DATA = {
+      "instagram.ads": {
+        advertisers: [
+          { name: "Nike" },
+          { name: "Spotify" },
+          { name: "Netflix" },
+          { name: "Airbnb" },
+          { name: "Apple Music" },
+          { name: "Headspace" },
+          { name: "Allbirds" },
+          { name: "Warby Parker" },
+        ],
+        ad_topics: [
+          { name: "Fitness & Wellness" },
+          { name: "Music & Audio" },
+          { name: "Streaming & Entertainment" },
+          { name: "Travel & Hospitality" },
+          { name: "Technology" },
+          { name: "Sustainable Fashion" },
+          { name: "Mental Health" },
+        ],
+      },
+      "instagram.profile": {
+        username: "demo_user",
+        full_name: "Demo User",
+        bio: "Just a demo account for testing Vana data portability",
+        follower_count: 847,
+        following_count: 312,
+        media_count: 156,
+        is_private: false,
+        is_verified: false,
+        is_business: false,
+      },
+    };
+
+    const parentOrigin = document.referrer
+      ? new URL(document.referrer).origin
+      : "*";
+
+    const statusEl = document.getElementById("status");
+    const outputEl = document.getElementById("output");
+    const btnScrape = document.getElementById("btn-scrape");
+    const btnCancel = document.getElementById("btn-cancel");
+
+    let config = null;
+
+    // Signal ready to parent
+    function sendToParent(msg) {
+      const target = window.opener || window.parent;
+      target.postMessage(msg, parentOrigin);
+    }
+
+    sendToParent({ type: "embrowse:ready" });
+    statusEl.textContent = "Ready — waiting for init config...";
+
+    // Listen for init from parent
+    window.addEventListener("message", (event) => {
+      if (event.data?.type !== "embrowse:init") return;
+      config = event.data;
+      statusEl.textContent =
+        `Configured: platform=${config.platform}, scopes=[${config.scopes.join(", ")}], server=${config.serverUrl}`;
+      btnScrape.disabled = false;
+      outputEl.textContent = JSON.stringify(config, null, 2);
+    });
+
+    // Simulate scraping with progress messages
+    btnScrape.addEventListener("click", async () => {
+      if (!config) return;
+      btnScrape.disabled = true;
+
+      const steps = [
+        "Launching browser...",
+        "Navigating to Instagram...",
+        "Extracting ad interests...",
+        "Extracting profile data...",
+        "Posting to Personal Server...",
+      ];
+
+      for (const step of steps) {
+        sendToParent({ type: "embrowse:progress", status: step });
+        statusEl.textContent = step;
+        await new Promise((r) => setTimeout(r, 800));
+      }
+
+      // POST each scope to the personal server
+      const ingested = [];
+      for (const scope of config.scopes) {
+        const data = MOCK_DATA[scope];
+        if (!data) continue;
+
+        try {
+          const url = `${config.serverUrl}/v1/data/${scope}`;
+          const headers = { "Content-Type": "application/json" };
+          if (config.serverAuthToken) {
+            headers["Authorization"] = `Bearer ${config.serverAuthToken}`;
+          }
+          const res = await fetch(url, {
+            method: "POST",
+            headers,
+            body: JSON.stringify(data),
+          });
+          if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+          ingested.push(scope);
+        } catch (err) {
+          // If server isn't reachable, still count as ingested for the mock
+          console.warn(`[mock-embrowse] POST to ${scope} failed:`, err.message);
+          ingested.push(scope);
+        }
+      }
+
+      sendToParent({ type: "embrowse:complete", scopes: ingested });
+      statusEl.textContent = `Done — ingested: ${ingested.join(", ")}`;
+      outputEl.textContent = JSON.stringify(MOCK_DATA, null, 2);
+    });
+
+    btnCancel.addEventListener("click", () => {
+      sendToParent({ type: "embrowse:cancel" });
+      statusEl.textContent = "Cancelled";
+    });
+  </script>
+</body>
+</html>

--- a/connect/src/app/(handoff)/connect/_components/connect-page-states.tsx
+++ b/connect/src/app/(handoff)/connect/_components/connect-page-states.tsx
@@ -1,8 +1,15 @@
 "use client";
 
-import { ArrowUpRightIcon, RotateCcwIcon, XIcon } from "lucide-react";
+import {
+  ArrowUpRightIcon,
+  CheckCircle2Icon,
+  GlobeIcon,
+  RotateCcwIcon,
+  XIcon,
+} from "lucide-react";
 import { useEffect } from "react";
 import { APP_ROUTES } from "@/app/routes";
+import type { EmbrowseStatus } from "@/app/_lib/use-embrowse";
 import { Spinner } from "@/components/elements/spinner";
 import { Text } from "@/components/typography/text";
 import { ButtonArrow } from "@/components/ui/button";
@@ -186,6 +193,141 @@ export function ConnectReadyState({
             )
           }
         />
+      }
+    />
+  );
+}
+
+export function ConnectEmbrowseState({
+  app,
+  embrowseStatus,
+  progressText,
+  errorMessage,
+  onOpenEmbrowse,
+  onRetry,
+}: {
+  app: ConnectAppMetadata;
+  embrowseStatus: EmbrowseStatus;
+  progressText: string | null;
+  errorMessage: string | null;
+  onOpenEmbrowse: () => void;
+  onRetry: () => void;
+}) {
+  const statusLabel =
+    embrowseStatus === "idle"
+      ? "Ready to connect your data"
+      : embrowseStatus === "loading"
+        ? "Opening…"
+        : embrowseStatus === "ready"
+          ? "Waiting for you in the popup…"
+          : embrowseStatus === "scraping"
+            ? (progressText ?? "Collecting data…")
+            : embrowseStatus === "error"
+              ? (errorMessage ?? "Something went wrong")
+              : embrowseStatus === "cancelled"
+                ? "Cancelled"
+                : "Done";
+
+  return (
+    <ConnectStateFrame
+      app={app}
+      title={
+        <Text as="h1" intent="title" align="center">
+          Connect your data
+        </Text>
+      }
+      subtitle={
+        <Text as="p" intent="large" dim balance>
+          {statusLabel}
+        </Text>
+      }
+      content={
+        embrowseStatus === "idle" ? (
+          <ConnectLaunchSection
+            primaryAction={{
+              kind: "button",
+              onClick: onOpenEmbrowse,
+              label: "Connect now",
+              leftIcon: <GlobeIcon />,
+            }}
+          />
+        ) : embrowseStatus === "error" || embrowseStatus === "cancelled" ? (
+          <ConnectLaunchSection
+            primaryAction={{
+              kind: "button",
+              onClick: onRetry,
+              label: "Try again",
+              leftIcon: <RotateCcwIcon />,
+            }}
+          />
+        ) : embrowseStatus === "loading" ||
+          embrowseStatus === "ready" ||
+          embrowseStatus === "scraping" ? (
+          <div className="flex justify-center">
+            <Spinner />
+          </div>
+        ) : null
+      }
+    />
+  );
+}
+
+export function ConnectCompleteState({
+  app,
+  completedScopes,
+  appUrl,
+}: {
+  app: ConnectAppMetadata;
+  completedScopes: string[];
+  appUrl: string | null;
+}) {
+  return (
+    <ConnectStateFrame
+      app={app}
+      title={
+        <Text as="h1" intent="title" withIcon align="center">
+          <CheckCircle2Icon className="text-success-foreground" />
+          Data connected
+        </Text>
+      }
+      subtitle={
+        <Text as="p" intent="large" dim balance>
+          {completedScopes.length > 0
+            ? `Connected: ${completedScopes.join(", ")}`
+            : "Your data has been securely stored on your Personal Server."}
+        </Text>
+      }
+      content={
+        <div className="space-y-3">
+          {appUrl ? (
+            <ConnectLaunchSection
+              primaryAction={{
+                kind: "link",
+                href: appUrl,
+                label: `Return to ${app.displayName}`,
+              }}
+              secondaryContent={
+                <Text as="p">
+                  or{" "}
+                  <a
+                    href={APP_ROUTES.dashboard}
+                    className="link hover:text-foreground"
+                  >
+                    Manage account
+                  </a>
+                </Text>
+              }
+            />
+          ) : (
+            <ConnectLaunchSection
+              primaryAction={{
+                kind: "link",
+                href: APP_ROUTES.dashboard,
+                label: "Manage your data",
+              }}
+            />
+          )}
+        </div>
       }
     />
   );

--- a/connect/src/app/(handoff)/connect/connect-page-client.tsx
+++ b/connect/src/app/(handoff)/connect/connect-page-client.tsx
@@ -5,7 +5,10 @@ import { useSearchParams } from "next/navigation";
 import type { ComponentType } from "react";
 import { PagePanel } from "@/app/_components/page-panel";
 import { PageShell } from "@/app/_components/page-shell";
+import { useEmbrowse } from "@/app/_lib/use-embrowse";
 import {
+  ConnectCompleteState,
+  ConnectEmbrowseState,
   ConnectErrorState,
   ConnectLoadingState,
   ConnectMissingSessionState,
@@ -99,6 +102,23 @@ export function ConnectPageClient({
     sessionId === "local-server-auth" &&
     appQuery.appName?.toLowerCase() === "dataconnect";
 
+  // Embrowse web flow — used when the connect flow completes and we need to
+  // scrape data in-browser instead of handing off to the desktop app.
+  // For now, the PS URL is passed as a query param or hardcoded for demo.
+  const serverUrl = searchParams.get("serverUrl") ?? "http://localhost:8080";
+  const embrowseUrl = searchParams.get("embrowseUrl") ?? "/mock-embrowse.html";
+  const embrowse = useEmbrowse({
+    embrowseUrl,
+    platform: appQuery.dataSource ?? "instagram",
+    scopes: appQuery.dataScopes ?? ["instagram.ads", "instagram.profile"],
+    serverUrl,
+  });
+
+  // Determine if we should show the web embrowse flow instead of the desktop deep link.
+  // For now, use a query param flag (?web=1) to opt in. In production, this would be
+  // determined by whether the user has a hosted PS or is on mobile.
+  const useWebFlow = searchParams.get("web") === "1";
+
   return (
     <>
       {!sessionId ? (
@@ -121,7 +141,33 @@ export function ConnectPageClient({
               <ConnectLoadingState app={app} />
             ) : null}
 
-            {view === "ready" && deepLinkUrl ? (
+            {view === "ready" &&
+            useWebFlow &&
+            embrowse.status !== "complete" ? (
+              <ConnectEmbrowseState
+                app={app}
+                embrowseStatus={embrowse.status}
+                progressText={embrowse.progressText}
+                errorMessage={embrowse.errorMessage}
+                onOpenEmbrowse={embrowse.openPopup}
+                onRetry={() => {
+                  embrowse.reset();
+                  embrowse.openPopup();
+                }}
+              />
+            ) : null}
+
+            {view === "ready" &&
+            useWebFlow &&
+            embrowse.status === "complete" ? (
+              <ConnectCompleteState
+                app={app}
+                completedScopes={embrowse.completedScopes}
+                appUrl={appQuery.appUrl}
+              />
+            ) : null}
+
+            {view === "ready" && !useWebFlow && deepLinkUrl ? (
               <ConnectReadyState
                 app={app}
                 requestedDataLabel={appQuery.requestedDataLabel}

--- a/connect/src/app/(handoff)/dashboard/dashboard-client.tsx
+++ b/connect/src/app/(handoff)/dashboard/dashboard-client.tsx
@@ -1,0 +1,153 @@
+"use client";
+
+import { CheckCircle2Icon, DatabaseIcon, ShieldCheckIcon } from "lucide-react";
+import { useSearchParams } from "next/navigation";
+import { PagePanel } from "@/app/_components/page-panel";
+import { PageShell } from "@/app/_components/page-shell";
+import { Spinner } from "@/components/elements/spinner";
+import { Text } from "@/components/typography/text";
+import { useDashboard } from "./use-dashboard";
+
+function formatScope(scope: string): string {
+  // "instagram.ads" → "Instagram Ads"
+  return scope
+    .split(".")
+    .map((s) => s.charAt(0).toUpperCase() + s.slice(1))
+    .join(" ");
+}
+
+function formatAddress(address: string): string {
+  if (address.length <= 10) return address;
+  return `${address.slice(0, 6)}…${address.slice(-4)}`;
+}
+
+function formatDate(dateStr: string): string {
+  try {
+    return new Date(dateStr).toLocaleDateString(undefined, {
+      month: "short",
+      day: "numeric",
+      year: "numeric",
+    });
+  } catch {
+    return dateStr;
+  }
+}
+
+export function DashboardClient() {
+  const searchParams = useSearchParams();
+  const serverUrl = searchParams.get("serverUrl") ?? "http://localhost:8080";
+  const { data, loading, error } = useDashboard(serverUrl);
+
+  return (
+    <PageShell>
+      <PagePanel className="text-left">
+        <div className="space-y-8 w-full max-w-lg mx-auto py-8">
+          <div>
+            <Text as="h1" intent="title">
+              Your Data
+            </Text>
+            <Text as="p" intent="large" dim>
+              Data stored on your Personal Server
+            </Text>
+          </div>
+
+          {loading && (
+            <div className="flex items-center gap-2">
+              <Spinner />
+              <Text as="p" dim>
+                Loading…
+              </Text>
+            </div>
+          )}
+
+          {error && (
+            <div className="rounded-lg border border-destructive/30 bg-destructive/5 p-4">
+              <Text as="p" color="destructive">
+                {error}
+              </Text>
+            </div>
+          )}
+
+          {data && (
+            <>
+              {/* Connected Data Sources */}
+              <section className="space-y-3">
+                <div className="flex items-center gap-2">
+                  <DatabaseIcon className="size-4" />
+                  <Text as="h2" intent="large" weight="semi">
+                    Connected Data
+                  </Text>
+                </div>
+
+                {data.dataScopes.length === 0 ? (
+                  <Text as="p" dim>
+                    No data connected yet.
+                  </Text>
+                ) : (
+                  <div className="space-y-2">
+                    {data.dataScopes.map((scope) => (
+                      <div
+                        key={scope.scope}
+                        className="flex items-center justify-between rounded-lg border p-3"
+                      >
+                        <div className="flex items-center gap-2">
+                          <CheckCircle2Icon className="size-4 text-success-foreground" />
+                          <Text as="span" weight="medium">
+                            {formatScope(scope.scope)}
+                          </Text>
+                        </div>
+                        {scope.collectedAt && (
+                          <Text as="span" intent="small" muted>
+                            {formatDate(scope.collectedAt)}
+                          </Text>
+                        )}
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </section>
+
+              {/* Connected Apps */}
+              <section className="space-y-3">
+                <div className="flex items-center gap-2">
+                  <ShieldCheckIcon className="size-4" />
+                  <Text as="h2" intent="large" weight="semi">
+                    Connected Apps
+                  </Text>
+                </div>
+
+                {data.grants.length === 0 ? (
+                  <Text as="p" dim>
+                    No apps connected yet.
+                  </Text>
+                ) : (
+                  <div className="space-y-2">
+                    {data.grants.map((grant) => (
+                      <div
+                        key={grant.id}
+                        className="rounded-lg border p-3 space-y-1"
+                      >
+                        <div className="flex items-center justify-between">
+                          <Text as="span" weight="medium">
+                            {grant.appName ??
+                              formatAddress(grant.granteeAddress)}
+                          </Text>
+                          <Text as="span" intent="small" muted>
+                            {grant.status}
+                          </Text>
+                        </div>
+                        <Text as="p" intent="small" muted>
+                          {grant.scopes.map(formatScope).join(", ")}
+                        </Text>
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </section>
+            </>
+          )}
+        </div>
+      </PagePanel>
+    </PageShell>
+  );
+}

--- a/connect/src/app/(handoff)/dashboard/page.tsx
+++ b/connect/src/app/(handoff)/dashboard/page.tsx
@@ -1,0 +1,5 @@
+import { DashboardClient } from "./dashboard-client";
+
+export default function DashboardPage() {
+  return <DashboardClient />;
+}

--- a/connect/src/app/(handoff)/dashboard/use-dashboard.ts
+++ b/connect/src/app/(handoff)/dashboard/use-dashboard.ts
@@ -1,0 +1,80 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+
+interface DataScope {
+  scope: string;
+  collectedAt: string;
+}
+
+interface Grant {
+  id: string;
+  granteeAddress: string;
+  scopes: string[];
+  status: string;
+  createdAt?: string;
+  appName?: string;
+  appUrl?: string;
+}
+
+interface DashboardData {
+  dataScopes: DataScope[];
+  grants: Grant[];
+}
+
+export function useDashboard(serverUrl: string) {
+  const [data, setData] = useState<DashboardData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchDashboard = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      // Fetch data scopes and grants in parallel from the Personal Server
+      const [scopesRes, grantsRes] = await Promise.all([
+        fetch(`${serverUrl}/v1/data`).catch(() => null),
+        fetch(`${serverUrl}/v1/grants`).catch(() => null),
+      ]);
+
+      const dataScopes: DataScope[] = [];
+      if (scopesRes?.ok) {
+        const scopesJson = (await scopesRes.json()) as
+          | { scopes?: DataScope[] }
+          | DataScope[];
+        if (Array.isArray(scopesJson)) {
+          dataScopes.push(...scopesJson);
+        } else if (Array.isArray(scopesJson?.scopes)) {
+          dataScopes.push(...scopesJson.scopes);
+        }
+      }
+
+      const grants: Grant[] = [];
+      if (grantsRes?.ok) {
+        const grantsJson = (await grantsRes.json()) as
+          | { grants?: Grant[] }
+          | Grant[];
+        if (Array.isArray(grantsJson)) {
+          grants.push(...grantsJson);
+        } else if (Array.isArray(grantsJson?.grants)) {
+          grants.push(...grantsJson.grants);
+        }
+      }
+
+      setData({ dataScopes, grants });
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : "Failed to load dashboard data",
+      );
+    } finally {
+      setLoading(false);
+    }
+  }, [serverUrl]);
+
+  useEffect(() => {
+    void fetchDashboard();
+  }, [fetchDashboard]);
+
+  return { data, loading, error, refresh: fetchDashboard };
+}

--- a/connect/src/app/_lib/embrowse-protocol.ts
+++ b/connect/src/app/_lib/embrowse-protocol.ts
@@ -1,0 +1,144 @@
+/**
+ * Embrowse communication protocol.
+ *
+ * Modeled after Plaid Link / Stripe Elements: the parent page sends
+ * configuration via postMessage, Embrowse reports lifecycle events back.
+ *
+ * Supports both iframe and popup modes. Popup is preferred when Embrowse
+ * needs cross-origin isolation (COOP/COEP) for SharedArrayBuffer / WASM,
+ * which browsers block inside iframes on non-isolated parent pages.
+ *
+ * Origin checking is enforced on both sides.
+ */
+
+// -- Messages: Parent → Embrowse ------------------------------------
+
+export interface EmbrowseInitMessage {
+  type: "embrowse:init";
+  /** Platform to scrape (e.g. "instagram") */
+  platform: string;
+  /** Scopes to collect (e.g. ["instagram.ads", "instagram.profile"]) */
+  scopes: string[];
+  /** Personal Server URL to POST results to */
+  serverUrl: string;
+  /** Auth token for the Personal Server (when not localhost) */
+  serverAuthToken?: string;
+}
+
+export type ParentToEmbrowseMessage = EmbrowseInitMessage;
+
+// -- Messages: Embrowse → Parent ------------------------------------
+
+export interface EmbrowseReadyMessage {
+  type: "embrowse:ready";
+}
+
+export interface EmbrowseProgressMessage {
+  type: "embrowse:progress";
+  status: string;
+}
+
+export interface EmbrowseCompleteMessage {
+  type: "embrowse:complete";
+  /** Scopes that were successfully ingested */
+  scopes: string[];
+}
+
+export interface EmbrowseErrorMessage {
+  type: "embrowse:error";
+  message: string;
+}
+
+export interface EmbrowseCancelMessage {
+  type: "embrowse:cancel";
+}
+
+export type EmbrowseToParentMessage =
+  | EmbrowseReadyMessage
+  | EmbrowseProgressMessage
+  | EmbrowseCompleteMessage
+  | EmbrowseErrorMessage
+  | EmbrowseCancelMessage;
+
+// -- Parent-side helpers --------------------------------------------
+
+const EMBROWSE_MESSAGE_TYPES = new Set([
+  "embrowse:ready",
+  "embrowse:progress",
+  "embrowse:complete",
+  "embrowse:error",
+  "embrowse:cancel",
+]);
+
+function isEmbrowseMessage(data: unknown): data is EmbrowseToParentMessage {
+  return (
+    typeof data === "object" &&
+    data !== null &&
+    "type" in data &&
+    typeof (data as { type: unknown }).type === "string" &&
+    EMBROWSE_MESSAGE_TYPES.has((data as { type: string }).type)
+  );
+}
+
+export interface EmbrowseHostOptions {
+  /** The target window — either an iframe's contentWindow or a popup */
+  target: Window;
+  /** The origin of the Embrowse window (e.g. "https://embrowse.vana.org") */
+  embrowseOrigin: string;
+  onReady?: () => void;
+  onProgress?: (status: string) => void;
+  onComplete?: (scopes: string[]) => void;
+  onError?: (message: string) => void;
+  onCancel?: () => void;
+}
+
+/**
+ * Listen for Embrowse lifecycle messages and send init config on ready.
+ * Works with both iframes and popups (any Window reference).
+ * Returns a cleanup function (call on unmount / close).
+ */
+export function connectEmbrowse(
+  options: EmbrowseHostOptions,
+  config: Omit<EmbrowseInitMessage, "type">,
+): () => void {
+  const {
+    target,
+    embrowseOrigin,
+    onReady,
+    onProgress,
+    onComplete,
+    onError,
+    onCancel,
+  } = options;
+
+  function handleMessage(event: MessageEvent) {
+    if (event.origin !== embrowseOrigin) return;
+    if (!isEmbrowseMessage(event.data)) return;
+
+    switch (event.data.type) {
+      case "embrowse:ready":
+        onReady?.();
+        // Send config once Embrowse signals it's ready
+        target.postMessage(
+          { type: "embrowse:init", ...config } satisfies EmbrowseInitMessage,
+          embrowseOrigin,
+        );
+        break;
+      case "embrowse:progress":
+        onProgress?.(event.data.status);
+        break;
+      case "embrowse:complete":
+        onComplete?.(event.data.scopes);
+        break;
+      case "embrowse:error":
+        onError?.(event.data.message);
+        break;
+      case "embrowse:cancel":
+        onCancel?.();
+        break;
+    }
+  }
+
+  window.addEventListener("message", handleMessage);
+  return () => window.removeEventListener("message", handleMessage);
+}

--- a/connect/src/app/_lib/use-embrowse.ts
+++ b/connect/src/app/_lib/use-embrowse.ts
@@ -1,0 +1,121 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { connectEmbrowse } from "./embrowse-protocol";
+
+export type EmbrowseStatus =
+  | "idle"
+  | "loading"
+  | "ready"
+  | "scraping"
+  | "complete"
+  | "error"
+  | "cancelled";
+
+interface UseEmbrowseOptions {
+  /** Embrowse URL (e.g. "https://embrowse.vana.org" or "/mock-embrowse.html") */
+  embrowseUrl: string;
+  /** Platform to scrape */
+  platform: string;
+  /** Scopes to request */
+  scopes: string[];
+  /** Personal Server URL to POST results to */
+  serverUrl: string;
+  /** Auth token for the Personal Server (when not localhost) */
+  serverAuthToken?: string;
+}
+
+export function useEmbrowse(options: UseEmbrowseOptions) {
+  const { embrowseUrl, platform, scopes, serverUrl, serverAuthToken } = options;
+  const popupRef = useRef<Window | null>(null);
+  const [status, setStatus] = useState<EmbrowseStatus>("idle");
+  const [progressText, setProgressText] = useState<string | null>(null);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [completedScopes, setCompletedScopes] = useState<string[]>([]);
+
+  const origin = typeof window !== "undefined" ? window.location.origin : "";
+  const embrowseOrigin = embrowseUrl.startsWith("/")
+    ? origin
+    : new URL(embrowseUrl).origin;
+
+  const resolvedUrl = embrowseUrl.startsWith("/")
+    ? `${origin}${embrowseUrl}`
+    : embrowseUrl;
+
+  const openPopup = useCallback(() => {
+    const popup = window.open(
+      resolvedUrl,
+      "embrowse",
+      "popup=true,width=480,height=720",
+    );
+    if (!popup) {
+      setStatus("error");
+      setErrorMessage("Popup blocked — please allow popups for this site");
+      return;
+    }
+    popupRef.current = popup;
+    setStatus("loading");
+  }, [resolvedUrl]);
+
+  // Wire up protocol listener when popup is open
+  useEffect(() => {
+    if (status !== "loading" && status !== "ready" && status !== "scraping")
+      return;
+    const popup = popupRef.current;
+    if (!popup) return;
+
+    // Detect popup close
+    const interval = setInterval(() => {
+      if (popup.closed) {
+        clearInterval(interval);
+        setStatus((prev) => (prev === "complete" ? prev : "cancelled"));
+      }
+    }, 500);
+
+    const cleanup = connectEmbrowse(
+      {
+        target: popup,
+        embrowseOrigin,
+        onReady: () => setStatus("ready"),
+        onProgress: (s: string) => {
+          setStatus("scraping");
+          setProgressText(s);
+        },
+        onComplete: (s: string[]) => {
+          setStatus("complete");
+          setCompletedScopes(s);
+          popup.close();
+        },
+        onError: (msg: string) => {
+          setStatus("error");
+          setErrorMessage(msg);
+        },
+        onCancel: () => setStatus("cancelled"),
+      },
+      { platform, scopes, serverUrl, serverAuthToken },
+    );
+
+    return () => {
+      clearInterval(interval);
+      cleanup();
+    };
+  }, [status, embrowseOrigin, platform, scopes, serverUrl, serverAuthToken]);
+
+  const reset = useCallback(() => {
+    popupRef.current?.close();
+    popupRef.current = null;
+    setStatus("idle");
+    setProgressText(null);
+    setErrorMessage(null);
+    setCompletedScopes([]);
+  }, []);
+
+  return {
+    status,
+    progressText,
+    errorMessage,
+    completedScopes,
+    openPopup,
+    reset,
+  };
+}

--- a/connect/src/app/routes.ts
+++ b/connect/src/app/routes.ts
@@ -1,6 +1,7 @@
 export const APP_ROUTES = {
   root: "/",
   connect: "/connect",
+  dashboard: "/dashboard",
   login: "/login",
   logout: "/logout",
   admin: "/admin",


### PR DESCRIPTION
## Summary

- Add browser-based data scraping (Embrowse) to the connect flow on account.vana.org
- Embrowse opens as a popup using a Plaid Link/Stripe Elements-style postMessage protocol
- `?web=1` query param opts into web flow instead of desktop deep link handoff
- `/dashboard` route shows connected data sources and granted apps from the Personal Server
- Mock embrowse HTML included for testing until Kahtaf's real Embrowse is ready

## New files

- `connect/src/app/_lib/embrowse-protocol.ts` — postMessage protocol (parent↔child)
- `connect/src/app/_lib/use-embrowse.ts` — React hook for popup lifecycle
- `connect/src/app/(handoff)/dashboard/` — dashboard page (P1: connected data + apps)
- `connect/public/mock-embrowse.html` — mock scraper for demo/testing

## Test plan

- [ ] Navigate to `/connect?sessionId=test&web=1` — should show embrowse flow after auth
- [ ] Click "Connect now" — popup opens with mock embrowse
- [ ] Click "Simulate scrape" in popup — data POSTs to PS, popup closes, success state shown
- [ ] "Manage account" link navigates to `/dashboard`
- [ ] `/dashboard?serverUrl=http://localhost:8080` shows data scopes and grants from PS
- [ ] Without `?web=1`, existing desktop deep link flow unchanged

## Related

- data-connect PR #85: embrowse protocol + mock (desktop/Tauri)
- vana-connect PR #54: 3PA example consuming Instagram ad interests

🤖 Generated with [Claude Code](https://claude.com/claude-code)