### PR TITLE
fix(ci): pass release tag to installer smoke test

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -223,7 +223,11 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - name: Smoke test latest published installer
-        run: sh ./scripts/test-install-github-release.sh
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          RELEASE_TAG=$(gh api repos/${GITHUB_REPOSITORY}/releases/latest --jq .tag_name)
+          sh ./scripts/test-install-github-release.sh --version "$RELEASE_TAG"
       - name: Verify latest release demo assets
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- fetch the latest GitHub release tag before running `test-install-github-release.sh`
- pass the required `--version` argument in `verify-release-install`
- keep the release smoke test in place instead of removing it

## Root cause
`verify-release-install` invoked `scripts/test-install-github-release.sh` without arguments, but that script requires `--version <release-tag>`. This caused the workflow to fail immediately with the usage message.

## Test plan
- [x] Run `sh ./scripts/test-install-github-release.sh --version v0.11.3`
- [x] Confirm install succeeds and the script reaches the expected `needs_input` smoke-test outcome for `vana connect github --json --no-input`
