### PR TITLE
feat(server): show on-chain discoverability status in server UI

### DIFF
--- a/connect/src/app/server/page.tsx
+++ b/connect/src/app/server/page.tsx
@@ -19,7 +19,11 @@ import { Text } from "@/components/typography/text";
 import { Button } from "@/components/ui/button";
 import { useAuthGuard } from "@/app/_auth/use-auth-guard";
 import { cn } from "@/lib/classes";
-import { useServer, type ServerStatus } from "./use-server";
+import {
+  type RegistrationStatus,
+  type ServerStatus,
+  useServer,
+} from "./use-server";
 
 export default function ServerPage() {
   const { isAuthed, isChecking } = useAuthGuard();
@@ -45,6 +49,7 @@ function ServerPageContent() {
     status,
     error,
     walletAddress,
+    registrationStatus,
     provision,
     deprovision,
     refresh,
@@ -142,6 +147,23 @@ function ServerPageContent() {
                   ) : null
                 }
               />
+              {status === "running" && (
+                <DetailRow
+                  hasTopRule
+                  label={
+                    <div className="flex items-baseline gap-1.75">
+                      <span className="font-semibold">Discoverable</span>
+                      <StatusIndicator
+                        tone={getRegistrationInfo(registrationStatus).tone}
+                        pulse={registrationStatus === "registering"}
+                      >
+                        {getRegistrationInfo(registrationStatus).label}
+                      </StatusIndicator>
+                    </div>
+                  }
+                  value={null}
+                />
+              )}
             </ServerCard>
           </ServerSection>
 
@@ -347,6 +369,22 @@ function getStatusInfo(status: ServerStatus): {
       return { tone: "destructive", label: "Error" };
     default:
       return { tone: "muted", label: status };
+  }
+}
+
+function getRegistrationInfo(status: RegistrationStatus): {
+  tone: StatusTone;
+  label: string;
+} {
+  switch (status) {
+    case "registered":
+      return { tone: "success", label: "Registered" };
+    case "registering":
+      return { tone: "accent", label: "Registering..." };
+    case "not_registered":
+      return { tone: "warning", label: "Not registered" };
+    default:
+      return { tone: "muted", label: "Checking..." };
   }
 }
 

--- a/connect/src/app/server/use-server.ts
+++ b/connect/src/app/server/use-server.ts
@@ -28,12 +28,21 @@ export type ServerStatus =
   | "deprovision_failed"
   | "error";
 
+export type RegistrationStatus =
+  | "unknown"
+  | "registering"
+  | "registered"
+  | "not_registered";
+
 export function useServer() {
   const { signMessage } = useSignMessage();
   const { wallets, ready: walletsReady } = useWallets();
   const [server, setServer] = useState<ApiServer | null>(null);
   const [status, setStatus] = useState<ServerStatus>("loading");
   const [error, setError] = useState<string | null>(null);
+  const [registrationStatus, setRegistrationStatus] =
+    useState<RegistrationStatus>("unknown");
+  const [serverId, setServerId] = useState<string | null>(null);
   const signatureRef = useRef<string | null>(null);
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const initialFetchDone = useRef(false);
@@ -106,6 +115,8 @@ export function useServer() {
       setServer(null);
       setStatus("idle");
       setError(null);
+      setRegistrationStatus("unknown");
+      setServerId(null);
       return null;
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));
@@ -177,32 +188,70 @@ export function useServer() {
     fetchServer();
   }, [walletsReady, embeddedWalletAddress, fetchServer]);
 
-  // When status flips to `running` for a server we haven't registered on-chain
-  // yet, fire-and-forget the gateway registration. Failure is non-fatal — the
-  // user can retry, and the server still serves owner traffic without it; only
-  // delegated grant/file signing is gated on this.
+  // When status flips to `running`, check whether the server is already
+  // registered on the gateway (PS /health exposes serverId). If not, kick off
+  // registration. Re-checks /health after registration completes so the UI
+  // reflects the final state.
   useEffect(() => {
-    if (status !== "running" || !server) return;
-    if (registeredOnChainRef.current.has(server.id)) return;
-    registeredOnChainRef.current.add(server.id);
+    if (status !== "running" || !server?.url) return;
+
+    let cancelled = false;
+    const serverUrl = server.url;
+    const dbId = server.id;
 
     void (async () => {
+      // 1. Probe /health for an existing serverId.
+      try {
+        const healthRes = await fetch(`${serverUrl}/health`, {
+          cache: "no-store",
+        });
+        if (!cancelled && healthRes.ok) {
+          const health = (await healthRes.json()) as {
+            identity?: { serverId?: string | null };
+          };
+          if (health.identity?.serverId) {
+            setServerId(health.identity.serverId);
+            setRegistrationStatus("registered");
+            registeredOnChainRef.current.add(dbId);
+            return;
+          }
+        }
+      } catch {
+        // Health probe failed — fall through to attempt registration anyway.
+      }
+
+      if (cancelled) return;
+      if (registeredOnChainRef.current.has(dbId)) return;
+      registeredOnChainRef.current.add(dbId);
+
+      // 2. Trigger registration.
+      setRegistrationStatus("registering");
       try {
         const sig = await getSignature();
-        const res = await fetch(`/api/servers/${server.id}/register-on-chain`, {
+        const res = await fetch(`/api/servers/${dbId}/register-on-chain`, {
           method: "POST",
           headers: { Authorization: `Bearer ${sig}` },
         });
-        if (!res.ok) {
-          // Soft failure — log but don't surface as a hard error in the UI.
-          // The server is still running and usable for owner ops.
+        if (cancelled) return;
+        if (res.ok) {
+          const body = (await res.json()) as { serverId?: string };
+          setServerId(body.serverId ?? null);
+          setRegistrationStatus("registered");
+        } else {
           const body = await res.json().catch(() => ({}));
           console.warn("On-chain registration failed:", body);
+          setRegistrationStatus("not_registered");
         }
       } catch (err) {
+        if (cancelled) return;
         console.warn("On-chain registration error:", err);
+        setRegistrationStatus("not_registered");
       }
     })();
+
+    return () => {
+      cancelled = true;
+    };
   }, [status, server, getSignature]);
 
   // Poll while provisioning
@@ -222,6 +271,8 @@ export function useServer() {
     status,
     error,
     walletAddress: embeddedWalletAddress,
+    registrationStatus,
+    serverId,
     provision,
     deprovision,
     refresh,


### PR DESCRIPTION
Adds a 'Discoverable' row to the Control section of /server, using the same DetailRow + StatusIndicator primitives as the existing Status row.

States:
- Checking... (muted) — initial probe of PS /health
- Registering... (accent, pulse) — gateway POST in flight
- Registered (success) — gateway returned a serverId
- Not registered (warning) — registration call failed; user can hard-refresh to retry

Hook also probes PS /health on mount to detect existing-registered case (so users revisiting an already-registered PS see Registered without re-triggering the registration call).