### PR TITLE
feat: auth-only mode for identity-only connect flow

### DIFF
--- a/connect/src/app/(handoff)/connect/connect-page-client.tsx
+++ b/connect/src/app/(handoff)/connect/connect-page-client.tsx
@@ -73,6 +73,7 @@ export function ConnectPageClient({
     error,
     sessionId,
     isAuthenticated,
+    isAuthOnly,
     deepLinkUrl,
     appContext,
     downloadDataConnectHref,
@@ -121,7 +122,17 @@ export function ConnectPageClient({
               <ConnectLoadingState app={app} />
             ) : null}
 
-            {view === "ready" && deepLinkUrl ? (
+            {view === "ready" && isAuthOnly ? (
+              <div className="flex flex-col items-center gap-3">
+                <div className="text-2xl text-green-500">&#10003;</div>
+                <h2 className="text-lg font-semibold">Connected</h2>
+                <p className="text-sm text-muted-foreground">
+                  You have been authenticated. You can close this tab.
+                </p>
+              </div>
+            ) : null}
+
+            {view === "ready" && !isAuthOnly && deepLinkUrl ? (
               <ConnectReadyState
                 app={app}
                 requestedDataLabel={appQuery.requestedDataLabel}

--- a/connect/src/app/(handoff)/connect/use-connect-page.ts
+++ b/connect/src/app/(handoff)/connect/use-connect-page.ts
@@ -91,6 +91,9 @@ export function useConnectPage() {
   const { wallets, ready: walletsReady } = useWallets();
   const { createWallet } = useCreateWallet();
 
+  const isAuthOnly = handoffContext?.mode === "auth";
+  const relayUrl = handoffContext?.relayUrl ?? null;
+
   const [view, setView] = useState<ConnectPageView>("loading");
   const [error, setError] = useState<string | null>(null);
   const [masterKeySig, setMasterKeySig] = useState<string | null>(null);
@@ -202,6 +205,65 @@ export function useConnectPage() {
     isUiDebugScenarioActive,
   ]);
 
+  // Auth-only mode: after Privy auth + wallet ready, claim+approve directly on relay.
+  // Skips master key signing and DataConnect deep link entirely.
+  const authOnlyAttemptedRef = useRef(false);
+  useEffect(() => {
+    if (!isAuthOnly) return;
+    if (!authenticated || !embeddedWalletAddress) return;
+    if (!sessionId || !secret || !relayUrl) return;
+    if (view === "ready" || view === "error") return;
+    if (authOnlyAttemptedRef.current) return;
+    authOnlyAttemptedRef.current = true;
+
+    setView("signing");
+
+    (async () => {
+      // Step 1: Claim the session (pending → claimed)
+      const claimRes = await fetch(`${relayUrl}/v1/session/claim`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ sessionId, secret }),
+      });
+      if (!claimRes.ok) {
+        const text = await claimRes.text();
+        throw new Error(`Claim failed: ${claimRes.status} ${text}`);
+      }
+
+      // Step 2: Approve with user address (claimed → approved)
+      const approveRes = await fetch(
+        `${relayUrl}/v1/session/${sessionId}/approve`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            secret,
+            grantId: "auth-only",
+            userAddress: embeddedWalletAddress,
+            scopes: ["identity.auth"],
+          }),
+        },
+      );
+      if (!approveRes.ok) {
+        const text = await approveRes.text();
+        throw new Error(`Approve failed: ${approveRes.status} ${text}`);
+      }
+
+      setView("ready");
+    })().catch((err) => {
+      setError(err instanceof Error ? err.message : "Auth-only flow failed");
+      setView("error");
+    });
+  }, [
+    isAuthOnly,
+    authenticated,
+    embeddedWalletAddress,
+    sessionId,
+    secret,
+    relayUrl,
+    view,
+  ]);
+
   // Ensure a Privy embedded wallet exists for signing.
   useEffect(() => {
     if (isUiDebugScenarioActive) return;
@@ -261,9 +323,10 @@ export function useConnectPage() {
     };
   }, []);
 
