### PR TITLE
fix: align demo GIF output path with VHS render script

### DIFF
--- a/docs/vhs/demo.tape
+++ b/docs/vhs/demo.tape
@@ -6,7 +6,7 @@
 #         VANA_DEMO_FAST_SUCCESS=1 \
 #         vhs docs/vhs/demo.tape
 
-Output docs/assets/demo.gif
+Output docs/vhs/demo.gif
 
 Set Shell "bash"
 Set FontSize 22

--- a/scripts/check-demo-freshness.sh
+++ b/scripts/check-demo-freshness.sh
@@ -4,7 +4,7 @@
 
 set -euo pipefail
 
-GIF="docs/assets/demo.gif"
+GIF="docs/vhs/demo.gif"
 TAPE="docs/vhs/demo.tape"
 
 # Source paths that affect what the CLI prints in human mode.


### PR DESCRIPTION
## Summary
- Demo tape wrote to `docs/assets/demo.gif` but `render-vhs.mjs` expected `docs/vhs/demo.gif`
- This mismatch caused the release workflow `demo-preview` step to fail
- Also fixes `check-demo-freshness.sh` to match

## Test plan
- [x] Release workflow should pass `demo-preview` step