### PR TITLE
fix(auth): streamline device login UX

### DIFF
--- a/connect/src/app/auth/device/page.test.tsx
+++ b/connect/src/app/auth/device/page.test.tsx
@@ -1,0 +1,74 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  searchParams: new URLSearchParams(),
+  deviceAuthState: {
+    isReady: true,
+    isLoggedIn: false,
+    status: "idle" as "idle" | "signing" | "approving" | "approved" | "error",
+    error: null as string | null,
+    approve: vi.fn(),
+    login: vi.fn(),
+  },
+}));
+
+vi.mock("next/navigation", () => ({
+  useSearchParams: () => mocks.searchParams,
+}));
+
+vi.mock("./use-device-auth", () => ({
+  useDeviceAuth: () => mocks.deviceAuthState,
+}));
+
+import DeviceAuthPage from "./page";
+
+describe("DeviceAuthPage", () => {
+  beforeEach(() => {
+    mocks.searchParams = new URLSearchParams();
+    mocks.deviceAuthState.isReady = true;
+    mocks.deviceAuthState.isLoggedIn = false;
+    mocks.deviceAuthState.status = "idle";
+    mocks.deviceAuthState.error = null;
+    mocks.deviceAuthState.approve.mockReset();
+    mocks.deviceAuthState.login.mockReset();
+    window.sessionStorage.clear();
+  });
+
+  it("accepts typed hyphens in the device code input", () => {
+    render(<DeviceAuthPage />);
+
+    const input = screen.getByPlaceholderText("XXXX-XXXX");
+    fireEvent.change(input, { target: { value: "abcd-efgh" } });
+
+    expect((input as HTMLInputElement).value).toBe("ABCD-EFGH");
+  });
+
+  it("persists a typed code through login and resumes approval after authentication", async () => {
+    const { rerender } = render(<DeviceAuthPage />);
+
+    const input = screen.getByPlaceholderText("XXXX-XXXX");
+    fireEvent.change(input, { target: { value: "abcd-efgh" } });
+    fireEvent.submit(
+      screen.getByRole("button", { name: /sign in to authorize/i }),
+    );
+
+    expect(mocks.deviceAuthState.login).toHaveBeenCalledTimes(1);
+    expect(window.sessionStorage.getItem("vana_pending_device_code")).toBe(
+      "ABCDEFGH",
+    );
+    expect(window.sessionStorage.getItem("vana_pending_device_approval")).toBe(
+      "1",
+    );
+
+    mocks.deviceAuthState.isLoggedIn = true;
+    rerender(<DeviceAuthPage />);
+
+    await waitFor(() => {
+      expect(mocks.deviceAuthState.approve).toHaveBeenCalledWith("ABCD-EFGH");
+    });
+    expect(window.sessionStorage.getItem("vana_pending_device_approval")).toBe(
+      null,
+    );
+  });
+});

--- a/connect/src/app/auth/device/page.tsx
+++ b/connect/src/app/auth/device/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useSearchParams } from "next/navigation";
-import { Suspense, useCallback, useEffect, useState } from "react";
+import { Suspense, useCallback, useEffect, useMemo, useState } from "react";
 import { PagePanel } from "@/app/_components/page-panel";
 import { PageShell } from "@/app/_components/page-shell";
 import { PageHeader } from "@/components/elements/page-header";
@@ -12,54 +12,174 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { useDeviceAuth } from "./use-device-auth";
 
