### PR TITLE
fix(server): surface real deprovision error in DELETE response

### DIFF
--- a/connect/src/app/api/servers/[id]/route.ts
+++ b/connect/src/app/api/servers/[id]/route.ts
@@ -106,11 +106,29 @@ export async function DELETE(
         dnsRecordId: server.dns_record_id,
       });
     } catch (err) {
-      console.error("Deprovision error:", err);
+      const errorName = err instanceof Error ? err.name : "Error";
+      const errorMessage = err instanceof Error ? err.message : String(err);
+      const deprovisionErrors = (
+        err as Error & {
+          deprovisionErrors?: { step: string; code: number; message: string }[];
+        }
+      ).deprovisionErrors;
+      console.error(
+        `[api/servers DELETE] serverId=${id} providerId=${server.provider_id ?? ""} tunnelId=${server.tunnel_id ?? ""} dnsRecordId=${server.dns_record_id ?? ""} ${errorName}: ${errorMessage}`,
+      );
       await updateServer(id, { state: "deprovision_failed" });
+      // Return the actual failure detail in the response body so it's visible
+      // without runtime-log access. This is admin/control-plane data; nothing
+      // here is secret (just step names + GCP/Cloudflare error messages).
       return apiError(
         "internal_error",
-        "Failed to deprovision server. Resources may still be running.",
+        `Failed to deprovision server: ${errorMessage}${
+          deprovisionErrors?.length
+            ? ` [steps: ${deprovisionErrors
+                .map((e) => `${e.step}(code=${e.code})`)
+                .join(", ")}]`
+            : ""
+        }`,
         500,
       );
     }

--- a/connect/src/lib/server-provider/gcp.ts
+++ b/connect/src/lib/server-provider/gcp.ts
@@ -483,7 +483,21 @@ export class GCPProvider implements ServerProvider {
     serverId: string,
     options?: { tunnelId?: string | null; dnsRecordId?: string | null },
   ): Promise<void> {
-    const errors: Error[] = [];
+    const errors: { step: string; code: number; message: string }[] = [];
+
+    const errCode = (err: unknown): number =>
+      err && typeof err === "object" && "code" in err
+        ? Number((err as { code: number }).code) || 0
+        : 0;
+    const errMessage = (err: unknown): string =>
+      err instanceof Error ? err.message : String(err);
+    const recordError = (step: string, err: unknown) => {
+      const entry = { step, code: errCode(err), message: errMessage(err) };
+      console.error(
+        `[deprovision] step=${step} serverId=${serverId} code=${entry.code} message=${entry.message}`,
+      );
+      errors.push(entry);
+    };
 
     // 1. Delete Cloudflare Tunnel + DNS (proceed even if this fails).
     // deleteTunnel tolerates already-deleted resources and missing ids,
@@ -495,39 +509,44 @@ export class GCPProvider implements ServerProvider {
           options.dnsRecordId ?? null,
         );
       } catch (err) {
-        console.error("Tunnel cleanup failed:", err);
-        errors.push(err instanceof Error ? err : new Error(String(err)));
+        recordError("tunnel", err);
       }
     }
 
     // 2. Delete the GCP VM and wait for completion. Without waiting, the
     // disk delete in step 3 races the VM teardown and fails with
     // RESOURCE_IN_USE_BY_ANOTHER_RESOURCE while the VM is still STOPPING.
