### PR TITLE
fix(server): pin Personal Server data disk name and tolerate legacy disks

### DIFF
--- a/connect/src/lib/server-provider/gcp.ts
+++ b/connect/src/lib/server-provider/gcp.ts
@@ -346,6 +346,10 @@ export class GCPProvider implements ServerProvider {
           },
           {
             initializeParams: {
+              // Pin the underlying GCE disk resource name. Without this, GCE
+              // auto-generates `<vmName>-1` and deprovision can't find the
+              // disk to delete by the deviceName-based lookup.
+              diskName: `${vmName}-data`,
               diskSizeGb: "10",
               diskType: `zones/${GCP_ZONE}/diskTypes/pd-standard`,
             },
@@ -514,8 +518,11 @@ export class GCPProvider implements ServerProvider {
       }
     }
 
-    // 3. Delete the persistent data disk (not auto-deleted with VM)
-    const diskName = `${serverId}-data`;
+    // 3. Delete the persistent data disk (not auto-deleted with VM).
+    // Newer provisions pin the disk name to `${vmName}-data`. Older
+    // provisions let GCE auto-generate the name, which lands as
+    // `${vmName}-1`. Try both so legacy rows can be cleaned up too.
+    const diskNameCandidates = [`${serverId}-data`, `${serverId}-1`];
     try {
       const { DisksClient } = await import("@google-cloud/compute");
       const saKey = process.env.GCP_SERVICE_ACCOUNT_KEY;
@@ -536,20 +543,27 @@ export class GCPProvider implements ServerProvider {
       } else {
         disksClient = new DisksClient({ projectId: this.project });
       }
-      await disksClient.delete({
-        project: this.project,
-        zone: GCP_ZONE,
-        disk: diskName,
-      });
-    } catch (err: unknown) {
-      const code =
-        err && typeof err === "object" && "code" in err
-          ? (err as { code: number }).code
-          : 0;
-      if (code !== 5 && code !== 404) {
-        console.error("Disk deletion failed:", err);
-        errors.push(err instanceof Error ? err : new Error(String(err)));
+      for (const diskName of diskNameCandidates) {
+        try {
+          await disksClient.delete({
+            project: this.project,
+            zone: GCP_ZONE,
+            disk: diskName,
+          });
+        } catch (err: unknown) {
+          const code =
+            err && typeof err === "object" && "code" in err
+              ? (err as { code: number }).code
+              : 0;
+          if (code !== 5 && code !== 404) {
+            console.error(`Disk deletion failed for ${diskName}:`, err);
+            errors.push(err instanceof Error ? err : new Error(String(err)));
+          }
+        }
       }
+    } catch (err) {
+      console.error("DisksClient init failed:", err);
+      errors.push(err instanceof Error ? err : new Error(String(err)));
     }
 
     if (errors.length > 0) {


### PR DESCRIPTION
## Summary

Personal Server deprovision was failing with HTTP 500 because the data disk delete couldn't find its target. Root cause: provisioning omits `diskName`, so GCE auto-generates `${vmName}-1`, but deprovision looks for `${vmName}-data`. Every PS provisioned with the current code was guaranteed to fail deprovision.

**Two fixes:**

- **Provision** now sets `diskName: \`${vmName}-data\`` explicitly, matching the deprovision lookup.
- **Deprovision** attempts both `${serverId}-data` and `${serverId}-1`, so existing rows provisioned before this fix can also be cleaned up.

## Why

After PR #113 made deprovision idempotent for Cloudflare resources, deprovision was still throwing 500. Live debugging traced the failure to `disksClient.delete()` returning 404 because the disk's actual GCE name didn't match the constructed name. The deprovision code's `code !== 5 && code !== 404` guard correctly classifies 404 as benign, but the underlying delete still appears to error before reaching that branch in some paths — specifically when the iterator fires errors before the gRPC client surfaces a typed `code`. Either way, the right fix is to make the disk name correct in the first place.

## Scope

Only `connect/src/lib/server-provider/gcp.ts`. No OIDC, account, builder, or data-connect surface touched.

## Test plan

- [ ] CI passes
- [ ] On preview: provision → deprovision a Personal Server, confirm row clears
- [ ] On production: same
- [ ] Inspect the resulting disk name in GCE — should be `${vmName}-data`