### PR TITLE
ci: resolve version before building SEA binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,53 @@ permissions:
   id-token: write
 
 jobs:
+  # Phase 1: Determine next version via dry-run.
+  # If no release is needed, all downstream jobs are skipped.
+  resolve-version:
+    runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+    outputs:
+      new-release-version: ${{ steps.version.outputs.new-release-version }}
+      new-release-published: ${{ steps.version.outputs.new-release-published }}
+    steps:
+      - uses: actions/create-github-app-token@v2
+        id: app-token
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 25
+          cache: pnpm
+          registry-url: https://registry.npmjs.org
+      - run: pnpm install --frozen-lockfile
+      - name: Determine next version
+        id: version
+        run: |
+          pnpm exec semantic-release --dry-run 2>&1 | tee /tmp/sr-output.txt
+          VERSION=$(grep -oP 'The next release version is \K[0-9]+\.[0-9]+\.[0-9]+' /tmp/sr-output.txt || true)
+          if [ -n "$VERSION" ]; then
+            echo "new-release-version=$VERSION" >> "$GITHUB_OUTPUT"
+            echo "new-release-published=true" >> "$GITHUB_OUTPUT"
+            echo "Next release: $VERSION"
+          else
+            echo "new-release-published=false" >> "$GITHUB_OUTPUT"
+            echo "No release needed"
+          fi
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  # Phase 2: Build SEA binaries with the correct version baked in.
   build-sea:
+    needs: resolve-version
+    if: needs.resolve-version.outputs.new-release-published == 'true'
     env:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
     strategy:
@@ -54,6 +100,9 @@ jobs:
           cache: pnpm
           registry-url: https://registry.npmjs.org
       - run: pnpm install --frozen-lockfile
+      # Inject the resolved version into package.json before building
+      - name: Set release version
+        run: npm version ${{ needs.resolve-version.outputs.new-release-version }} --no-git-tag-version --allow-same-version
       - run: pnpm clean
       - run: pnpm build
       - run: pnpm pack:check
@@ -66,7 +115,11 @@ jobs:
             artifacts/sea/vana-${{ matrix.platform }}-${{ matrix.arch }}
             artifacts/sea/vana-${{ matrix.platform }}-${{ matrix.arch }}.${{ matrix.archive_format }}
             artifacts/sea/vana-${{ matrix.platform }}-${{ matrix.arch }}.${{ matrix.archive_format }}.sha256
+
+  # Phase 2 (parallel): Build demo assets
   demo-preview:
+    needs: resolve-version
+    if: needs.resolve-version.outputs.new-release-published == 'true'
     runs-on: ubuntu-latest
     env:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
@@ -92,8 +145,11 @@ jobs:
           path: |
             docs/transcripts
             docs/vhs
+
+  # Phase 3: Run semantic-release for real (npm publish, git tag, GitHub release).
   release:
-    needs: [build-sea, demo-preview]
+    needs: [resolve-version, build-sea, demo-preview]
+    if: needs.resolve-version.outputs.new-release-published == 'true'
     runs-on: ubuntu-latest
     env:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
@@ -145,6 +201,7 @@ jobs:
           RELEASE_TAG=$(gh api repos/${GITHUB_REPOSITORY}/releases/latest --jq .tag_name)
           mapfile -t RELEASE_FILES < <(node ./scripts/collect-release-assets.mjs)
           gh release upload "$RELEASE_TAG" "${RELEASE_FILES[@]}" --clobber
+
   verify-release-install:
     needs: release
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
SEA binaries were reporting the old version because they built before semantic-release bumped package.json. New three-phase workflow:

1. **resolve-version** — dry-run semantic-release to get the next version (~30s)
2. **build-sea + demo-preview** — parallel builds with correct version injected
3. **release** — semantic-release publishes with pre-built artifacts

No release needed → all jobs skip immediately.

## Test plan
- [ ] Push a `feat:` commit and verify `vana --version` matches the release tag