### PR TITLE
ci: add workflow_dispatch to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,7 @@ on:
     paths-ignore:
       - "connect/**"
       - "examples/**"
+  workflow_dispatch:
 
 permissions:
   contents: write


### PR DESCRIPTION
Allows manual release triggers. Also triggers a fresh release run with the updated GitHub App permissions.