### PR TITLE
fix(server): pass GCP credentials to DisksClient on deprovision

### DIFF
--- a/connect/src/lib/server-provider/gcp.ts
+++ b/connect/src/lib/server-provider/gcp.ts
@@ -282,6 +282,25 @@ docker run -d \\
 // GCP Provider
 // ---------------------------------------------------------------------------
 
+/**
+ * Load GCP credentials from GCP_SERVICE_ACCOUNT_KEY.
+ * Vercel sometimes mangles raw JSON in env vars, so we accept either raw JSON
+ * or base64-encoded JSON. Returns null when no key is configured (falls back
+ * to ADC, which only works on GCP-hosted runtimes).
+ */
+function loadGcpCredentials(): {
+  client_email: string;
+  private_key: string;
+} | null {
+  const saKey = process.env.GCP_SERVICE_ACCOUNT_KEY;
+  if (!saKey) return null;
+  try {
+    return JSON.parse(saKey);
+  } catch {
+    return JSON.parse(Buffer.from(saKey, "base64").toString("utf-8"));
+  }
+}
+
 export class GCPProvider implements ServerProvider {
   private client: InstancesClient;
   private project: string;
@@ -289,19 +308,12 @@ export class GCPProvider implements ServerProvider {
   constructor() {
     this.project = requireEnv("GCP_PROJECT");
 
-    const saKey = process.env.GCP_SERVICE_ACCOUNT_KEY;
-    if (saKey) {
-      let key: { client_email: string; private_key: string };
-      try {
-        key = JSON.parse(saKey);
-      } catch {
-        // Try base64 decoding (some env var systems mangle raw JSON)
-        key = JSON.parse(Buffer.from(saKey, "base64").toString("utf-8"));
-      }
+    const credentials = loadGcpCredentials();
+    if (credentials) {
       this.client = new InstancesClient({
         credentials: {
-          client_email: key.client_email,
-          private_key: key.private_key,
+          client_email: credentials.client_email,
+          private_key: credentials.private_key,
         },
         projectId: this.project,
       });
@@ -558,24 +570,16 @@ export class GCPProvider implements ServerProvider {
       const diskNameCandidates = [`${serverId}-data`, `${serverId}-1`];
       try {
         const { DisksClient } = await import("@google-cloud/compute");
-        const saKey = process.env.GCP_SERVICE_ACCOUNT_KEY;
-        let disksClient: InstanceType<typeof DisksClient>;
-        if (saKey) {
-          try {
-            const key = JSON.parse(saKey);
-            disksClient = new DisksClient({
+        const credentials = loadGcpCredentials();
+        const disksClient: InstanceType<typeof DisksClient> = credentials
+          ? new DisksClient({
               credentials: {
-                client_email: key.client_email,
-                private_key: key.private_key,
+                client_email: credentials.client_email,
+                private_key: credentials.private_key,
               },
               projectId: this.project,
-            });
-          } catch {
-            disksClient = new DisksClient({ projectId: this.project });
-          }
-        } else {
-          disksClient = new DisksClient({ projectId: this.project });
-        }
+            })
+          : new DisksClient({ projectId: this.project });
         for (const diskName of diskNameCandidates) {
           // Up to 5 retries for FAILED_PRECONDITION (disk still attached to a
           // VM that is mid-delete) — usually clears within a few seconds.


### PR DESCRIPTION
## Summary

Captured signal from PR #116 instrumentation:

> Failed to deprovision server: Deprovision partially failed: disk:ps-srvazcrf7gqsmdxg-data(code=0): Could not load the default credentials. Browse to https://cloud.google.com/docs/authentication/getting-started for more information.; disk:ps-srvazcrf7gqsmdxg-1(code=0): ...

The disk-cleanup step constructed \`DisksClient\` without credentials, while \`InstancesClient\` (in the class constructor) was given them. On Vercel there is no ADC, so the disk client failed every time — even after the VM and tunnel had been cleaned up successfully.

The \`InstancesClient\` constructor also tolerates base64-encoded \`GCP_SERVICE_ACCOUNT_KEY\` values (Vercel sometimes mangles raw JSON); the \`DisksClient\` block did not, and its catch fallback silently dropped to credential-less ADC.

## Changes

- Extract \`loadGcpCredentials()\` helper. Returns parsed \`{client_email, private_key}\` from \`GCP_SERVICE_ACCOUNT_KEY\` (raw JSON or base64), or \`null\` when unset.
- Use it for **both** \`InstancesClient\` (constructor) and \`DisksClient\` (deprovision step) so they share one auth path.
- No behavior change when \`GCP_SERVICE_ACCOUNT_KEY\` is unset — ADC fallback preserved for GCP-hosted runtimes.

## Validation

- \`pnpm exec tsc --noEmit\` clean (excluding pre-existing \`.next/\` validator stubs).
- \`pnpm exec biome check\` clean on the changed file.

## Test plan

- [ ] After merge + deploy, repro on \`account.vana.org/server\`: provision, click Remove. Expect 200 and the row to clear.
- [ ] For the existing orphaned data disk \`ps-srvazcrf7gqsmdxg-data\` (and any others), the next Remove from the \`deprovision_failed\` state should now actually delete the disk.