### PR TITLE
feat(runtime): add requestData and requestManualAction APIs (design spec inside)

### DIFF
--- a/openspec/changes/redesign-connector-interaction-api/design.md
+++ b/openspec/changes/redesign-connector-interaction-api/design.md
@@ -1,0 +1,110 @@
+## Context
+
+The connector page API is shared across three runtimes:
+
+- **vana-connect** `src/runtime/playwright/in-process-run.ts` — powers the `vana` CLI and the `@opendatalabs/connect` SDK.
+- **data-connect** `playwright-runner/index.cjs` — the desktop Playwright sidecar.
+- **context-gateway** `src/lib/playwright-proxy.ts` — the server-side proxy that runs connectors against a remote worker behind a fixed CG UI.
+
+All three execute the same connector scripts from `vana-com/data-connectors` (the shared `*-playwright.js` files). Each runtime independently implements the page API, with no shared implementation layer. Divergence has crept in:
+
+- vana-connect's `--no-input` mode enforces "user unavailable" behavior at the runtime level with three different mechanisms (throw / return value / silent poll).
+- data-connect has no `--no-input` concept and `promptUser` polls forever if a user never acts.
+- context-gateway has no headed browser to surface to the end user at all and has already banned `promptUser` at runtime by throwing.
+
+## Goals
+
+- One connector contract that all three runtimes can implement honestly.
+- Make "user unavailable" a return value, not an exception, a silent hang, or a runtime-specific log.
+- Let connector authors write one branch for "needs user" regardless of which runtime will host their script.
+- Allow incremental rollout — old APIs keep working, connectors migrate one at a time.
+
+## Non-goals
+
+- Not unifying the three runtime implementations into a single shared module. They have legitimately different host constraints (CG has no surfaced browser; data-connect owns a real desktop browser; vana-connect is a headless per-invocation runner).
+- Not removing the old four methods. They stay until every connector has migrated, which may take months.
+- Not adding new capabilities (e.g. file upload, OAuth redirect) — this change is only about cleaning up what's already there.
+
+## Decisions
+
+### D1. Result-object contract, not thrown exceptions
+
+The new methods return `InteractionResult<T>`:
+
+```ts
+type InteractionResult<T = void> =
+  | { status: "success"; data?: T }
+  | { status: "skipped"; reason: SkipReason };
+```
+
+Rejected: throwing a `UserUnavailableError` that connectors catch. Reason: the existing `NeedsInputError` pattern in `requestInput` is exactly what we're running away from. Exceptions make the happy-path code read as if the user is always present, which is backwards for headless-first runtimes.
+
+### D2. `SkipReason` as an open vocabulary, initially `"no-input" | "no-headed-browser"`
+
+`"no-input"` means "this runtime supports user input in principle but the current invocation is running without one."
+
+`"no-headed-browser"` means "this runtime never has a headed browser for the end user" (CG).
+
+Rejected: collapsing both into `"no-input"`. Reason: connector authors may want to differentiate. A connector running in CG can reasonably decide "we'll never have a user here, fall back to cached-cookie collection," whereas the same connector in CLI `--no-input` mode might emit a `needs-input` event asking a human to re-run with input. Same runtime response, different long-term signal.
+
+Additional reasons can be added later (e.g. `"cancelled"`, `"timeout"`) without breaking existing consumers — connectors must treat `status: "skipped"` as "don't do the user-interaction thing" regardless of reason.
+
+### D3. `requestManualAction` subsumes `showBrowser + promptUser + goHeadless`
+
+The old flow was:
+
+```js
+const { headed } = await page.showBrowser(url);
+if (!headed) return;
+await page.promptUser("Complete login", () => loggedIn());
+await page.goHeadless();
+```
+
+Three calls, three failure modes, no uniform skip semantics.
+
+The new flow is:
+
+```js
+const r = await page.requestManualAction("Complete login", () => loggedIn(), {
+  url,
+  autoGoHeadless: true,
+});
+if (r.status === "skipped") return collectFromCachedCookies();
+```
+
+One call, one result. The runtime decides whether a headed browser is available; the connector decides what to do when it isn't.
+
+### D4. Per-runtime skip semantics
+
+- **vana-connect**: `requestManualAction` skips iff `request.noInput === true`. Reason: `"no-input"`.
+- **data-connect**: same. Reason: `"no-input"`. (Introduces no-input plumbing if absent.)
+- **context-gateway**: `requestManualAction` always skips. Reason: `"no-headed-browser"`. No headed browser is ever surfaced to the CG end user.
+
+This is honest: CG isn't pretending to have a user that isn't there.
+
+### D5. Rollout is runtime-first, connector-second
+
+A connector using `requestData` or `requestManualAction` will throw `TypeError` in a runtime that hasn't shipped them. The dependency order is strict:
+
+1. Runtime publishes the new methods.
+2. Runtime ships (npm publish / CG deploy / desktop release).
+3. Connectors targeting that runtime can start using the new methods.
+
+Connectors in `data-connectors/` target all three runtimes. The pragmatic rule is: no connector migration merges until all three runtimes have shipped the new APIs.
+
+Rejected: feature-detecting the new APIs in each connector (`if (page.requestData) ...`). Reason: doubles the code in every connector and defeats the point of the redesign.
+
+### D6. Old APIs stay deprecated but functional indefinitely
+
+Marked `@deprecated` in `types/connector.d.ts`. Not removed. The deprecation annotation is the IDE hint; the runtime keeps implementing them. Remove only after every connector has migrated, which is a separate future decision.
+
+## Risks
+
+- **Runtime drift**: each runtime owns its own implementation. If one of them drifts from the contract (e.g. data-connect forgets to wire `noInput` before adding `requestManualAction`), a migrated connector could hang. Mitigation: add the integration tests in tasks 1.5, 1.6, and 3.3 before migrating any connector.
+- **CG honest-skip behavior changes connector outcomes**: today, calling `promptUser` in CG throws and the connector errors out. After the change, `requestManualAction` in CG returns skipped and the connector chooses what to do. This changes whether a session appears "failed" or "collected partial." Audit each migrated connector for this.
+- **PR #46 staleness**: #46 was drafted before this plan. It will need a rebase and a per-connector review to make sure it's handling `skipped` results the way the plan intends.
+
+## Open questions
+
+- Should `requestData`'s `skipped` branch ever emit a `needs-input` event? (Currently #102 does not — it's a pure return. Event emission happens in `requestInput`'s `--no-input` throw path. Preserving symmetry says no, but some product surfaces may still want the event.)
+- When should `legacy-auth` events actually be retired from vana-connect? Depends on whether any consumer outside this repo subscribes to them.