+const PENDING_DEVICE_CODE_KEY = "vana_pending_device_code";
+const PENDING_APPROVAL_KEY = "vana_pending_device_approval";
+
+function normalizeDeviceCode(raw: string): string {
+  return raw
+    .toUpperCase()
+    .replace(/[^A-Z0-9]/g, "")
+    .slice(0, 8);
+}
+
+function formatDeviceCode(raw: string): string {
+  const normalized = normalizeDeviceCode(raw);
+  if (normalized.length <= 4) {
+    return normalized;
+  }
+  return `${normalized.slice(0, 4)}-${normalized.slice(4)}`;
+}
+
+function readPendingCode(): string {
+  if (typeof window === "undefined") {
+    return "";
+  }
+  return window.sessionStorage.getItem(PENDING_DEVICE_CODE_KEY) ?? "";
+}
+
+function writePendingCode(code: string): void {
+  if (typeof window === "undefined") {
+    return;
+  }
+  if (code) {
+    window.sessionStorage.setItem(PENDING_DEVICE_CODE_KEY, code);
+  } else {
+    window.sessionStorage.removeItem(PENDING_DEVICE_CODE_KEY);
+  }
+}
+
+function readPendingApproval(): boolean {
+  if (typeof window === "undefined") {
+    return false;
+  }
+  return window.sessionStorage.getItem(PENDING_APPROVAL_KEY) === "1";
+}
+
+function writePendingApproval(pending: boolean): void {
+  if (typeof window === "undefined") {
+    return;
+  }
+  if (pending) {
+    window.sessionStorage.setItem(PENDING_APPROVAL_KEY, "1");
+  } else {
+    window.sessionStorage.removeItem(PENDING_APPROVAL_KEY);
+  }
+}
+
 function DeviceAuthContent() {
   const searchParams = useSearchParams();
   const initialCode = searchParams.get("code") ?? "";
-  const [userCode, setUserCode] = useState(initialCode);
+  const initialPendingCode = useMemo(() => {
+    const providedCode = normalizeDeviceCode(initialCode);
+    if (providedCode) {
+      return providedCode;
+    }
+    return normalizeDeviceCode(readPendingCode());
+  }, [initialCode]);
+  const [userCode, setUserCode] = useState(() =>
+    formatDeviceCode(initialPendingCode),
+  );
   const { isReady, isLoggedIn, status, error, approve, login } =
     useDeviceAuth();
 
-  // Auto-approve if code was provided in URL and user is already logged in
-  const [autoApproved, setAutoApproved] = useState(false);
+  const normalizedUserCode = useMemo(
+    () => normalizeDeviceCode(userCode),
+    [userCode],
+  );
+  const [lastSubmittedCode, setLastSubmittedCode] = useState<string | null>(
+    null,
+  );
+
   useEffect(() => {
-    if (
-      initialCode &&
-      isReady &&
-      isLoggedIn &&
-      status === "idle" &&
-      !autoApproved
-    ) {
-      setAutoApproved(true);
-      approve(initialCode);
+    writePendingCode(normalizedUserCode);
+  }, [normalizedUserCode]);
+
+  useEffect(() => {
+    if (status === "approved") {
+      writePendingApproval(false);
+      writePendingCode("");
     }
-  }, [initialCode, isReady, isLoggedIn, status, autoApproved, approve]);
+    if (status === "error") {
+      setLastSubmittedCode(null);
+    }
+  }, [status]);
+
+  const submitApproval = useCallback(
+    (code: string) => {
+      const normalized = normalizeDeviceCode(code);
+      if (!normalized) {
+        return;
+      }
+      if (lastSubmittedCode === normalized) {
+        return;
+      }
+
+      setLastSubmittedCode(normalized);
+      writePendingCode(normalized);
+      approve(formatDeviceCode(normalized));
+    },
+    [approve, lastSubmittedCode],
+  );
+
+  useEffect(() => {
+    if (!isReady || !isLoggedIn || status !== "idle") {
+      return;
+    }
+
+    const pendingApproval = readPendingApproval();
+    if (pendingApproval && normalizedUserCode.length === 8) {
+      writePendingApproval(false);
+      submitApproval(normalizedUserCode);
+      return;
+    }
+
+    if (initialCode && normalizedUserCode.length === 8) {
+      submitApproval(normalizedUserCode);
+    }
+  }, [
+    initialCode,
+    isLoggedIn,
+    isReady,
+    normalizedUserCode,
+    status,
+    submitApproval,
+  ]);
 
   const handleSubmit = useCallback(
     (e: React.FormEvent) => {
       e.preventDefault();
-      if (!userCode.trim()) return;
+      if (!normalizedUserCode) return;
+
+      writePendingCode(normalizedUserCode);
 
       if (!isLoggedIn) {
+        writePendingApproval(true);
         login();
         return;
       }
 
-      approve(userCode.trim());
+      submitApproval(normalizedUserCode);
     },
-    [userCode, isLoggedIn, approve, login],
+    [normalizedUserCode, isLoggedIn, login, submitApproval],
   );
 
