### PR TITLE
feat(server): register Personal Server on-chain at provision time

### DIFF
--- a/connect/src/app/api/servers/[id]/register-on-chain/route.ts
+++ b/connect/src/app/api/servers/[id]/register-on-chain/route.ts
@@ -1,0 +1,79 @@
+import type { NextRequest } from "next/server";
+import { recoverWalletAddress } from "@/lib/api-auth";
+import { apiError, apiOptions, apiSuccess } from "@/lib/api-error";
+import { findServerById } from "@/lib/db/neon";
+import { registerServerOnChain } from "@/lib/server-provider/register-on-chain";
+
+// Generous timeout — calls PS /health, /api/sign, then gateway /v1/servers.
+export const maxDuration = 30;
+
+function extractSignature(request: NextRequest): string | null {
+  return (
+    request.headers.get("authorization")?.replace("Bearer ", "") ??
+    request.nextUrl.searchParams.get("masterKeySignature")
+  );
+}
+
+export async function OPTIONS() {
+  return apiOptions();
+}
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+  const sig = extractSignature(request);
+  if (!sig) {
+    return apiError("authentication_error", "Missing masterKeySignature", 401);
+  }
+
+  let walletAddress: string;
+  try {
+    walletAddress = await recoverWalletAddress(sig);
+  } catch {
+    return apiError("authentication_error", "Invalid signature", 401);
+  }
+
+  const server = await findServerById(id);
+  if (!server) {
+    return apiError("not_found_error", "Server not found", 404);
+  }
+
+  if (server.user_id !== walletAddress.toLowerCase()) {
+    return apiError("not_found_error", "Server not found", 404);
+  }
+
+  if (!server.url) {
+    return apiError(
+      "invalid_request_error",
+      "Server is not running yet — cannot register before /health is reachable",
+      400,
+    );
+  }
+
+  // Sign + post via the same-host /api/sign endpoint
+  const origin = request.nextUrl.origin;
+  const signEndpoint = `${origin}/api/sign`;
+
+  const result = await registerServerOnChain({
+    masterKeySignature: sig as `0x${string}`,
+    ownerAddress: walletAddress as `0x${string}`,
+    serverUrl: server.url,
+    signEndpoint,
+  });
+
+  if (!result.ok) {
+    return apiError(
+      "internal_error",
+      `On-chain registration failed (${result.error.code}): ${result.error.message}`,
+      500,
+    );
+  }
+
+  return apiSuccess({
+    object: "server.registration",
+    serverId: result.data.serverId,
+    serverAddress: result.data.serverAddress,
+  });
+}