--- a/openspec/changes/redesign-connector-interaction-api/proposal.md
+++ b/openspec/changes/redesign-connector-interaction-api/proposal.md
@@ -1,0 +1,39 @@
+## Why
+
+Connectors need to interact with the user in three situations: collect credentials, prompt for a manual browser action, or bail out cleanly when no user is available (`--no-input` mode, scheduled refresh, Context Gateway). Today there are three APIs for these situations — `requestInput`, `promptUser`, `showBrowser` — and each has a different `--no-input` failure mode:
+
+- `requestInput` throws `NeedsInputError`.
+- `showBrowser` returns `{ headed: false }`.
+- `promptUser` silently polls forever (CLI / desktop) or throws (CG).
+
+Connector authors have to remember three guard patterns for the same conceptual situation, and they routinely get it wrong. The already-fixed `legacyAuthTriggered` result-discard bug was a concrete instance: a connector collected valid data from cached cookies, returned it, and the runtime threw the result away because an internal flag said "legacy auth was triggered."
+
+The connector API is shared by three runtimes — vana-connect's in-process runner, data-connect's playwright-runner sidecar, and Context Gateway's playwright-proxy. Each runtime has diverged subtly around user interaction (CG bans `promptUser` entirely; data-connect's `promptUser` hangs forever in no-input mode). Unifying the API under a result-object contract lets a single connector run cleanly on all three runtimes and makes "user unavailable" a first-class return value rather than a runtime-specific exception, log, or silent hang.
+
+## What Changes
+
+- Add `requestData(payload)` and `requestManualAction(message, checkFn, options?)` methods to the connector page API, each returning `InteractionResult` (`{ status: "success", data? }` or `{ status: "skipped", reason }`).
+- Keep `requestInput`, `promptUser`, `showBrowser`, `goHeadless` unchanged for backward compatibility. Mark them `@deprecated` in the shared type contract.
+- Update vana-connect's in-process runtime to implement the new methods and to recognize a `{ status: "skipped", reason: "no-input" }` return value as a non-result (do not persist as collected data).
+- Update data-connect's `playwright-runner/index.cjs` to implement the new methods with the full headed-browser semantics.
+- Update context-gateway's `playwright-proxy.ts` to implement the new methods with degenerate semantics: `requestData` proxies to the existing `getInput` channel; `requestManualAction` returns `{ status: "skipped", reason: "no-headed-browser" }` immediately.
+- Migrate each connector in `vana-com/data-connectors` to the new APIs only after every runtime it targets has shipped the new methods. Rollout per connector is conditional, not atomic.
+- Document the skipped-reason vocabulary (`"no-input"`, `"no-headed-browser"`) and the connector-author pattern for handling skipped returns.
+
+## Capabilities
+
+### New Capabilities
+
+- `connector-interaction-api`: Defines the `requestData` / `requestManualAction` contract, the `InteractionResult` shape, the reason vocabulary, and runtime obligations for each of the three host runtimes.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- **Affected repos**: `vana-com/vana-connect` (this repo — runtime additions, already drafted as PR #102), `vana-com/data-connect` (desktop playwright-runner), `vana-com/context-gateway` (playwright-proxy), `vana-com/data-connectors` (type contract + connector migrations — drafted as PR #46).
+- **Breaking changes**: None. Old APIs remain functional; migration is per-connector and can lag the runtime rollout.
+- **Rollout dependency**: A connector using the new APIs will throw `TypeError` in a runtime that hasn't shipped them. Every runtime a connector targets must ship the new methods before that connector is migrated.
+- **Publishing**: vana-connect runtime changes require an npm publish of `@opendatalabs/connect`. Desktop changes require a data-connect release. CG changes deploy via its own pipeline.
+- **Retirement**: once migrations are broadly complete, `legacyAuthTriggered` and the `legacy-auth` event can be removed from vana-connect's runtime.

--- a/openspec/changes/redesign-connector-interaction-api/specs/connector-interaction-api/spec.md
+++ b/openspec/changes/redesign-connector-interaction-api/specs/connector-interaction-api/spec.md
@@ -1,0 +1,76 @@
+## ADDED Requirements
+
+### Requirement: Connector page API exposes `requestData`
+
+The connector page API SHALL provide a `requestData(payload)` method returning `InteractionResult<Record<string, string>>`.
+
+#### Scenario: Success in interactive mode
+
+- **WHEN** a connector calls `requestData({ schema, message })` in a runtime with an available user input channel
+- **THEN** the runtime SHALL collect the input and return `{ status: "success", data }` where `data` matches the requested schema
+
+#### Scenario: Skipped in no-input mode
+
+- **WHEN** a connector calls `requestData(...)` in a runtime where no user input channel is available for this invocation
+- **THEN** the runtime SHALL return `{ status: "skipped", reason: "no-input" }` or `{ status: "skipped", reason: "no-headed-browser" }` as appropriate, without throwing
+
+#### Scenario: Skipped return is not persisted as collected data
+
+- **WHEN** a connector returns `{ status: "skipped", reason: "no-input" }` (or any other skipped result) as its top-level return value
+- **THEN** the runtime SHALL NOT persist that object as the connector's collected data
+
+### Requirement: Connector page API exposes `requestManualAction`
+
+The connector page API SHALL provide a `requestManualAction(message, checkFn, options?)` method returning `InteractionResult<void>`.
+
+#### Scenario: Success after manual action
+
+- **WHEN** a connector calls `requestManualAction(message, checkFn, options)` in a runtime with a headed browser available and the user completes the action
+- **THEN** the runtime SHALL return `{ status: "success" }` once `checkFn()` resolves truthy
+
+#### Scenario: Skipped in no-input mode
+
+- **WHEN** a connector calls `requestManualAction(...)` in a runtime operating in `--no-input` mode (or equivalent) with a user-capable channel
+- **THEN** the runtime SHALL return `{ status: "skipped", reason: "no-input" }` immediately without polling
+
+#### Scenario: Skipped when no headed browser exists
+
+- **WHEN** a connector calls `requestManualAction(...)` in a runtime that never surfaces a headed browser to the end user (e.g. context-gateway)
+- **THEN** the runtime SHALL return `{ status: "skipped", reason: "no-headed-browser" }` immediately
+
+#### Scenario: autoGoHeadless after success
+
+- **WHEN** `requestManualAction` resolves successfully and `options.autoGoHeadless` is not `false`
+- **THEN** the runtime SHALL transition the browser context back to a headless profile and navigate to `about:blank`
+
+### Requirement: Skip reason vocabulary is documented and open
+
+The contract SHALL define `SkipReason` as an extensible string union initially including `"no-input"` and `"no-headed-browser"`.
+
+#### Scenario: Connector treats unknown reasons uniformly
+
+- **WHEN** a connector receives `{ status: "skipped", reason }` with any `reason` value
+- **THEN** the connector SHALL treat the result as "the interaction did not complete" and SHALL NOT branch on specific reason values unless explicitly intended
+
+### Requirement: Old interaction APIs remain functional and are marked deprecated
+
+The contract SHALL keep `requestInput`, `promptUser`, `showBrowser`, and `goHeadless` functional.
+
+#### Scenario: Deprecated JSDoc annotations
+
+- **WHEN** a developer imports `types/connector.d.ts`
+- **THEN** the four old methods SHALL carry `@deprecated` JSDoc with a pointer to `requestData` / `requestManualAction`
+
+#### Scenario: Old methods continue to work unchanged
+
+- **WHEN** an un-migrated connector calls `requestInput`, `promptUser`, `showBrowser`, or `goHeadless`
+- **THEN** the runtime SHALL honor the historical semantics of that method in that runtime (no behavior change)
+
+### Requirement: All three runtimes implement the new methods before any connector migrates
+
+Before any connector in `vana-com/data-connectors` is migrated to the new APIs, every runtime that runs that connector SHALL have shipped an implementation of `requestData` and `requestManualAction`.
+
+#### Scenario: Runtime-first rollout
+
+- **WHEN** a new method is added to the connector contract
+- **THEN** `vana-connect`, `data-connect` (desktop), and `context-gateway` SHALL all publish/deploy implementations of that method before any connector script calls it

--- a/openspec/changes/redesign-connector-interaction-api/tasks.md
+++ b/openspec/changes/redesign-connector-interaction-api/tasks.md
@@ -1,0 +1,52 @@
+## 1. Contract and vana-connect runtime (this repo)
+
+- [x] 1.1 Add `requestData(payload)` to `src/runtime/playwright/in-process-run.ts` returning `InteractionResult<Record<string,string>>`.
+- [x] 1.2 Add `requestManualAction(message, checkFn, options?)` returning `InteractionResult<void>` and integrate with existing `ensureHeadedBrowser` / `reopenContext` helpers.
+- [x] 1.3 Teach the post-connector result path to treat `{ status: "skipped", reason: "no-input" }` as a non-result.
+- [x] 1.4 Add JSDoc on the old four methods (`requestInput`, `promptUser`, `showBrowser`, `goHeadless`) marking them `@deprecated` with a pointer to the new APIs.
+- [ ] 1.5 Add an integration test covering `requestData` in `--no-input` mode (skipped) and in interactive mode (success).
+- [ ] 1.6 Add an integration test covering `requestManualAction` in `--no-input` mode (skipped) and with `checkFn` eventually passing (success).
+- [ ] 1.7 Cut a pre-release of `@opendatalabs/connect` that exposes the new APIs, publish to npm.
+
+## 2. data-connectors type contract
+
+- [ ] 2.1 Add `InteractionResult<T>`, `ManualActionOptions`, and the two new method signatures to `types/connector.d.ts`.
+- [ ] 2.2 Add `@deprecated` JSDoc annotations on `requestInput`, `promptUser`, `showBrowser`, `goHeadless` in `types/connector.d.ts`.
+- [ ] 2.3 Document `"no-input"` and `"no-headed-browser"` as the initial `reason` vocabulary in `skills/vana-connect/reference/PATTERNS.md`.
+- [ ] 2.4 Update the connector template at `skills/vana-connect/templates/connector-script.js` to use the new APIs.
+- [ ] 2.5 Rebase or recreate PR #46 on top of the new contract.
+
+## 3. data-connect runtime
+
+- [ ] 3.1 Add `requestData` and `requestManualAction` to `playwright-runner/index.cjs` with full headed-browser semantics matching vana-connect's behavior.
+- [ ] 3.2 Ensure `requestManualAction` honors `request.noInput` (introduce the concept to this runtime if absent) and returns `{ status: "skipped", reason: "no-input" }` rather than polling forever.
+- [ ] 3.3 Add a manual-run regression checklist covering one headed and one no-input connector invocation.
+- [ ] 3.4 Cut a data-connect release containing the runtime changes.
+
+## 4. context-gateway runtime
+
+- [ ] 4.1 Add `requestData(payload)` to `src/lib/playwright-proxy.ts` that proxies the existing `getInput` channel and wraps the response in `{ status: "success", data }`.
+- [ ] 4.2 Add `requestManualAction(...)` that immediately returns `{ status: "skipped", reason: "no-headed-browser" }` and logs the skipped message.
+- [ ] 4.3 Update CG docs that currently document "`promptUser` is unsupported" to instead describe the new skip-based contract.
+- [ ] 4.4 Keep the existing `promptUser` throw in place until migrations complete, then retire it.
+- [ ] 4.5 Deploy CG with the new runtime methods.
+
+## 5. Connector migrations (data-connectors)
+
+- [ ] 5.1 Migrate `oura/oura-playwright.js`.
+- [ ] 5.2 Migrate `github/github-playwright.js`.
+- [ ] 5.3 Migrate `spotify/spotify-playwright.js`.
+- [ ] 5.4 Migrate `linkedin/linkedin-playwright.js`.
+- [ ] 5.5 Migrate `meta/instagram-playwright.js`.
+- [ ] 5.6 Migrate `uber/uber-playwright.js`.
+- [ ] 5.7 Migrate `shopify/shop-playwright.js`.
+- [ ] 5.8 Migrate `openai/chatgpt-playwright.js`.
+- [ ] 5.9 Migrate `google/youtube-playwright.js`.
+- [ ] 5.10 Migrate `heb/heb-playwright.js`.
+- [ ] 5.11 For each migrated connector, verify it runs successfully in every runtime it targets (CLI, desktop, CG) before merging its migration.
+
+## 6. Retirement (post-migration)
+
+- [ ] 6.1 Remove `runState.legacyAuthTriggered` and the `legacy-auth` event from vana-connect's runtime.
+- [ ] 6.2 Replace CG's `promptUser` throw with the same skip-based return as `requestManualAction`.
+- [ ] 6.3 Remove the deprecation JSDoc from old APIs if and when they are physically removed from the contract. (Likely much later; do not rush.)

--- a/src/runtime/playwright/in-process-run.ts
+++ b/src/runtime/playwright/in-process-run.ts
@@ -356,7 +356,13 @@ export function startInProcessConnectorRun({
       const connectorFunction = buildConnectorFunction(connectorCode);
       const result = await connectorFunction.call(null, pageApi);
 
-      if (!runState.hasResult && result != null) {
+      const isSkipResult =
+        result &&
+        typeof result === "object" &&
+        "status" in result &&
+        (result as { status: unknown }).status === "skipped";
+
+      if (!runState.hasResult && result != null && !isSkipResult) {
         const exportData =
           result &&
           typeof result === "object" &&
@@ -497,6 +503,51 @@ function createPageApi({
     );
   }
 
+  async function collectInput(
+    payload: PendingInputRequest,
+  ): Promise<Record<string, string>> {
+    const fields = Object.keys(payload.schema?.properties ?? {});
+    const message = payload.message ?? "Additional input is required.";
+    const inputRequest: RuntimeInputRequest = {
+      message,
+      schema: payload.schema,
+      fields,
+      responseInputPath,
+    };
+
+    if (!request.onNeedInput) {
+      await writePendingInput({
+        pendingInputPath,
+        responseInputPath,
+        message,
+        schema: inputRequest.schema,
+      });
+      pushEvent({
+        type: "needs-input",
+        source: request.source,
+        message,
+        fields: inputRequest.fields,
+        schema: inputRequest.schema,
+        pendingInputPath,
+        responseInputPath,
+        logPath,
+      });
+      const response = await pollForInputResponse(responseInputPath, 1_800_000);
+      await fsp.rm(pendingInputPath, { force: true });
+      return response;
+    }
+
+    const input = await request.onNeedInput(inputRequest);
+    await ensureParentDir(responseInputPath);
+    await fsp.writeFile(
+      responseInputPath,
+      `${JSON.stringify(input)}\n`,
+      "utf8",
+    );
+    await fsp.rm(pendingInputPath, { force: true });
+    return input;
+  }
+
   return {
     goto: async (
       url: string,
@@ -530,73 +581,27 @@ function createPageApi({
     },
 
     requestInput: async (payload: PendingInputRequest) => {
-      const fields = Object.keys(payload.schema?.properties ?? {});
-      const inputRequest: RuntimeInputRequest = {
-        message: payload.message ?? "Additional input is required.",
-        schema: payload.schema,
-        fields,
-        responseInputPath,
-      };
-
       if (request.noInput) {
-        // --no-input mode: fail immediately
+        const fields = Object.keys(payload.schema?.properties ?? {});
         await writePendingInput({
           pendingInputPath,
           responseInputPath,
-          message: inputRequest.message ?? "Additional input is required.",
-          schema: inputRequest.schema,
+          message: payload.message ?? "Additional input is required.",
+          schema: payload.schema,
         });
         pushEvent({
           type: "needs-input",
           source: request.source,
-          message: inputRequest.message ?? "Additional input is required.",
-          fields: inputRequest.fields,
-          schema: inputRequest.schema,
+          message: payload.message ?? "Additional input is required.",
+          fields,
+          schema: payload.schema,
           pendingInputPath,
           responseInputPath,
           logPath,
         });
         throw new NeedsInputError();
       }
-
-      if (!request.onNeedInput) {
-        // IPC mode: write question file, emit event, poll for answer.
-        // An external agent reads the pending file, collects input from
-        // the user, and writes the response file.
-        await writePendingInput({
-          pendingInputPath,
-          responseInputPath,
-          message: inputRequest.message ?? "Additional input is required.",
-          schema: inputRequest.schema,
-        });
-        pushEvent({
-          type: "needs-input",
-          source: request.source,
-          message: inputRequest.message ?? "Additional input is required.",
-          fields: inputRequest.fields,
-          schema: inputRequest.schema,
-          pendingInputPath,
-          responseInputPath,
-          logPath,
-        });
-
-        const response = await pollForInputResponse(
-          responseInputPath,
-          1_800_000,
-        ); // 30 min timeout
-        await fsp.rm(pendingInputPath, { force: true });
-        return response;
-      }
-
-      const input = await request.onNeedInput(inputRequest);
-      await ensureParentDir(responseInputPath);
-      await fsp.writeFile(
-        responseInputPath,
-        `${JSON.stringify(input)}\n`,
-        "utf8",
-      );
-      await fsp.rm(pendingInputPath, { force: true });
-      return input;
+      return collectInput(payload);
     },
 
     requestData: async (payload: PendingInputRequest) => {
@@ -604,49 +609,8 @@ function createPageApi({
         writeLog("[page] requestData skipped (no-input mode)");
         return { status: "skipped" as const, reason: "no-input" as const };
       }
-
-      const fields = Object.keys(payload.schema?.properties ?? {});
-      const inputRequest: RuntimeInputRequest = {
-        message: payload.message ?? "Additional input is required.",
-        schema: payload.schema,
-        fields,
-        responseInputPath,
-      };
-
-      if (!request.onNeedInput) {
-        await writePendingInput({
-          pendingInputPath,
-          responseInputPath,
-          message: inputRequest.message ?? "Additional input is required.",
-          schema: inputRequest.schema,
-        });
-        pushEvent({
-          type: "needs-input",
-          source: request.source,
-          message: inputRequest.message ?? "Additional input is required.",
-          fields: inputRequest.fields,
-          schema: inputRequest.schema,
-          pendingInputPath,
-          responseInputPath,
-          logPath,
-        });
-        const response = await pollForInputResponse(
-          responseInputPath,
-          1_800_000,
-        );
-        await fsp.rm(pendingInputPath, { force: true });
-        return { status: "success" as const, data: response };
-      }
-
-      const input = await request.onNeedInput(inputRequest);
-      await ensureParentDir(responseInputPath);
-      await fsp.writeFile(
-        responseInputPath,
-        `${JSON.stringify(input)}\n`,
-        "utf8",
-      );
-      await fsp.rm(pendingInputPath, { force: true });
-      return { status: "success" as const, data: input };
+      const data = await collectInput(payload);
+      return { status: "success" as const, data };
     },
 
     requestManualAction: async (
@@ -683,7 +647,7 @@ function createPageApi({
         url: url ?? runState.page?.url(),
       });
 
-      writeLog(`[page] requestManualAction: ${message}`);
+      writeLog(`[prompt] ${message}`);
       while (true) {
         await new Promise((resolve) => setTimeout(resolve, interval));
         if (
@@ -698,7 +662,7 @@ function createPageApi({
         try {
           const result = await checkFn();
           if (result) {
-            writeLog("[page] Manual action completed");
+            writeLog("[prompt] User action completed");
             break;
           }
         } catch {

--- a/src/runtime/playwright/in-process-run.ts
+++ b/src/runtime/playwright/in-process-run.ts
@@ -599,6 +599,134 @@ function createPageApi({
       return input;
     },
 
+    requestData: async (payload: PendingInputRequest) => {
+      if (request.noInput) {
+        writeLog("[page] requestData skipped (no-input mode)");
+        return { status: "skipped" as const, reason: "no-input" as const };
+      }
+
+      const fields = Object.keys(payload.schema?.properties ?? {});
+      const inputRequest: RuntimeInputRequest = {
+        message: payload.message ?? "Additional input is required.",
+        schema: payload.schema,
+        fields,
+        responseInputPath,
+      };
+
+      if (!request.onNeedInput) {
+        await writePendingInput({
+          pendingInputPath,
+          responseInputPath,
+          message: inputRequest.message ?? "Additional input is required.",
+          schema: inputRequest.schema,
+        });
+        pushEvent({
+          type: "needs-input",
+          source: request.source,
+          message: inputRequest.message ?? "Additional input is required.",
+          fields: inputRequest.fields,
+          schema: inputRequest.schema,
+          pendingInputPath,
+          responseInputPath,
+          logPath,
+        });
+        const response = await pollForInputResponse(
+          responseInputPath,
+          1_800_000,
+        );
+        await fsp.rm(pendingInputPath, { force: true });
+        return { status: "success" as const, data: response };
+      }
+
+      const input = await request.onNeedInput(inputRequest);
+      await ensureParentDir(responseInputPath);
+      await fsp.writeFile(
+        responseInputPath,
+        `${JSON.stringify(input)}\n`,
+        "utf8",
+      );
+      await fsp.rm(pendingInputPath, { force: true });
+      return { status: "success" as const, data: input };
+    },
+
+    requestManualAction: async (
+      message: string,
+      checkFn: () => Promise<unknown>,
+      options?: {
+        url?: string;
+        interval?: number;
+        autoGoHeadless?: boolean;
+      },
+    ) => {
+      const { url, interval = 2000, autoGoHeadless = true } = options ?? {};
+
+      if (request.noInput) {
+        writeLog("[page] requestManualAction skipped (no-input mode)");
+        return { status: "skipped" as const, reason: "no-input" as const };
+      }
+
+      await ensureHeadedBrowser(
+        runState,
+        request.source,
+        logPath,
+        pushEvent,
+        writeLog,
+        networkCaptures,
+        capturedResponses,
+        url,
+      );
+      pushEvent({
+        type: "headed-required",
+        source: request.source,
+        message,
+        logPath,
+        url: url ?? runState.page?.url(),
+      });
+
+      writeLog(`[page] requestManualAction: ${message}`);
+      while (true) {
+        await new Promise((resolve) => setTimeout(resolve, interval));
+        if (
+          request.signal?.aborted ||
+          runState.browserClosed ||
+          !runState.page
+        ) {
+          throw new Error(
+            "Browser session ended before manual interaction completed.",
+          );
+        }
+        try {
+          const result = await checkFn();
+          if (result) {
+            writeLog("[page] Manual action completed");
+            break;
+          }
+        } catch {
+          // Keep waiting until the connector's condition passes.
+        }
+      }
+
+      if (autoGoHeadless) {
+        await reopenContext(
+          runState,
+          networkCaptures,
+          capturedResponses,
+          true,
+          writeLog,
+          pushEvent,
+          request.source,
+          logPath,
+        );
+        if (runState.page) {
+          await runState.page.goto("about:blank", {
+            waitUntil: "domcontentloaded",
+          });
+        }
+      }
+
+      return { status: "success" as const };
+    },
+
     sleep: (ms: number) => new Promise((resolve) => setTimeout(resolve, ms)),
 
     setData: async (key: string, value: unknown) => {

--- a/src/runtime/playwright/in-process-run.ts
+++ b/src/runtime/playwright/in-process-run.ts
@@ -360,7 +360,9 @@ export function startInProcessConnectorRun({
         result &&
         typeof result === "object" &&
         "status" in result &&
-        (result as { status: unknown }).status === "skipped";
+        (result as { status: unknown }).status === "skipped" &&
+        "reason" in result &&
+        (result as { reason: unknown }).reason === "no-input";
 
       if (!runState.hasResult && result != null && !isSkipResult) {
         const exportData =


### PR DESCRIPTION
## Summary

Adds `requestData` and `requestManualAction` to the connector page API, each returning an `InteractionResult` (`{ status: "success", data? } | { status: "skipped", reason }`). Old APIs (`requestInput`, `promptUser`, `showBrowser`, `goHeadless`) remain unchanged for backward compatibility — migration is per-connector.

## Status update (2026-04-20)

- The two runtime bug fixes originally bundled into this PR were extracted and merged as #111 (vana-connect) and vana-com/data-connect#107, so they could ship immediately.
- This PR is now scoped strictly to the API additions.
- A full OpenSpec change proposal for the four-repo rollout is now included: `openspec/changes/redesign-connector-interaction-api/` (proposal, tasks, design, spec).
- Rebased onto current `main`.

## What the OpenSpec change covers

`openspec/changes/redesign-connector-interaction-api/` validates with `openspec validate ... --strict`. It captures:

- **Why** the three-API status quo (throw / return value / silent poll) is a design problem and how `InteractionResult` fixes it.
- **Per-runtime skip semantics** — `vana-connect` and `data-connect` skip on `--no-input` with `reason: "no-input"`; `context-gateway` always skips with `reason: "no-headed-browser"` because it never surfaces a headed browser.
- **Strict runtime-first rollout order** — no connector migration can merge until all three runtimes (vana-connect, data-connect, context-gateway) have shipped the new methods, otherwise migrated connectors throw `TypeError` at runtime.
- **Task list** covering all four repos: this repo, `vana-com/data-connect`, `vana-com/context-gateway`, `vana-com/data-connectors` (plus PR #46's connector migrations).
- **Retirement plan** for `legacyAuthTriggered` and CG's `promptUser`-throw after migrations complete.

## Context (original investigation)

Investigated a bug where `vana status` showed "needs login" for ChatGPT when the session was valid. Root cause was a connector bug (checking login on `about:blank`), fixed in vana-com/data-connectors#44. But the investigation revealed deeper design issues:

- Three interaction APIs with inconsistent `--no-input` semantics (throw vs return value vs silent no-op)
- The runtime emitting `legacy-auth` events that the CLI treated as terminal outcomes mid-run
- Prior art research (OAuth Device Flow, MSAL, Terraform, Temporal) consistently shows "user needed" should be a return value, not an exception

The new APIs follow a consistent contract: always return a result object, never throw for expected states, let the connector decide what to do.

## Test plan

- [x] All existing tests pass
- [ ] Integration test with a connector using `requestData` in `--no-input` mode (tracked as task 1.5 in the OpenSpec plan)
- [ ] Integration test with a connector using `requestManualAction` in `--no-input` mode (tracked as task 1.6)
- [ ] Follow-up: migrate connectors in vana-com/data-connectors to new APIs — blocked until all three runtimes have shipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)