### PR TITLE
fix: next-prompt skill treats guidance as directive, not task list

### DIFF
--- a/skills/next-prompt/SKILL.md
+++ b/skills/next-prompt/SKILL.md
@@ -104,19 +104,9 @@ The user's `Permissions` section overrides these defaults.
 
 **Do not present a numbered list of options.** Pick the best one. If you're wrong, the user will redirect you. That's faster than making them choose every time.
 
-## What to look for in each source
+## Reading sources
 
-**GitHub:** Recent commits (what was worked on), open issues, PRs awaiting review, dependency alerts, repos with recent activity vs. stale repos.
-
-**ChatGPT:** Recent conversation topics (what the user is thinking about), saved memories (stated preferences and goals), repeated questions (knowledge gaps or recurring concerns).
-
-**LinkedIn:** Unread messages (especially from contacts matching focus areas), profile views, job-relevant activity.
-
-**Spotify:** Listening patterns can indicate work state (focus music = deep work, podcasts = learning, silence = meetings or away).
-
-**YouTube:** Recent watch history and subscriptions signal what the user is learning about or interested in.
-
-**Shop/Uber:** Time-sensitive receipts, returns windows, upcoming trips.
+Each result file in `~/.vana/results/` is a different connected source. Don't assume a fixed set — new sources will appear over time. Read the JSON structure to understand what each source contains and look for what's actionable: recent activity, pending items, time-sensitive deadlines, unanswered messages, recurring patterns.
 
 ## Rules
 


### PR DESCRIPTION
## Summary

- Reframes `~/.vana/next-prompt.md` as a standing directive (like a system prompt) instead of a task backlog
- Renames "Priorities" → "Focus", adds structured "Permissions" (do without asking / ask first), keeps "Standing instructions"
- Replaces the numbered-list-of-suggestions flow with pick-one-and-do-it behavior
- Adds risk classification table (safe/visible/destructive) for action gating
- Adds YouTube as a data source, updates LinkedIn reference from hardcoded labels to generic "focus areas"

## Test plan

- [ ] Run `vana next-prompt` with an empty Focus section — agent should work from data alone without prompting user to fill in tasks
- [ ] Run with a populated Focus section — agent should use it as context, not treat items as a checklist
- [ ] Verify agent picks one action and executes instead of presenting a numbered menu

🤖 Generated with [Claude Code](https://claude.com/claude-code)