-  // Sign the master key after authentication
+  // Sign the master key after authentication (skipped in auth-only mode)
   useEffect(() => {
     if (isUiDebugScenarioActive) return;
+    if (isAuthOnly) return;
     if (view === "error" || view === "ready") return;
     if (phase !== "signing-ready" || signingRef.current) return;
 
@@ -350,6 +413,7 @@ export function useConnectPage() {
     error: ui.error,
     sessionId: ui.sessionId,
     isAuthenticated: ready && authenticated,
+    isAuthOnly,
     deepLinkUrl: ui.deepLinkUrl,
     appContext: handoffContext
       ? {

--- a/connect/src/app/_lib/handoff-contract.test.ts
+++ b/connect/src/app/_lib/handoff-contract.test.ts
@@ -27,6 +27,8 @@ function createContext(
     version: 1,
     sessionId: "sess-1",
     secret: "sec-1",
+    mode: null,
+    relayUrl: null,
     appUrl: null,
     dataSource: null,
     app: "discover-me",

--- a/connect/src/app/_lib/handoff-contract.ts
+++ b/connect/src/app/_lib/handoff-contract.ts
@@ -20,6 +20,10 @@ export type ConnectHandoffContext = {
   version: typeof HANDOFF_CONTEXT_VERSION;
   sessionId: string;
   secret: string | null;
+  /** Flow mode: "auth" for identity-only (skip DataConnect), null for default connect flow. */
+  mode: string | null;
+  /** Session Relay URL, provided when mode is "auth" so the portal can call claim/approve directly. */
+  relayUrl: string | null;
   appUrl: string | null;
   dataSource: string | null;
   scopes?: string[];
@@ -37,6 +41,8 @@ type SearchParamReader = {
 type NormalizableInput = {
   sessionId: unknown;
   secret: unknown;
+  mode: unknown;
+  relayUrl: unknown;
   appUrl: unknown;
   dataSource: unknown;
   scopes: unknown;
@@ -97,6 +103,8 @@ function normalizeContext(
   if (!sessionId) return null;
 
   const secret = readNonEmptyString(input.secret);
+  const mode = readNonEmptyString(input.mode);
+  const relayUrl = readNonEmptyString(input.relayUrl);
   const appUrl = readNonEmptyString(input.appUrl);
   const dataSource = readNonEmptyString(input.dataSource);
   const scopes = normalizeScopes(input.scopes);
@@ -110,6 +118,8 @@ function normalizeContext(
     version: HANDOFF_CONTEXT_VERSION,
     sessionId,
     secret,
+    mode,
+    relayUrl,
     appUrl,
     dataSource,
     ...(scopes ? { scopes } : {}),
@@ -131,6 +141,8 @@ export function parseFromSearchParams(
     {
       sessionId: searchParams.get("sessionId"),
       secret: searchParams.get("secret"),
+      mode: searchParams.get("mode"),
+      relayUrl: searchParams.get("relayUrl"),
       appUrl: searchParams.get("appUrl"),
       dataSource: searchParams.get("dataSource"),
       scopes: searchParams.get("scopes") ?? searchParams.get("scope"),
@@ -156,6 +168,8 @@ function parseContextJsonPayload(
       {
         sessionId: parsed.sessionId,
         secret: parsed.secret,
+        mode: parsed.mode,
+        relayUrl: parsed.relayUrl,
         appUrl: parsed.appUrl,
         dataSource: parsed.dataSource,
         scopes: parsed.scopes,
@@ -430,6 +444,8 @@ function createHandoffQueryParams(
     ConnectHandoffContext,
     | "sessionId"
     | "secret"
+    | "mode"
+    | "relayUrl"
     | "appUrl"
     | "dataSource"
     | "scopes"
@@ -444,6 +460,12 @@ function createHandoffQueryParams(
   params.set("sessionId", context.sessionId);
   if (context.secret) {
     params.set("secret", context.secret);
+  }
+  if (context.mode) {
+    params.set("mode", context.mode);
+  }
+  if (context.relayUrl) {
+    params.set("relayUrl", context.relayUrl);
   }
   if (context.appUrl) {
     params.set("appUrl", context.appUrl);

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -96,8 +96,15 @@ export interface DataClientConfig {
 export interface ConnectConfig {
   /** Builder private key in hex format. */
   privateKey: `0x${string}`;
-  /** Data scopes to request. */
-  scopes: string[];
+  /** Data scopes to request. Defaults to `["identity.auth"]` when mode is `"auth"`. */
+  scopes?: string[];
+  /**
+   * Flow mode.
+   * - `"connect"` (default): full data grant flow via DataConnect.
+   * - `"auth"`: identity-only — user authenticates and returns their address,
+   *   no DataConnect required.
+   */
+  mode?: "auth" | "connect";
   /** Public app URL used by Connect UI to resolve favicon branding. */
   appUrl?: string;
   /** Human-readable label for the requested data source shown in Connect UI. */

--- a/src/server/connect.ts
+++ b/src/server/connect.ts
@@ -34,6 +34,14 @@ export async function connect(
   const signer = createRequestSigner({ privateKey: config.privateKey });
   const granteeAddress = signer.address;
 
+  const mode = config.mode ?? "connect";
+  const scopes =
+    config.scopes && config.scopes.length > 0
+      ? config.scopes
+      : mode === "auth"
+        ? ["identity.auth"]
+        : [];
+
   const relay = createSessionRelay({
     privateKey: config.privateKey,
     granteeAddress,
@@ -41,7 +49,7 @@ export async function connect(
   });
 
   const relayResult = await relay.initSession({
-    scopes: config.scopes,
+    scopes,
     webhookUrl: config.webhookUrl,
     appUserId: config.appUserId,
   });
@@ -49,6 +57,10 @@ export async function connect(
   // Build the account.vana.org connect URL from the relay response
   const connectUrl = new URL("/connect", accountUrl);
   connectUrl.searchParams.set("sessionId", relayResult.sessionId);
+  if (mode === "auth") {
+    connectUrl.searchParams.set("mode", "auth");
+    connectUrl.searchParams.set("relayUrl", sessionRelayUrl);
+  }
   if (typeof config.appUrl === "string" && config.appUrl.trim().length > 0) {
     connectUrl.searchParams.set("appUrl", config.appUrl.trim());
   }


### PR DESCRIPTION
## Summary

- Adds `mode: "auth"` option to `ConnectConfig` that authenticates users and returns their wallet address without requiring DataConnect or the full data grant flow
- After Privy auth on the Account Portal, the session is claimed and approved directly on the Session Relay, bypassing the DataConnect deep link entirely
- Zero changes to Session Relay — reuses existing `/claim` and `/approve` endpoints with a synthetic `identity.auth` scope

## Changes

**SDK (`src/`):**
- `ConnectConfig.mode?: "auth" | "connect"` — new optional field
- `ConnectConfig.scopes` — now optional (defaults to `["identity.auth"]` for auth mode)
- `connect()` passes `mode` and `relayUrl` to the Account Portal via connectUrl params

**Account Portal (`connect/`):**
- `handoff-contract.ts` — threads `mode` + `relayUrl` through the handoff context (survives auth redirects)
- `use-connect-page.ts` — auth-only flow: after Privy auth + wallet ready, calls `/claim` then `/approve` directly, skips master key signing
- `page.tsx` — shows "Connected" confirmation instead of DataConnect deep link for auth-only mode

## Usage

```typescript
const session = await connect({
  privateKey: process.env.VANA_PRIVATE_KEY as `0x${string}`,
  mode: "auth",
});
// Redirect user to session.connectUrl
// User signs in via Privy → Account Portal auto-approves
const result = await pollUntilComplete(session.sessionId);
// result.grant.userAddress = "0x..."
```

## Backward compatibility

- Existing `connect({ scopes: [...] })` flow is completely untouched
- All 69 SDK tests pass
- All 20 Account Portal tests pass
- No Session Relay changes

## Test plan

- [ ] Verify existing connect flow still works (scopes + DataConnect)
- [ ] Test auth-only flow: `mode: "auth"` → Privy login → address returned
- [ ] Verify handoff context survives auth redirects with mode + relayUrl
- [ ] Test error handling (relay down, claim fails, approve fails)

🤖 Generated with [Claude Code](https://claude.com/claude-code)