### PR TITLE
fix: import ordering in tests, clean up auto-schedule comment

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -4342,11 +4342,8 @@ async function maybeAutoSchedule(
   const existing = await getExistingScheduleInterval();
   if (existing !== null) return; // Schedule already exists
 
-  // Create a schedule. On Linux this is always hourly (cron doesn't defer
-  // missed jobs, so isCollectionDue() filters per-source at each tick).
-  // On macOS/Windows the OS handles missed-job deferral natively.
   await runScheduleAdd("daily", { json: false, quiet: true });
-  emit.detail("Auto-scheduled collection.");
+  emit.detail("Auto-scheduled daily collection.");
 }
 
 function generateLaunchdPlist(

--- a/test/cli/index.test.ts
+++ b/test/cli/index.test.ts
@@ -1,10 +1,5 @@
 import { createRequire } from "node:module";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-
-const require = createRequire(import.meta.url);
-const { version: PKG_VERSION } = require("../../package.json") as {
-  version: string;
-};
 import {
   cliDataListSchema,
   cliDataPathSchema,
@@ -18,6 +13,11 @@ import {
   cliSourcesSchema,
   sourceRequiredErrorSchema,
 } from "../../src/core/cli-types.js";
+
+const require = createRequire(import.meta.url);
+const { version: PKG_VERSION } = require("../../package.json") as {
+  version: string;
+};
 
 const mockListAvailableSources = vi.fn();
 const mockDetectPersonalServerTarget = vi.fn();


### PR DESCRIPTION
## Summary
- Move `createRequire`/`PKG_VERSION` declarations after all imports in `test/cli/index.test.ts` to satisfy TypeScript strict import ordering
- Remove misleading Linux-hourly comment from `maybeAutoSchedule` in `src/cli/index.ts` — the cron-level detail already lives in `runScheduleAdd`

## Test plan
- [x] `pnpm build` passes
- [x] `pnpm test` passes (206/206)
- [x] `prettier --write` confirms no formatting changes needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)