### PR TITLE
fix: update Homebrew tap name and install URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The `vana` CLI collects your personal data from any platform. See the **[CLI REA
 Install on macOS with Homebrew:
 
 ```bash
-brew tap vana-com/vana
+brew tap vana-com/tap
 brew install vana
 vana status
 ```
@@ -17,7 +17,7 @@ vana status
 Or use the hosted prerelease installer on macOS/Linux:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/vana-com/vana-connect/feat/connect-cli-v1/install/install.sh | sh -s -- --version canary-feat-connect-cli-v1
+curl -fsSL https://raw.githubusercontent.com/vana-com/vana-connect/main/install/install.sh | sh
 ```
 
 Branch prerelease:

--- a/scripts/test-install-github-release.sh
+++ b/scripts/test-install-github-release.sh
@@ -2,7 +2,7 @@
 set -eu
 
 REPO="${VANA_RELEASE_REPO:-vana-com/vana-connect}"
-BRANCH="${VANA_INSTALLER_BRANCH:-feat/connect-cli-v1}"
+BRANCH="${VANA_INSTALLER_BRANCH:-main}"
 VERSION="${VANA_VERSION:-}"
 SOURCE="${VANA_CONNECT_SOURCE:-github}"
 

--- a/skills/connect-data/SKILL.md
+++ b/skills/connect-data/SKILL.md
@@ -37,7 +37,7 @@ brew install vana-com/tap/vana
 macOS and Linux:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/vana-com/vana-connect/feat/connect-cli-v1/install/install.sh | sh -s -- --version canary-feat-connect-cli-v1
+curl -fsSL https://raw.githubusercontent.com/vana-com/vana-connect/main/install/install.sh | sh
 ```
 
 Only if the installed CLI path is unavailable or blocked, fall back to:


### PR DESCRIPTION
- Homebrew tap: `vana-com/vana` → `vana-com/tap` (repo was renamed to `homebrew-tap`)
- Install script URL: `feat/connect-cli-v1` branch → `main`
- Remove `--version canary-feat-connect-cli-v1` flag from install commands