### PR TITLE
fix: show all sources that need attention in status output

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1616,6 +1616,66 @@ async function runStatus(options: GlobalOptions): Promise<number> {
     }
   }
 
+  // Show attention-needing sources that weren't already displayed above
+  const displayedSourceIds = new Set(connectedSources.map(([id]) => id));
+  const hiddenAttentionSources = status.sources.filter(
+    (s) => rankSourceStatus(s) <= 4 && !displayedSourceIds.has(s.source),
+  );
+  if (hiddenAttentionSources.length > 0) {
+    if (connectedSources.length === 0) {
+      emit.blank();
+    }
+    for (const source of hiddenAttentionSources) {
+      const displayName = displaySource(source.source, sourceLabels);
+      const presentation = getSourceStatusPresentation(source);
+      const collectedAgo = source.lastCollectedAt
+        ? `collected ${formatRelativeTime(source.lastCollectedAt)}`
+        : "";
+      emit.keyValue(
+        `  ${displayName}`,
+        `${presentation.label}${collectedAgo ? `     ${collectedAgo}` : ""}`,
+        presentation.tone,
+      );
+      // Show actionable detail line
+      if (
+        source.lastRunOutcome === CliOutcomeStatus.INGEST_FAILED &&
+        source.ingestScopes
+      ) {
+        const failedScopes = source.ingestScopes.filter(
+          (s) => s.status === "failed",
+        );
+        for (const scope of failedScopes) {
+          const errMsg = scope.error ?? "sync failed";
+          emit.detail(
+            `  \u21b3 ${source.source}.${scope.scope}: ${errMsg}. Run \`vana connect ${source.source}\``,
+          );
+        }
+        if (failedScopes.length === 0) {
+          emit.detail(
+            `  \u21b3 Sync failed. Run \`vana connect ${source.source}\``,
+          );
+        }
+      } else if (
+        source.lastRunOutcome === CliOutcomeStatus.CONNECTOR_UNAVAILABLE
+      ) {
+        emit.detail(`  \u21b3 No connector available. Run \`vana sources\``);
+      } else if (source.lastRunOutcome === CliOutcomeStatus.RUNTIME_ERROR) {
+        const reason = source.lastError ?? "runtime error";
+        emit.detail(
+          `  \u21b3 ${reason}. Run \`vana connect ${source.source}\``,
+        );
+      } else if (source.lastRunOutcome === CliOutcomeStatus.NEEDS_INPUT) {
+        emit.detail(
+          `  \u21b3 Requires interactive login. Run \`vana connect ${source.source}\``,
+        );
+      } else if (source.lastRunOutcome === CliOutcomeStatus.LEGACY_AUTH) {
+        emit.detail(
+          `  \u21b3 Manual auth step required. Run \`vana connect ${source.source}\``,
+        );
+      }
+    }
+  }
+
   if (nextSteps.length > 0) {
     emit.blank();
     const command = extractCommand(nextSteps[0]);

--- a/test/cli/index.test.ts
+++ b/test/cli/index.test.ts
@@ -714,6 +714,9 @@ describe("runCli", () => {
         Personal Server: not connected
         Sources:       1 connected, 1 needs attention
 
+          Shop:        manual step
+          ↳ Manual auth step required. Run \`vana connect shop\`
+
         Next: \`vana connect shop\`
       "
     `);


### PR DESCRIPTION
## Summary
- Sources counted in the "X need attention" summary but not shown in the connected sources list are now rendered after healthy sources with actionable detail lines
- Covers sync-failed, connector-unavailable, runtime-error, needs-input, and legacy-auth outcomes
- Each hidden attention source gets a status label and a `↳` hint with the remediation command

## Test plan
- [x] Existing snapshot test updated to verify the new "Shop: manual step" line appears
- [x] `pnpm build && pnpm test` — 220/220 passing
- [x] `pnpm prettier --check` on changed files passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)