-  const formatCodeInput = useCallback(
+  const handleCodeChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
-      let value = e.target.value.toUpperCase().replace(/[^A-Z0-9]/g, "");
-      if (value.length > 8) value = value.slice(0, 8);
-      if (value.length > 4) {
-        value = `${value.slice(0, 4)}-${value.slice(4)}`;
+      const nextCode = formatDeviceCode(e.target.value);
+      if (normalizeDeviceCode(nextCode) !== lastSubmittedCode) {
+        setLastSubmittedCode(null);
       }
-      setUserCode(value);
+      setUserCode(nextCode);
     },
-    [],
+    [lastSubmittedCode],
   );
+
+  useEffect(() => {
+    if (!isLoggedIn || status !== "idle" || normalizedUserCode.length !== 8) {
+      return;
+    }
+    submitApproval(normalizedUserCode);
+  }, [isLoggedIn, normalizedUserCode, status, submitApproval]);
 
   if (!isReady) {
     return (
@@ -114,7 +234,7 @@ function DeviceAuthContent() {
               type="text"
               placeholder="XXXX-XXXX"
               value={userCode}
-              onChange={formatCodeInput}
+              onChange={handleCodeChange}
               autoComplete="off"
               autoFocus
               className="text-center text-lg tracking-widest font-mono"
@@ -133,7 +253,7 @@ function DeviceAuthContent() {
               size="lg"
               fullWidth
               disabled={
-                !userCode.trim() ||
+                !normalizedUserCode ||
                 status === "signing" ||
                 status === "approving"
               }
@@ -154,11 +274,11 @@ function DeviceAuthContent() {
             </Button>
           </form>
 
-          {!isLoggedIn && (
-            <Text as="p" color="mutedForeground" intent="small">
-              You need to sign in to your Vana account to authorize this device.
-            </Text>
-          )}
+          <Text as="p" color="mutedForeground" intent="small">
+            {isLoggedIn
+              ? "Next you’ll confirm a free signature to approve this device."
+              : "You’ll sign in first, then confirm a free signature to approve this device."}
+          </Text>
         </div>
       </PagePanel>
     </PageShell>

--- a/connect/src/app/auth/device/use-device-auth.ts
+++ b/connect/src/app/auth/device/use-device-auth.ts
@@ -33,27 +33,26 @@ export function useDeviceAuth() {
     (w) => w.walletClientType === "privy" || w.walletClientType === "privy-v2",
   );
 
-  // Bootstrap embedded wallet for first-time users (same as connect flow)
   useEffect(() => {
     if (
       !isLoggedIn ||
       !walletsReady ||
       embeddedWallet ||
       walletBootstrapRef.current
-    )
+    ) {
       return;
+    }
+
     walletBootstrapRef.current = true;
     createWallet().catch(() => {
-      // Wallet may already exist — ignore
+      // Wallet may already exist — ignore.
     });
   }, [isLoggedIn, walletsReady, embeddedWallet, createWallet]);
 
   const approve = useCallback(
     async (userCode: string) => {
       if (!embeddedWallet) {
-        setError(
-          "No wallet found. Creating one — please try again in a moment.",
-        );
+        setError("Preparing your wallet. Please try again in a moment.");
         createWallet().catch(() => {});
         return;
       }
@@ -64,7 +63,10 @@ export function useDeviceAuth() {
       try {
         const { signature } = await signMessage(
           { message: MASTER_KEY_MESSAGE },
-          { address: embeddedWallet.address as `0x${string}` },
+          {
+            address: embeddedWallet.address as `0x${string}`,
+            uiOptions: { showWalletUIs: false },
+          },
         );
 
         setStatus("approving");
@@ -92,7 +94,7 @@ export function useDeviceAuth() {
         setStatus("error");
       }
     },
-    [embeddedWallet, signMessage],
+    [createWallet, embeddedWallet, signMessage],
   );
 
   return {

--- a/connect/src/app/server/use-server.test.ts
+++ b/connect/src/app/server/use-server.test.ts
@@ -1,0 +1,105 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  signMessage: vi.fn(),
+  walletsState: {
+    ready: true,
+    wallets: [
+      {
+        walletClientType: "privy",
+        address: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+      },
+    ],
+  },
+}));
+
+vi.mock("@privy-io/react-auth", () => ({
+  useSignMessage: () => ({ signMessage: mocks.signMessage }),
+  useWallets: () => mocks.walletsState,
+}));
+
+import { useServer } from "./use-server";
+
+describe("useServer", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mocks.signMessage.mockReset();
+    mocks.signMessage.mockResolvedValue({ signature: "sig-123" });
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it("polls the per-server route while provisioning and transitions to running", async () => {
+    const fetchMock = vi.mocked(fetch);
+    fetchMock
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ data: [] }), { status: 200 }),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            object: "server",
+            id: "srv_123",
+            user_id: "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
+            provider: "gcp",
+            provider_id: "gcp-123",
+            url: "https://ps.example.com",
+            mcp_endpoint: "https://ps.example.com/mcp",
+            state: "provisioning",
+            created_at: "2026-03-23T00:00:00.000Z",
+            updated_at: "2026-03-23T00:00:00.000Z",
+          }),
+          { status: 200 },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            object: "server",
+            id: "srv_123",
+            user_id: "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
+            provider: "gcp",
+            provider_id: "gcp-123",
+            url: "https://ps.example.com",
+            mcp_endpoint: "https://ps.example.com/mcp",
+            state: "running",
+            created_at: "2026-03-23T00:00:00.000Z",
+            updated_at: "2026-03-23T00:05:00.000Z",
+          }),
+          { status: 200 },
+        ),
+      );
+
+    const { result } = renderHook(() => useServer());
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith("/api/servers", {
+      headers: { Authorization: "Bearer sig-123" },
+    });
+
+    await act(async () => {
+      await result.current.provision();
+    });
+
+    expect(result.current.status).toBe("provisioning");
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5000);
+      await Promise.resolve();
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith("/api/servers/srv_123", {
+      headers: { Authorization: "Bearer sig-123" },
+    });
+    expect(result.current.status).toBe("running");
+  });
+});

