### PR TITLE
fix(registry): point BASE_URL at connectors/ subdirectory

### DIFF
--- a/src/connectors/registry.ts
+++ b/src/connectors/registry.ts
@@ -6,8 +6,11 @@ import { getConnectorCacheDir } from "../core/paths.js";
 
 const REGISTRY_URL =
   "https://raw.githubusercontent.com/vana-com/data-connectors/main/registry.json";
+// Connector script files live under `connectors/` in the data-connectors
+// repo. The registry.json `baseUrl` field also points here; we mirror it
+// as a constant so offline/local paths resolve correctly too.
 const BASE_URL =
-  "https://raw.githubusercontent.com/vana-com/data-connectors/main";
+  "https://raw.githubusercontent.com/vana-com/data-connectors/main/connectors";
 
 export interface ConnectorRegistryEntry {
   id?: string;


### PR DESCRIPTION
## Summary
The v0.13.0 post-release smoke test (`verify-release-install`) failed with:
```
{"type":"outcome","status":"connector_unavailable","source":"github","reason":"Failed to download ...github-playwright.js: 404"}
```

**Root cause:** `BASE_URL` in `src/connectors/registry.ts` points at `data-connectors/main/` but the actual connector files live under `data-connectors/main/connectors/`. data-connectors#58 moved everything into a `connectors/` subdirectory and updated `registry.json`'s `baseUrl` field accordingly — but vana-connect has its own hardcoded constant that wasn't updated.

Verified:
- `curl https://raw.githubusercontent.com/vana-com/data-connectors/main/github/github-playwright.js` → 404
- `curl https://raw.githubusercontent.com/vana-com/data-connectors/main/connectors/github/github-playwright.js` → 200

## Test plan
- [x] `pnpm test` (259/259 passing)
- [x] `pnpm lint` clean
- [x] `pnpm format:check` clean
- [ ] Post-release verify smoke test passes after merge