### PR TITLE
fix(server): make Personal Server deprovision idempotent

### DIFF
--- a/connect/src/app/api/servers/[id]/route.ts
+++ b/connect/src/app/api/servers/[id]/route.ts
@@ -94,12 +94,14 @@ export async function DELETE(
     return apiError("not_found_error", "Server not found", 404);
   }
 
-  if (server.provider_id) {
+  // Always run cleanup if we have any provider-side state recorded —
+  // VM, tunnel, or DNS — so retry from `deprovision_failed` works.
+  if (server.provider_id || server.tunnel_id || server.dns_record_id) {
     try {
       const provider = getServerProvider();
-      await provider.deprovision(server.provider_id, {
-        tunnelId: server.tunnel_id ?? undefined,
-        dnsRecordId: server.dns_record_id ?? undefined,
+      await provider.deprovision(server.provider_id ?? "", {
+        tunnelId: server.tunnel_id,
+        dnsRecordId: server.dns_record_id,
       });
     } catch (err) {
       console.error("Deprovision error:", err);

--- a/connect/src/app/server/page.tsx
+++ b/connect/src/app/server/page.tsx
@@ -341,6 +341,8 @@ function getStatusInfo(status: ServerStatus): {
       return { tone: "accent", label: "Provisioning..." };
     case "stopped":
       return { tone: "warning", label: "Stopped" };
+    case "deprovision_failed":
+      return { tone: "destructive", label: "Cleanup failed" };
     case "error":
       return { tone: "destructive", label: "Error" };
     default:

--- a/connect/src/app/server/use-server.ts
+++ b/connect/src/app/server/use-server.ts
@@ -25,6 +25,7 @@ export type ServerStatus =
   | "provisioning"
   | "running"
   | "stopped"
+  | "deprovision_failed"
   | "error";
 
 export function useServer() {

--- a/connect/src/lib/server-provider/gcp.ts
+++ b/connect/src/lib/server-provider/gcp.ts
@@ -63,17 +63,39 @@ async function cfFetch<T = unknown>(
 
   const json = (await resp.json()) as {
     success: boolean;
-    errors?: { message: string }[];
+    errors?: { code?: number; message: string }[];
     result: T;
   };
 
   if (!json.success) {
     const msg =
       json.errors?.map((e) => e.message).join("; ") ?? "Unknown CF error";
-    throw new Error(`Cloudflare API error: ${msg}`);
+    const err = new Error(`Cloudflare API error: ${msg}`) as Error & {
+      cfErrors?: { code?: number; message: string }[];
+      cfStatus?: number;
+    };
+    err.cfErrors = json.errors;
+    err.cfStatus = resp.status;
+    throw err;
   }
 
   return json.result;
+}
+
+// Cloudflare error codes that mean "the resource is already gone" — safe to ignore on delete.
+// 1003: tunnel not found; 7003/7000: route/path not found; 81044: DNS record not found.
+const CF_NOT_FOUND_CODES = new Set([1003, 7003, 7000, 81044]);
+
+function isCfNotFound(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+  const cfErr = err as Error & {
+    cfErrors?: { code?: number }[];
+    cfStatus?: number;
+  };
+  if (cfErr.cfStatus === 404) return true;
+  return (cfErr.cfErrors ?? []).some(
+    (e) => e.code !== undefined && CF_NOT_FOUND_CODES.has(e.code),
+  );
 }
 
 /**
@@ -150,26 +172,39 @@ async function createTunnel(userId: string): Promise<CloudflareTunnelResult> {
 }
 
 async function deleteTunnel(
-  tunnelId: string,
-  dnsRecordId: string,
+  tunnelId: string | null | undefined,
+  dnsRecordId: string | null | undefined,
 ): Promise<void> {
   const accountId = requireEnv("CLOUDFLARE_ACCOUNT_ID");
   const zoneId = requireEnv("CLOUDFLARE_ZONE_ID");
 
   // Delete DNS record first (so traffic stops going to the tunnel)
-  try {
-    await cfFetch(`/zones/${zoneId}/dns_records/${dnsRecordId}`, {
-      method: "DELETE",
-    });
-  } catch (err) {
-    console.error("Failed to delete DNS record:", err);
-    // Continue to delete the tunnel even if DNS delete fails
+  if (dnsRecordId) {
+    try {
+      await cfFetch(`/zones/${zoneId}/dns_records/${dnsRecordId}`, {
+        method: "DELETE",
+      });
+    } catch (err) {
+      if (!isCfNotFound(err)) {
+        console.error("Failed to delete DNS record:", err);
+        // Continue to delete the tunnel even if DNS delete fails for non-404 reasons
+      }
+    }
   }
 
   // Delete the tunnel — cascade=true cleans up connections even if cloudflared is still running
-  await cfFetch(`/accounts/${accountId}/cfd_tunnel/${tunnelId}?cascade=true`, {
-    method: "DELETE",
-  });
+  if (tunnelId) {
+    try {
+      await cfFetch(
+        `/accounts/${accountId}/cfd_tunnel/${tunnelId}?cascade=true`,
+        { method: "DELETE" },
+      );
+    } catch (err) {
+      if (!isCfNotFound(err)) {
+        throw err;
+      }
+    }
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -442,14 +477,19 @@ export class GCPProvider implements ServerProvider {
 
   async deprovision(
     serverId: string,
-    options?: { tunnelId?: string; dnsRecordId?: string },
+    options?: { tunnelId?: string | null; dnsRecordId?: string | null },
   ): Promise<void> {
     const errors: Error[] = [];
 
-    // 1. Delete Cloudflare Tunnel + DNS (proceed even if this fails)
-    if (options?.tunnelId && options?.dnsRecordId) {
+    // 1. Delete Cloudflare Tunnel + DNS (proceed even if this fails).
+    // deleteTunnel tolerates already-deleted resources and missing ids,
+    // so retry from a `deprovision_failed` state is safe.
+    if (options?.tunnelId || options?.dnsRecordId) {
       try {
-        await deleteTunnel(options.tunnelId, options.dnsRecordId);
+        await deleteTunnel(
+          options.tunnelId ?? null,
+          options.dnsRecordId ?? null,
+        );
       } catch (err) {
         console.error("Tunnel cleanup failed:", err);
         errors.push(err instanceof Error ? err : new Error(String(err)));

--- a/connect/src/lib/server-provider/types.ts
+++ b/connect/src/lib/server-provider/types.ts
@@ -28,6 +28,6 @@ export interface ServerProvider {
   status(serverId: string): Promise<ServerStatus>;
   deprovision(
     serverId: string,
-    options?: { tunnelId?: string; dnsRecordId?: string },
+    options?: { tunnelId?: string | null; dnsRecordId?: string | null },
   ): Promise<void>;
 }


### PR DESCRIPTION
## Summary

DELETE /api/servers/{id} now retries cleanly from a `deprovision_failed` state instead of leaving the row stuck. Three surgical changes:

- **Cloudflare deletes tolerate \"already gone\" responses.** `cfFetch` attaches CF error codes/HTTP status to thrown errors; `deleteTunnel` uses a new `isCfNotFound` helper to swallow 404s on both DNS and tunnel deletes.
- **Cleanup runs even when only partial state was recorded.** Previously the route required both `tunnel_id` and `dns_record_id` to be set, and the provider required both to call `deleteTunnel`. Both now fire when any provider-side id (`provider_id`, `tunnel_id`, or `dns_record_id`) exists.
- **`deprovision_failed` is surfaced in the UI.** The Personal Server status page renders it as \"Cleanup failed\" (destructive tone). The existing \"Remove Server\" button already shows for non-`provisioning` states, so it now acts as a retry.

## Why

A previous deprovision attempt left a row in `deprovision_failed` while the underlying GCE / Cloudflare resources had already been cleaned up out-of-band. The old code path could not recover — DELETE always re-failed because the orphaned tunnel/DNS ids returned 404, which the CF helper threw on. Surface stays stuck, no retry path in the UI.

## Scope

Only files under `/server`, `/api/servers`, and `lib/server-provider`. **No changes** to:
- OIDC, login, sessions
- Account actions / consent / access
- Hydra paths
- Builder / data-connect surfaces

## Validation

- \`pnpm exec tsc --noEmit\` — clean for touched files (the unrelated CSS-import error in \`app/layout.tsx\` is pre-existing).
- \`pnpm test -- --run src/app/server\` — 322 passed / 17 skipped (matches baseline).
- Lint hit OOM locally; will re-run in CI.

## Test plan

- [ ] CI passes (typecheck, lint, tests)
- [ ] Preview deploys
- [ ] On preview \`account-dev.vana.org\`: provision a Personal Server, then \"Remove Server\" — completes successfully
- [ ] Force a partial-failure scenario (manually delete tunnel/DNS first, then click Remove Server) — retry succeeds and clears the row