### PR TITLE
fix: use minimal config for release version dry-run

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,19 @@ jobs:
       - name: Determine next version
         id: version
         run: |
-          pnpm exec semantic-release --dry-run 2>&1 | tee /tmp/sr-output.txt
+          # Use a minimal config for the dry-run that skips npm/git/github
+          # verification — we only need the commit analyzer to resolve the
+          # next version number.
+          cat > /tmp/.releaserc-version-only.yaml <<'RCEOF'
+          branches: ["main"]
+          plugins:
+            - - "@semantic-release/commit-analyzer"
+              - preset: conventionalcommits
+                releaseRules:
+                  - breaking: true
+                    release: minor
+          RCEOF
+          pnpm exec semantic-release --dry-run --extends /tmp/.releaserc-version-only.yaml 2>&1 | tee /tmp/sr-output.txt || true
           VERSION=$(grep -oP 'The next release version is \K[0-9]+\.[0-9]+\.[0-9]+' /tmp/sr-output.txt || true)
           if [ -n "$VERSION" ]; then
             echo "new-release-version=$VERSION" >> "$GITHUB_OUTPUT"
@@ -57,7 +69,6 @@ jobs:
           fi
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   # Phase 2: Build SEA binaries with the correct version baked in.
   build-sea:


### PR DESCRIPTION
The dry-run was failing on npm token validation before determining the version. Uses a commit-analyzer-only config for the version resolution step.