### PR TITLE
fix(server): use Privy snake_case primary_type for typed-data signing

### DIFF
--- a/connect/src/lib/server-provider/register-on-chain.ts
+++ b/connect/src/lib/server-provider/register-on-chain.ts
@@ -131,7 +131,9 @@ export async function registerServerOnChain(
       ],
       ...SERVER_REGISTRATION_TYPES,
     },
-    primaryType: "ServerRegistration" as const,
+    // Privy's signTypedData expects snake_case `primary_type`, not the
+    // EIP-712 standard `primaryType`. Validation in /api/sign accepts both.
+    primary_type: "ServerRegistration" as const,
     message: {
       ownerAddress: input.ownerAddress,
       serverAddress,


### PR DESCRIPTION
Privy's signTypedData rejected our payload because we used the EIP-712 standard 'primaryType' camelCase. Privy expects 'primary_type' snake_case. /api/sign/sign-validation already accepts both.