--- a/connect/src/app/server/use-server.ts
+++ b/connect/src/app/server/use-server.ts
@@ -38,6 +38,11 @@ export function useServer() {
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const initialFetchDone = useRef(false);
   const provisioningServerIdRef = useRef<string | null>(null);
+  // Tracks server ids we've already triggered on-chain registration for, so
+  // we don't repeat the call on every poll/refresh after the server transitions
+  // to `running`. Idempotent on the server too (gateway returns 409 →
+  // treated as success), but avoiding the network roundtrip is cheaper.
+  const registeredOnChainRef = useRef<Set<string>>(new Set());
 
   const embeddedWalletAddress = (() => {
     for (const wallet of wallets) {
@@ -171,6 +176,34 @@ export function useServer() {
     initialFetchDone.current = true;
     fetchServer();
   }, [walletsReady, embeddedWalletAddress, fetchServer]);
+
+  // When status flips to `running` for a server we haven't registered on-chain
+  // yet, fire-and-forget the gateway registration. Failure is non-fatal — the
+  // user can retry, and the server still serves owner traffic without it; only
+  // delegated grant/file signing is gated on this.
+  useEffect(() => {
+    if (status !== "running" || !server) return;
+    if (registeredOnChainRef.current.has(server.id)) return;
+    registeredOnChainRef.current.add(server.id);
+
+    void (async () => {
+      try {
+        const sig = await getSignature();
+        const res = await fetch(`/api/servers/${server.id}/register-on-chain`, {
+          method: "POST",
+          headers: { Authorization: `Bearer ${sig}` },
+        });
+        if (!res.ok) {
+          // Soft failure — log but don't surface as a hard error in the UI.
+          // The server is still running and usable for owner ops.
+          const body = await res.json().catch(() => ({}));
+          console.warn("On-chain registration failed:", body);
+        }
+      } catch (err) {
+        console.warn("On-chain registration error:", err);
+      }
+    })();
+  }, [status, server, getSignature]);
 
   // Poll while provisioning
   useEffect(() => {

--- a/connect/src/lib/server-provider/register-on-chain.ts
+++ b/connect/src/lib/server-provider/register-on-chain.ts
@@ -1,0 +1,248 @@
+/**
+ * Register a freshly provisioned Personal Server on the Data Portability
+ * Gateway via `POST /v1/servers`. Establishes the on-chain delegation that
+ * lets the PS sign FileRegistration / GrantRegistration / GrantRevocation on
+ * the user's behalf without needing to invoke the user's wallet for each
+ * protocol op.
+ *
+ * Trust chain established here:
+ *   user wallet (ownerAddress)
+ *     └── signs ServerRegistration EIP-712
+ *           → gateway records: ownerAddress trusts serverAddress
+ *
+ * After this lands, builder discovery (`GET /v1/servers/{ownerAddress}`)
+ * resolves to this server's URL, and PS-signed grant/file operations are
+ * accepted by the gateway under the delegation fallback.
+ */
+
+import type { Address, Hex } from "viem";
+
+const SERVERS_DOMAIN = {
+  name: "Vana Data Portability",
+  version: "1",
+  chainId: BigInt(
+    process.env.NEXT_PUBLIC_VANA_CHAIN_ID ?? process.env.VANA_CHAIN_ID ?? 1480,
+  ),
+  verifyingContract: (process.env.DATA_PORTABILITY_SERVER_CONTRACT ??
+    "0x0000000000000000000000000000000000000000") as Address,
+} as const;
+
+const SERVER_REGISTRATION_TYPES = {
+  ServerRegistration: [
+    { name: "ownerAddress", type: "address" },
+    { name: "serverAddress", type: "address" },
+    { name: "publicKey", type: "string" },
+    { name: "serverUrl", type: "string" },
+  ],
+} as const;
+
+const GATEWAY_URL =
+  process.env.DATA_GATEWAY_URL ?? "https://data-gateway.vana.org";
+
+export type RegisterServerErrorCode =
+  | "ALREADY_REGISTERED"
+  | "VALIDATION_ERROR"
+  | "SIGN_FAILED"
+  | "HEALTH_FETCH_FAILED"
+  | "NETWORK_ERROR"
+  | "UNEXPECTED_ERROR";
+
+export type RegisterServerResult =
+  | { ok: true; data: { serverId: string; serverAddress: Address } }
+  | { ok: false; error: { code: RegisterServerErrorCode; message: string } };
+
+export interface RegisterServerInput {
+  /** EIP-191 signature over "vana-master-key-v1" — used to sign ServerRegistration via /api/sign */
+  masterKeySignature: Hex;
+  /** Owner wallet address (recovered from masterKeySignature) */
+  ownerAddress: Address;
+  /** Public URL the PS is reachable at, e.g. https://0xabc….myvana.app */
+  serverUrl: string;
+  /** Origin to call /api/sign on (defaults to current host's account.vana.org) */
+  signEndpoint: string;
+}
+
+/**
+ * Fetches the PS's identity (serverAddress + publicKey) from its /health
+ * endpoint, then signs and submits the ServerRegistration to the gateway.
+ *
+ * Idempotent: gateway returns 409 if server is already registered, which we
+ * treat as success (caller usually doesn't care).
+ */
+export async function registerServerOnChain(
+  input: RegisterServerInput,
+): Promise<RegisterServerResult> {
+  // 1. Fetch identity from PS /health
+  let serverAddress: Address;
+  let publicKey: string;
+  try {
+    const healthRes = await fetch(`${input.serverUrl}/health`, {
+      // Gateway calls are public; /health is unauthenticated.
+      cache: "no-store",
+    });
+    if (!healthRes.ok) {
+      return {
+        ok: false,
+        error: {
+          code: "HEALTH_FETCH_FAILED",
+          message: `PS /health returned ${healthRes.status}`,
+        },
+      };
+    }
+    const health = (await healthRes.json()) as {
+      identity?: { address?: string; publicKey?: string };
+    };
+    if (!health.identity?.address || !health.identity?.publicKey) {
+      return {
+        ok: false,
+        error: {
+          code: "HEALTH_FETCH_FAILED",
+          message: "PS /health did not return identity.address + publicKey",
+        },
+      };
+    }
+    serverAddress = health.identity.address as Address;
+    publicKey = health.identity.publicKey;
+  } catch (err) {
+    return {
+      ok: false,
+      error: {
+        code: "HEALTH_FETCH_FAILED",
+        message: err instanceof Error ? err.message : String(err),
+      },
+    };
+  }
+
+  // 2. Build the EIP-712 typed-data payload exactly matching the gateway's
+  //    ServerRegistration verification (lib/eip712.ts in vana-com/data-gateway).
+  const typedData = {
+    domain: {
+      name: SERVERS_DOMAIN.name,
+      version: SERVERS_DOMAIN.version,
+      chainId: SERVERS_DOMAIN.chainId.toString(),
+      verifyingContract: SERVERS_DOMAIN.verifyingContract,
+    },
+    types: {
+      EIP712Domain: [
+        { name: "name", type: "string" },
+        { name: "version", type: "string" },
+        { name: "chainId", type: "uint256" },
+        { name: "verifyingContract", type: "address" },
+      ],
+      ...SERVER_REGISTRATION_TYPES,
+    },
+    primaryType: "ServerRegistration" as const,
+    message: {
+      ownerAddress: input.ownerAddress,
+      serverAddress,
+      publicKey,
+      serverUrl: input.serverUrl,
+    },
+  };
+
+  // 3. Sign via /api/sign (server-side Privy authorization signer)
+  let signature: Hex;
+  try {
+    const signRes = await fetch(input.signEndpoint, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        masterKeySignature: input.masterKeySignature,
+        type: "eth_signTypedData_v4",
+        typedData,
+      }),
+    });
+    if (!signRes.ok) {
+      const body = await signRes.json().catch(() => ({}));
+      return {
+        ok: false,
+        error: {
+          code: "SIGN_FAILED",
+          message:
+            (body as { error?: string }).error ??
+            `Sign endpoint returned ${signRes.status}`,
+        },
+      };
+    }
+    const json = (await signRes.json()) as { signature?: Hex };
+    if (!json.signature) {
+      return {
+        ok: false,
+        error: { code: "SIGN_FAILED", message: "No signature returned" },
+      };
+    }
+    signature = json.signature;
+  } catch (err) {
+    return {
+      ok: false,
+      error: {
+        code: "SIGN_FAILED",
+        message: err instanceof Error ? err.message : String(err),
+      },
+    };
+  }
+
+  // 4. POST to gateway /v1/servers
+  try {
+    const res = await fetch(`${GATEWAY_URL}/v1/servers`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Web3Signed ${signature}`,
+      },
+      body: JSON.stringify({
+        ownerAddress: input.ownerAddress,
+        serverAddress,
+        publicKey,
+        serverUrl: input.serverUrl,
+      }),
+    });
+
+    if (res.status === 201) {
+      const body = (await res.json()) as { serverId?: string };
+      return {
+        ok: true,
+        data: { serverId: body.serverId ?? "", serverAddress },
+      };
+    }
+
+    if (res.status === 409) {
+      // Already registered for this serverAddress — treat as success.
+      return {
+        ok: true,
+        data: { serverId: "", serverAddress },
+      };
+    }
+
+    if (res.status === 400 || res.status === 401 || res.status === 403) {
+      const body = await res.json().catch(() => ({}));
+      return {
+        ok: false,
+        error: {
+          code: "VALIDATION_ERROR",
+          message:
+            (body as { error?: string }).error ??
+            `Gateway rejected with status ${res.status}`,
+        },
+      };
+    }
+
+    return {
+      ok: false,
+      error: {
+        code: "UNEXPECTED_ERROR",
+        message: `Gateway returned status ${res.status}`,
+      },
+    };
+  } catch (err) {
+    const isNetworkError =
+      err instanceof TypeError && /fetch|network/i.test(err.message);
+    return {
+      ok: false,
+      error: {
+        code: isNetworkError ? "NETWORK_ERROR" : "UNEXPECTED_ERROR",
+        message: err instanceof Error ? err.message : String(err),
+      },
+    };
+  }
+}


### PR DESCRIPTION
## Summary

After a Personal Server transitions to running, account.vana.org now signs an EIP-712 ServerRegistration with the user's wallet (via the existing `/api/sign` endpoint and Privy authorization signer) and posts it to the Data Portability Gateway `POST /v1/servers`.

This establishes the on-chain delegation that lets the PS sign FileRegistration / GrantRegistration / GrantRevocation on the user's behalf without invoking the user's wallet for each protocol op. Without this, builder discovery (`GET /v1/servers/{ownerAddress}`) returns nothing and PS-signed grant ops are rejected by the gateway.

## Behavior

- After `useServer` sees `status === "running"`, fires `POST /api/servers/{id}/register-on-chain` once per session (per-server-id idempotency in the hook).
- The route fetches PS `/health` to discover `serverAddress` + `publicKey`, builds the typed-data payload, calls `/api/sign` to obtain a Privy-signed signature for the user's wallet, then POSTs to `${DATA_GATEWAY_URL}/v1/servers`.
- 409 from gateway (already registered) is treated as success.
- Network/sign/gateway failures are logged but non-fatal; the server still serves owner traffic without on-chain registration. Only delegated grant/file signing depends on this.

## Files

- New `connect/src/lib/server-provider/register-on-chain.ts` — pure helper.
- New `connect/src/app/api/servers/[id]/register-on-chain/route.ts` — POST endpoint, owner-auth via masterKeySignature.
- `connect/src/app/server/use-server.ts` — fire-once useEffect on `status === "running"`.

## Configuration

Reads contracts/chain from env:

- `NEXT_PUBLIC_VANA_CHAIN_ID` / `VANA_CHAIN_ID` (default 1480)
- `DATA_PORTABILITY_SERVER_CONTRACT` (must be set in production)
- `DATA_GATEWAY_URL` (default `https://data-gateway.vana.org`)

## Scope

No changes to OIDC, account-action, builder, or data-connect paths. The route is gated by the same masterKeySignature-recovery owner-auth as the existing `/api/servers` endpoints.

## Test plan

- [ ] CI passes (typecheck, tests, lint)
- [ ] On preview/account-dev: provision a fresh PS, observe `register-on-chain` fires after running
- [ ] Verify `GET https://data-gateway.vana.org/v1/servers/{ownerAddress}` returns the registered server
- [ ] Repeat provision (already registered) → 409 is silent success