### PR TITLE
fix(runtime): goHeadless about:blank + drop legacyAuth result-discard

### DIFF
--- a/src/runtime/playwright/in-process-run.ts
+++ b/src/runtime/playwright/in-process-run.ts
@@ -355,9 +355,6 @@ export function startInProcessConnectorRun({
       }
       const connectorFunction = buildConnectorFunction(connectorCode);
       const result = await connectorFunction.call(null, pageApi);
-      if (runState.legacyAuthTriggered) {
-        return;
-      }
 
       if (!runState.hasResult && result != null) {
         const exportData =
@@ -808,7 +805,7 @@ function createPageApi({
         logPath,
       );
       if (runState.page) {
-        await runState.page.goto("https://chatgpt.com/", {
+        await runState.page.goto("about:blank", {
           waitUntil: "domcontentloaded",
         });
       }


### PR DESCRIPTION
## Summary

Two independent runtime bug fixes, extracted from #102 so they can ship without waiting on the interaction-API redesign.

- **`goHeadless()` navigates to `https://chatgpt.com/`** after reopening the headless context (line 811 on `main`). Every connector using `goHeadless()` — oura, spotify, github, etc. — incurs an unnecessary network roundtrip to `chatgpt.com` and leaks ChatGPT-specific state into unrelated sessions. Change to `about:blank`.
- **`legacyAuthTriggered` silently discards valid results.** When `showBrowser()` or `promptUser()` is called in `--no-input` mode and the connector still manages to collect data (e.g. from cached cookies), the post-run gate at line 358 drops the result. Remove the gate. The flag stays — it still deduplicates `legacy-auth` events in `showBrowser`/`promptUser`.

## Why split from #102

#102 bundles these fixes with the `requestData` / `requestManualAction` API redesign. The redesign is the right direction but needs coordinated rollout across four repos (this one, `data-connect`, `context-gateway`, `data-connectors`). These two fixes help every connector user today and don't depend on any of that.

See also: `data-connect` companion PR for the same `goHeadless → about:blank` fix in `playwright-runner/index.cjs`.

## Test plan

- [ ] CI green
- [ ] `npx vana collect oura --no-input --json` — verify no stray `chatgpt.com` request in the headless phase
- [ ] `npx vana collect chatgpt --no-input --json` — verify a valid session still returns a clean result (the previously-discarded path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)