--- a/connect/src/app/server/use-server.ts
+++ b/connect/src/app/server/use-server.ts
@@ -36,6 +36,7 @@ export function useServer() {
   const signatureRef = useRef<string | null>(null);
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const initialFetchDone = useRef(false);
+  const provisioningServerIdRef = useRef<string | null>(null);
 
   const embeddedWalletAddress = (() => {
     for (const wallet of wallets) {
@@ -74,22 +75,28 @@ export function useServer() {
   const fetchServer = useCallback(async () => {
     try {
       const sig = await getSignature();
-      const res = await fetch(`/api/servers`, {
+      const serverId = provisioningServerIdRef.current;
+      const endpoint = serverId ? `/api/servers/${serverId}` : "/api/servers";
+      const res = await fetch(endpoint, {
         headers: { Authorization: `Bearer ${sig}` },
       });
       if (!res.ok) {
         throw new Error(`Failed to fetch server: ${res.status}`);
       }
       const json = await res.json();
-      const data: ApiServer[] = json.data ?? [];
-      if (data.length > 0) {
-        const s = data[0];
+      const records: ApiServer[] =
+        json.data ?? (json.object === "server" ? [json] : []);
+      if (records.length > 0) {
+        const s = records[0];
         setServer(s);
         const state = s.state as ServerStatus;
+        provisioningServerIdRef.current =
+          state === "provisioning" ? s.id : null;
         setStatus(state === "provisioning" ? "provisioning" : state);
         setError(null);
         return s;
       }
+      provisioningServerIdRef.current = null;
       setServer(null);
       setStatus("idle");
       setError(null);
@@ -123,6 +130,7 @@ export function useServer() {
       }
       const s: ApiServer = await res.json();
       setServer(s);
+      provisioningServerIdRef.current = s.id;
       setStatus("provisioning");
       setError(null);
     } catch (err) {
@@ -147,6 +155,7 @@ export function useServer() {
         );
       }
       setServer(null);
+      provisioningServerIdRef.current = null;
       setStatus("idle");
       stopPolling();
     } catch (err) {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -189,6 +189,7 @@ export async function runCli(argv = process.argv): Promise<number> {
   const shouldNotify =
     !parsedOptions.json &&
     process.stdout.isTTY &&
+    installMethod !== "development" &&
     !process.env.VANA_NO_UPDATE_NOTIFIER &&
     !process.env.CI &&
     !process.env.AGENT &&
@@ -1606,11 +1607,7 @@ async function runStatus(options: GlobalOptions): Promise<number> {
   // Auth state
   const authCreds = loadCredentials();
   if (authCreds && !isExpired(authCreds)) {
-    emit.keyValue(
-      "Account",
-      formatAddress(authCreds.account.address),
-      "success",
-    );
+    emit.keyValue("Account", authCreds.account.address, "success");
     emit.keyValue(
       "Auth",
       `Authenticated (expires in ${formatExpiresIn(authCreds.account.expires_at)})`,
@@ -2992,7 +2989,7 @@ async function runServerSync(options: GlobalOptions): Promise<number> {
           if (sr.status === "stored") {
             emit.info(`  ${renderer.theme.success("\u2713")} ${sr.scope}`);
           } else {
-            const errDetail = sr.error ?? "failed";
+            const errDetail = sr.error ? humanizeIssue(sr.error) : "Failed";
             emit.info(
               `  ${renderer.theme.error("\u2717")} ${sr.scope} ${renderer.theme.muted(`\u2014 ${errDetail}`)}`,
             );
@@ -5624,12 +5621,17 @@ async function runLogin(
   if (authTarget === "self-hosted" && psUrl) {
     const renderer =
       !options.json && !options.quiet ? createLoginRenderer() : null;
+    const humanRenderer = createHumanRenderer();
     renderer?.title(psUrl);
 
     try {
       const result = await runSelfHostedLoginFlow(psUrl, (url: string) => {
-        renderer?.note("Open this URL in your browser:");
-        renderer?.note(url);
+        if (!options.json && !options.quiet) {
+          process.stderr.write(
+            `  ${humanRenderer.theme.muted("Open this URL in your browser:")}\n`,
+          );
+          process.stderr.write(`  ${humanRenderer.theme.muted(url)}\n`);
+        }
         renderer?.scopeActive("Waiting for authorization");
         // Try to open browser — use spawn with args array to prevent shell injection
         // (a malicious self-hosted PS could return a URL with shell metacharacters)
@@ -5768,13 +5770,24 @@ async function runLogin(
 
   // Interactive mode
   const renderer = createLoginRenderer();
+  const humanRenderer = createHumanRenderer();
+  const writeStaticLoginNotes = (lines: string[]) => {
+    if (options.json || options.quiet) {
+      return;
+    }
+    for (const line of lines) {
+      process.stderr.write(`  ${humanRenderer.theme.muted(line)}\n`);
+    }
+  };
   renderer.title("Vana");
 
   const creds = await runDeviceCodeFlow({
     onCode: (code, uri) => {
-      renderer.note("Open this URL in your browser:");
-      renderer.note(uri);
-      renderer.note(`Enter this code: ${code}`);
+      writeStaticLoginNotes([
+        "Open this URL in your browser:",
+        uri,
+        `Enter this code: ${code}`,
+      ]);
     },
     onWaiting: () => {
       renderer.scopeActive("Waiting for authorization");

--- a/src/personal-server/scope-resolver.ts
+++ b/src/personal-server/scope-resolver.ts
@@ -28,6 +28,17 @@ function ensureObject(data: unknown): Record<string, unknown> {
   return { value: data };
 }
 
+function normalizeScopeSegment(segment: string): string {
+  return segment
+    .replace(/([a-z0-9])([A-Z])/g, "$1_$2")
+    .replace(/[\s-]+/g, "_")
+    .toLowerCase();
+}
+
+function normalizeScope(scope: string): string {
+  return scope.split(".").filter(Boolean).map(normalizeScopeSegment).join(".");
+}
+
 /**
  * Resolve connector output keys to personal server scopes.
  *
@@ -56,7 +67,7 @@ export function resolveScopes(
   );
   if (dottedKeys.length > 0) {
     return dottedKeys.map((key) => ({
-      scope: key,
+      scope: normalizeScope(key),
       data: ensureObject(result[key]),
     }));
   }
@@ -69,7 +80,10 @@ export function resolveScopes(
       const dotIndex = scope.indexOf(".");
       const key = dotIndex >= 0 ? scope.slice(dotIndex + 1) : scope;
       if (key in result) {
-        mappings.push({ scope, data: ensureObject(result[key]) });
+        mappings.push({
+          scope: normalizeScope(scope),
+          data: ensureObject(result[key]),
+        });
       }
     }
     return mappings;
@@ -79,7 +93,7 @@ export function resolveScopes(
   return keys
     .filter((key) => !EXCLUDED_KEYS.has(key))
     .map((key) => ({
-      scope: `${source}.${key}`,
+      scope: normalizeScope(`${source}.${key}`),
       data: ensureObject(result[key]),
     }));
 }

--- a/test/cli/index.test.ts
+++ b/test/cli/index.test.ts
@@ -34,6 +34,7 @@ const mockSelect = vi.fn();
 const mockSearchSelect = vi.fn();
 const mockReaddir = vi.fn();
 const mockReadFile = vi.fn();
+const mockReadFileSync = vi.fn();
 const mockExistsSync = vi.fn();
 
 class ExitPromptError extends Error {
@@ -191,6 +192,7 @@ vi.mock("../../src/cli/auth.js", async () => {
 vi.mock("node:fs", () => ({
   default: {
     existsSync: mockExistsSync,
+    readFileSync: mockReadFileSync,
   },
 }));
 
@@ -241,6 +243,7 @@ describe("runCli", () => {
     mockPassword.mockReset();
     mockReaddir.mockReset();
     mockReadFile.mockReset();
+    mockReadFileSync.mockReset();
     mockExistsSync.mockReset();
 
     runtimeState = "installed";
@@ -269,6 +272,9 @@ describe("runCli", () => {
     mockPassword.mockResolvedValue("testpass");
     mockReaddir.mockRejectedValue(new Error("missing"));
     mockReadFile.mockRejectedValue(new Error("missing"));
+    mockReadFileSync.mockImplementation(() => {
+      throw new Error("missing");
+    });
     mockExistsSync.mockReturnValue(false);
     mockRunDeviceCodeFlow.mockReset();
     mockRunSelfHostedLoginFlow.mockReset();
@@ -921,6 +927,47 @@ describe("runCli", () => {
     );
     expect(stdout).not.toContain('HTTP 401: {"error"');
     expect(stdout).toContain("Next: `vana connect youtube`");
+  });
+
+  it("shows the full authenticated account address in human status output", async () => {
+    mockListAvailableSources.mockResolvedValue([
+      { id: "github", name: "GitHub", authMode: "interactive" },
+    ]);
+    mockReadCliState.mockResolvedValue({
+      version: 1,
+      sources: {
+        github: {
+          lastRunOutcome: "connected_and_ingested",
+          dataState: "ingested_personal_server",
+          lastCollectedAt: "2026-03-23T16:00:00.000Z",
+        },
+      },
+    });
+    mockReadFileSync.mockImplementation((filePath: string) => {
+      if (String(filePath).endsWith("/auth.json")) {
+        return JSON.stringify({
+          account: {
+            address: "0x2ab394e4be7c43ac360d226a31e1c90bc01aafa1",
+            session_token: "vana_account_session",
+            expires_at: "2026-04-22T19:25:14.420Z",
+          },
+          personal_server: {
+            url: "https://0x2ab394e4be7c43ac360d226a31e1c90bc01aafa1.myvana.app",
+            session_token: "vana_ps_session",
+            expires_at: "2026-04-22T19:25:14.420Z",
+          },
+        });
+      }
+      throw new Error("missing");
+    });
+
+    const { runCli } = await import("../../src/cli/index.js");
+    const exitCode = await runCli(["node", "vana", "status"]);
+
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain(
+      "Account:       0x2ab394e4be7c43ac360d226a31e1c90bc01aafa1",
+    );
   });
 
   it("guides first run from status when the runtime is already installed", async () => {
@@ -3913,5 +3960,52 @@ describe("runCli", () => {
     expect(stdout).toContain("schema not registered");
     expect(stdout).toContain("Next:");
     expect(stdout).toContain("vana server sync");
+  });
+
+  it("server sync humanizes transport and scope validation errors", async () => {
+    mockDetectPersonalServerTarget.mockResolvedValue({
+      state: "available",
+      url: "http://localhost:8080",
+    });
+    mockReadCliState.mockResolvedValue({
+      version: 1,
+      sources: {
+        youtube: {
+          connectorInstalled: true,
+          lastResultPath: "/tmp/results/youtube.json",
+          dataState: "collected_local",
+        },
+      },
+    });
+    mockIngestResult.mockResolvedValue([
+      {
+        type: "ingest-partial",
+        source: "youtube",
+        scopeResults: [
+          {
+            scope: "youtube.playlist_items",
+            status: "failed",
+            error:
+              'HTTP 400: {"error":"INVALID_SCOPE","message":"Scope must be {source}.{category}[.{subcategory}] with lowercase alphanumeric segments (may start with a letter or digit)"}',
+          },
+          {
+            scope: "youtube.watch_later",
+            status: "failed",
+            error:
+              'HTTP 401: {"error":{"code":401,"errorCode":"MISSING_AUTH","message":"Missing authentication"}}',
+          },
+        ],
+      },
+    ]);
+
+    const { runCli } = await import("../../src/cli/index.js");
+    const exitCode = await runCli(["node", "vana", "server", "sync"]);
+
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("youtube.playlist_items");
+    expect(stdout).toContain("Unsupported scope");
+    expect(stdout).toContain("Authentication required");
+    expect(stdout).not.toContain('HTTP 400: {"error":"INVALID_SCOPE"');
+    expect(stdout).not.toContain('HTTP 401: {"error":{"code":401');
   });
 });

--- a/test/personal-server/scope-resolver.test.ts
+++ b/test/personal-server/scope-resolver.test.ts
@@ -104,4 +104,24 @@ describe("resolveScopes", () => {
       { scope: "github.profile", data: { login: "alice" } },
     ]);
   });
+
+  it("normalizes camelCase dotted scopes to canonical snake_case", () => {
+    const result = {
+      "youtube.playlistItems": [{ id: "pl-1" }],
+      "youtube.watchLater": [{ id: "vid-1" }],
+    };
+
+    const mappings = resolveScopes("youtube", result, null);
+
+    expect(mappings).toEqual([
+      {
+        scope: "youtube.playlist_items",
+        data: { items: [{ id: "pl-1" }] },
+      },
+      {
+        scope: "youtube.watch_later",
+        data: { items: [{ id: "vid-1" }] },
+      },
+    ]);
+  });
 });


### PR DESCRIPTION
## Summary
- preserve typed device codes across login and auto-resume approval
- poll the per-server status route so provisioning can transition to `running`
- make login instructions copy-stable, expand the account address in `vana status`, and humanize invalid-scope/sync errors

## Verification
- `pnpm test test/personal-server/scope-resolver.test.ts test/cli/index.test.ts`
- `cd connect && pnpm test src/app/auth/device/page.test.tsx src/app/server/use-server.test.ts`
- `pnpm exec tsc --noEmit`
- `cd connect && pnpm exec tsc --noEmit`