-    try {
-      const [operation] = await this.client.delete({
-        project: this.project,
-        zone: GCP_ZONE,
-        instance: serverId,
-      });
-      // Poll until the VM is fully deleted (typically <15s for a stopped instance).
-      // The Compute v1 SDK exposes operation.promise() via the long-running
-      // operation client returned alongside InstancesClient; for older
-      // versions, fall back to manual polling via the zone operations endpoint.
-      const op = operation as unknown as {
-        promise?: () => Promise<unknown>;
-        latestResponse?: { name?: string };
-      };
-      if (typeof op.promise === "function") {
-        await op.promise();
-      }
-    } catch (err: unknown) {
-      const code =
-        err && typeof err === "object" && "code" in err
-          ? (err as { code: number }).code
-          : 0;
-      if (code !== 5 && code !== 404) {
-        console.error("VM deletion failed:", err);
-        errors.push(err instanceof Error ? err : new Error(String(err)));
+    if (serverId) {
+      try {
+        const [operation] = await this.client.delete({
+          project: this.project,
+          zone: GCP_ZONE,
+          instance: serverId,
+        });
+        // Poll until the VM is fully deleted (typically <15s for a stopped instance).
+        // The Compute v1 SDK exposes operation.promise() via the long-running
+        // operation client returned alongside InstancesClient; for older
+        // versions, fall back to manual polling via the zone operations endpoint.
+        const op = operation as unknown as {
+          promise?: () => Promise<unknown>;
+        };
+        if (typeof op.promise === "function") {
+          try {
+            await op.promise();
+          } catch (waitErr) {
+            // The VM may have been deleted between our delete call and the
+            // wait — that's a "stopped" code we can ignore.
+            const code = errCode(waitErr);
+            if (code !== 5 && code !== 404) {
+              recordError("vm-wait", waitErr);
+            }
+          }
+        }
+      } catch (err: unknown) {
+        const code = errCode(err);
+        if (code !== 5 && code !== 404) {
+          recordError("vm-delete", err);
+        }
       }
     }
 
@@ -535,75 +554,76 @@ export class GCPProvider implements ServerProvider {
     // Newer provisions pin the disk name to `${vmName}-data`. Older
     // provisions let GCE auto-generate the name, which lands as
     // `${vmName}-1`. Try both so legacy rows can be cleaned up too.
-    const diskNameCandidates = [`${serverId}-data`, `${serverId}-1`];
-    try {
-      const { DisksClient } = await import("@google-cloud/compute");
-      const saKey = process.env.GCP_SERVICE_ACCOUNT_KEY;
-      let disksClient: InstanceType<typeof DisksClient>;
-      if (saKey) {
-        try {
-          const key = JSON.parse(saKey);
-          disksClient = new DisksClient({
-            credentials: {
-              client_email: key.client_email,
-              private_key: key.private_key,
-            },
-            projectId: this.project,
-          });
-        } catch {
+    if (serverId) {
+      const diskNameCandidates = [`${serverId}-data`, `${serverId}-1`];
+      try {
+        const { DisksClient } = await import("@google-cloud/compute");
+        const saKey = process.env.GCP_SERVICE_ACCOUNT_KEY;
+        let disksClient: InstanceType<typeof DisksClient>;
+        if (saKey) {
+          try {
+            const key = JSON.parse(saKey);
+            disksClient = new DisksClient({
+              credentials: {
+                client_email: key.client_email,
+                private_key: key.private_key,
+              },
+              projectId: this.project,
+            });
+          } catch {
+            disksClient = new DisksClient({ projectId: this.project });
+          }
+        } else {
           disksClient = new DisksClient({ projectId: this.project });
         }
-      } else {
-        disksClient = new DisksClient({ projectId: this.project });
-      }
-      for (const diskName of diskNameCandidates) {
-        // Up to 5 retries for FAILED_PRECONDITION (disk still attached to a
-        // VM that is mid-delete) — usually clears within a few seconds.
-        let attempt = 0;
-        const maxAttempts = 5;
-        while (attempt < maxAttempts) {
-          try {
-            await disksClient.delete({
-              project: this.project,
-              zone: GCP_ZONE,
-              disk: diskName,
-            });
-            break;
-          } catch (err: unknown) {
-            const code =
-              err && typeof err === "object" && "code" in err
-                ? (err as { code: number }).code
-                : 0;
-            if (code === 5 || code === 404) {
-              break; // already gone
-            }
-            // gRPC FAILED_PRECONDITION (9) or HTTP 400 — disk still in use,
-            // back off and retry. Anything else is a real failure.
-            const isInUse = code === 9 || code === 400;
-            if (!isInUse || attempt === maxAttempts - 1) {
-              console.error(
-                `Disk deletion failed for ${diskName} (code=${code}):`,
-                err,
-              );
-              errors.push(err instanceof Error ? err : new Error(String(err)));
+        for (const diskName of diskNameCandidates) {
+          // Up to 5 retries for FAILED_PRECONDITION (disk still attached to a
+          // VM that is mid-delete) — usually clears within a few seconds.
+          let attempt = 0;
+          const maxAttempts = 5;
+          while (attempt < maxAttempts) {
+            try {
+              await disksClient.delete({
+                project: this.project,
+                zone: GCP_ZONE,
+                disk: diskName,
+              });
               break;
+            } catch (err: unknown) {
+              const code = errCode(err);
+              if (code === 5 || code === 404) {
+                break; // already gone
+              }
+              // gRPC FAILED_PRECONDITION (9) or HTTP 400 — disk still in use,
+              // back off and retry. Anything else is a real failure.
+              const isInUse = code === 9 || code === 400;
+              if (!isInUse || attempt === maxAttempts - 1) {
+                recordError(`disk:${diskName}`, err);
+                break;
+              }
+              await new Promise((resolve) =>
+                setTimeout(resolve, 2000 * (attempt + 1)),
+              );
+              attempt += 1;
             }
-            await new Promise((resolve) =>
-              setTimeout(resolve, 2000 * (attempt + 1)),
-            );
-            attempt += 1;
           }
         }
+      } catch (err) {
+        recordError("disks-init", err);
       }
-    } catch (err) {
-      console.error("DisksClient init failed:", err);
-      errors.push(err instanceof Error ? err : new Error(String(err)));
     }
 
     if (errors.length > 0) {
-      throw new Error(
-        `Deprovision partially failed: ${errors.map((e) => e.message).join("; ")}`,
-      );
+      const detail = errors
+        .map((e) => `${e.step}(code=${e.code}): ${e.message}`)
+        .join("; ");
+      const wrapped = new Error(
+        `Deprovision partially failed: ${detail}`,
+      ) as Error & {
+        deprovisionErrors?: typeof errors;
+      };
+      wrapped.deprovisionErrors = errors;
+      throw wrapped;
     }
   }
 }


### PR DESCRIPTION
## Summary

DELETE `/api/servers/{id}` was returning a generic 500 (`Failed to deprovision server. Resources may still be running.`) regardless of which step inside `provider.deprovision()` actually failed. Vercel's events API only exposes build logs, so the underlying `console.error` lines were not reachable from the dashboard. Three prior fixes (#113, #114, #115) addressed plausible causes blind, and the deprovision still 500s in the field.

This change makes the next reproduction self-diagnosing.

## Changes

- `lib/server-provider/gcp.ts`
  - Each error inside `deprovision()` is now tagged with its step (`tunnel`, `vm-delete`, `vm-wait`, `disk:<name>`, `disks-init`) and the gRPC/HTTP `code`.
  - The thrown `Error` carries a `deprovisionErrors` array (step + code + message per failure) in addition to the human-readable message.
  - Split the initial VM `delete` from the LRO `op.promise()` wait so a stale-op timeout is distinguishable from an immediate API error.
  - Skip VM/disk steps when `serverId` is empty (defensive — the route already gates on that, but the contract is now obvious).
- `app/api/servers/[id]/route.ts`
  - 500 response body now includes the actual error message + step summary, e.g. `Failed to deprovision server: Deprovision partially failed: vm-wait(code=4): Deadline exceeded [steps: vm-wait(code=4)]`.
  - Structured single-line `console.error` with `serverId`, `providerId`, `tunnelId`, `dnsRecordId`, `errorName`, `errorMessage` so runtime logs are greppable when they do become accessible.

No secrets are returned: only step labels and the provider's own error text (GCP/Cloudflare error messages).

## Validation

- `pnpm exec tsc --noEmit` clean (excluding pre-existing `.next/` validator stubs that reference unmerged PR #112 routes).
- `pnpm exec biome check` clean on changed files.
- `pnpm test`: same 7 pre-existing `use-login-page` failures as on main (`localStorage.clear is not a function` — jsdom env, OIDC scope, unrelated). My target `src/app/server/use-server.test.ts` passes.

## Test plan

- [ ] After merge + Vercel deploy on `account.vana.org/server`: provision a fresh PS, click Remove, capture the 500 response body in DevTools, share with team for the next targeted fix.
- [ ] Confirm the structured log line shows up in Vercel runtime logs when accessible.