### PR TITLE
fix: strip trailing period in health message, cap update check wait at 2s

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -626,7 +626,10 @@ Examples:
   // The concurrent check may have populated the cache during this run.
   if (shouldNotify) {
     try {
-      await updateCheckPromise;
+      await Promise.race([
+        updateCheckPromise,
+        new Promise((resolve) => setTimeout(resolve, 2000)),
+      ]);
       const cache = await readUpdateCheck();
       if (cache && isNewerVersion(cliVersion, cache.latestVersion)) {
         const { upgrade } = getLifecycleCommands(
@@ -3535,7 +3538,8 @@ export function formatHealthMessage(reason: string | undefined): string | null {
   if (!reason) return null;
   const colonIndex = reason.indexOf(": ");
   const prefix = colonIndex > 0 ? reason.slice(0, colonIndex) : reason;
-  const detail = colonIndex > 0 ? reason.slice(colonIndex + 2) : "";
+  const detail =
+    colonIndex > 0 ? reason.slice(colonIndex + 2).replace(/\.$/, "") : "";
 
   switch (prefix) {
     case "needs-input":

--- a/test/cli/index.test.ts
+++ b/test/cli/index.test.ts
@@ -3458,6 +3458,12 @@ describe("runCli", () => {
     expect(formatHealthMessage("error-result: Session expired")).toBe(
       "Connector returned an error: Session expired.",
     );
+    // Trailing period in detail is stripped to avoid double-period
+    expect(
+      formatHealthMessage("legacy-auth: Disabled in --no-input mode."),
+    ).toBe(
+      "Needed a browser window: Disabled in --no-input mode. Reconnect interactively.",
+    );
     // Unknown prefix falls back gracefully
     expect(formatHealthMessage("something-new: details")).toBe(
       "something-new: details",


### PR DESCRIPTION
## Summary

- **Double period fix**: `formatHealthMessage` now strips a trailing period from the `detail` portion of the health reason string before appending its own, preventing output like `"...disabled in --no-input mode.. Reconnect interactively."`
- **Update check hang fix**: The `finally` block in `runCli()` now races `updateCheckPromise` against a 2-second timeout, so a slow DNS lookup or network issue can no longer block CLI exit (previously seen hanging for 1m52s)

## Test plan

- [x] Added test case for trailing-period stripping in `formatHealthMessage`
- [x] All 220 existing tests pass
- [x] `pnpm validate` passes (lint + format + test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)