### PR TITLE
feat(grants): real Personal Server grants from approved account actions

### DIFF
--- a/connect/migrations/007_add_oauth_clients.sql
+++ b/connect/migrations/007_add_oauth_clients.sql
@@ -1,0 +1,47 @@
+-- Persistent registry of OAuth clients (apps that integrate Sign in with Vana
+-- and/or initiate account-hosted action requests). Replaces the localStorage
+-- admin store, which was browser-local and not survivable.
+--
+-- Optional builder binding: pure identity consumers (Sign in with Vana that
+-- never request data) do not need on-chain builder identity, so
+-- grantee_address / builder_id / public_key are nullable. Clients that DO
+-- request data must populate them so the action-decision flow can mint a
+-- real grant on the user's Personal Server.
+--
+-- application_id is a stable, app-friendly identifier (free-form short
+-- string) that the action-decision flow stamps onto consent events for
+-- audit. If null, account-action handlers fall back to client_id.
+
+CREATE TABLE IF NOT EXISTS oauth_clients (
+  client_id        TEXT PRIMARY KEY,
+  application_id   TEXT,
+  display_name     TEXT NOT NULL,
+  app_url          TEXT NOT NULL,
+  owner_address    TEXT NOT NULL,                                       -- the registrant's wallet
+  grantee_address  TEXT,                                                -- on-chain builder address; NULL for identity-only clients
+  builder_id       TEXT,                                                -- on-chain builder id (bytes32 hex)
+  public_key       TEXT,                                                -- builder public key, 0x04-prefixed uncompressed
+  webhook_url      TEXT,
+  redirect_uris    JSONB NOT NULL DEFAULT '[]'::jsonb,                  -- allowed OIDC redirect URIs
+  registered_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+  CHECK (length(display_name) > 0),
+  CHECK (app_url ~ '^https?://'),
+  CHECK (owner_address ~ '^0x[a-fA-F0-9]{40}$'),
+  CHECK (grantee_address IS NULL OR grantee_address ~ '^0x[a-fA-F0-9]{40}$'),
+  CHECK (builder_id IS NULL OR builder_id ~ '^0x[a-fA-F0-9]{64}$'),
+  CHECK (public_key IS NULL OR public_key ~ '^0x04[a-fA-F0-9]{128}$'),
+  -- Real-grant readiness is all-or-nothing: any builder field requires the
+  -- others, so the action-decision flow can rely on a populated triple.
+  CHECK (
+    (grantee_address IS NULL AND builder_id IS NULL AND public_key IS NULL)
+    OR (grantee_address IS NOT NULL AND builder_id IS NOT NULL AND public_key IS NOT NULL)
+  )
+);
+
+CREATE INDEX IF NOT EXISTS oauth_clients_grantee_idx
+  ON oauth_clients (grantee_address);
+
+CREATE INDEX IF NOT EXISTS oauth_clients_owner_idx
+  ON oauth_clients (owner_address);

--- a/connect/src/app/api/account/actions/account-actions-runtime.ts
+++ b/connect/src/app/api/account/actions/account-actions-runtime.ts
@@ -25,7 +25,10 @@ import {
   type LoginEvidence,
   type PrivyVerifiedUser,
 } from "@/lib/auth/login-session-adapter";
-import { resolveVanaUserByPrivyEvidence } from "@/lib/db/account";
+import {
+  findLinkedWalletsByUser,
+  resolveVanaUserByPrivyEvidence,
+} from "@/lib/db/account";
 import {
   consumeActionCodeWithExchangeEvent,
   findActionRequestById,
@@ -33,6 +36,10 @@ import {
   insertConsentEvent,
   persistActionDecisionBundle,
 } from "@/lib/db/account-actions";
+import { findOauthClientById } from "@/lib/db/oauth-clients";
+import { findServerByUserId } from "@/lib/db/neon";
+import { executeGrantViaPersonalServer } from "@/lib/auth/execute-grant-via-personal-server";
+import type { RequestedData } from "@/lib/auth/account-action";
 
 let privyClient: PrivyClient | null = null;
 
@@ -167,6 +174,17 @@ export async function runGetActionRequest(
   return toGetResponse(result);
 }
 
+async function resolveSubjectWalletAddress(
+  vanaUserId: string,
+): Promise<string | null> {
+  const wallets = await findLinkedWalletsByUser(vanaUserId);
+  // Primary wallet wins; fall back to first verified Ethereum wallet.
+  const primary = wallets.find((w) => w.is_primary);
+  if (primary) return primary.address;
+  const firstEth = wallets.find((w) => w.chain_type === "ethereum");
+  return firstEth?.address ?? null;
+}
+
 export async function runActionDecision(
   request: Request,
   actionRequestId: string,
@@ -183,6 +201,34 @@ export async function runActionDecision(
     resolveVanaUser,
     findActionRequestById,
     persistActionDecisionBundle,
+    resolveSubjectWalletAddress,
+    executeGrant: async (input) => {
+      const requestedData = input.requestedData as RequestedData;
+      return executeGrantViaPersonalServer({
+        vanaUserId: input.vanaUserId,
+        clientId: input.clientId,
+        scopes: requestedData.scopes ?? [],
+        // expiresAt + nonce are caller-driven; first slice mints unbounded
+        // grants (expiresAt=0 = no expiry) with epoch-ms nonce. Future
+        // slices may pull these from the request body.
+        expiresAt: 0,
+        nonce: Date.now(),
+        resolvePersonalServer: async (vanaUserId) => {
+          // vana_user_id → primary wallet → personal_servers row
+          const subject = await resolveSubjectWalletAddress(vanaUserId);
+          if (!subject) return null;
+          const server = await findServerByUserId(subject.toLowerCase());
+          if (!server || !server.url || !server.control_plane_token)
+            return null;
+          return {
+            serverId: server.id,
+            serverUrl: server.url,
+            accessToken: server.control_plane_token,
+          };
+        },
+        resolveOauthClient: async (clientId) => findOauthClientById(clientId),
+      });
+    },
   });
   return toDecisionResponse(result);
 }

--- a/connect/src/app/api/admin/oauth-clients/[clientId]/route.ts
+++ b/connect/src/app/api/admin/oauth-clients/[clientId]/route.ts
@@ -1,0 +1,61 @@
+import type { NextRequest } from "next/server";
+import { recoverWalletAddress } from "@/lib/api-auth";
+import { apiError, apiOptions, apiSuccess } from "@/lib/api-error";
+import { deleteOauthClient, findOauthClientById } from "@/lib/db/oauth-clients";
+
+export const maxDuration = 30;
+
+function extractSignature(request: NextRequest): string | null {
+  return (
+    request.headers.get("authorization")?.replace("Bearer ", "") ??
+    request.nextUrl.searchParams.get("masterKeySignature")
+  );
+}
+
+export async function OPTIONS() {
+  return apiOptions();
+}
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ clientId: string }> },
+) {
+  const { clientId } = await params;
+  const row = await findOauthClientById(clientId);
+  if (!row) {
+    return apiError("not_found_error", "OAuth client not found", 404);
+  }
+  return apiSuccess(row);
+}
+
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ clientId: string }> },
+) {
+  const sig = extractSignature(request);
+  if (!sig) {
+    return apiError("authentication_error", "Missing masterKeySignature", 401);
+  }
+  let walletAddress: string;
+  try {
+    walletAddress = (await recoverWalletAddress(sig)).toLowerCase();
+  } catch {
+    return apiError("authentication_error", "Invalid signature", 401);
+  }
+
+  const { clientId } = await params;
+  const existing = await findOauthClientById(clientId);
+  if (!existing) {
+    return apiError("not_found_error", "OAuth client not found", 404);
+  }
+  if (existing.owner_address !== walletAddress) {
+    // 404 (not 403) to avoid leaking existence to non-owners.
+    return apiError("not_found_error", "OAuth client not found", 404);
+  }
+
+  const removed = await deleteOauthClient(clientId);
+  if (!removed) {
+    return apiError("not_found_error", "OAuth client not found", 404);
+  }
+  return apiSuccess({ object: "oauth_client.deleted", clientId });
+}

--- a/connect/src/app/api/admin/oauth-clients/route.ts
+++ b/connect/src/app/api/admin/oauth-clients/route.ts
@@ -1,0 +1,152 @@
+/**
+ * Admin API for the `oauth_clients` registry — replaces the localStorage
+ * admin store. Authenticated callers must present a master-key signature
+ * (proves wallet ownership) and become the registry's `owner_address`.
+ *
+ * GET  /api/admin/oauth-clients          — list clients owned by the caller
+ * POST /api/admin/oauth-clients          — register or upsert a client
+ * DELETE /api/admin/oauth-clients/{id}   — delete a client (other route file)
+ */
+
+import type { NextRequest } from "next/server";
+import { isAddress } from "viem";
+import { recoverWalletAddress } from "@/lib/api-auth";
+import { apiError, apiOptions, apiSuccess } from "@/lib/api-error";
+import {
+  findOauthClientsByOwner,
+  upsertOauthClient,
+} from "@/lib/db/oauth-clients";
+
+export const maxDuration = 30;
+
+function extractSignature(request: NextRequest): string | null {
+  return (
+    request.headers.get("authorization")?.replace("Bearer ", "") ??
+    request.nextUrl.searchParams.get("masterKeySignature")
+  );
+}
+
+async function authenticate(
+  request: NextRequest,
+): Promise<{ ok: true; ownerAddress: string } | { ok: false; res: Response }> {
+  const sig = extractSignature(request);
+  if (!sig) {
+    return {
+      ok: false,
+      res: apiError("authentication_error", "Missing masterKeySignature", 401),
+    };
+  }
+  try {
+    const ownerAddress = await recoverWalletAddress(sig);
+    return { ok: true, ownerAddress: ownerAddress.toLowerCase() };
+  } catch {
+    return {
+      ok: false,
+      res: apiError("authentication_error", "Invalid signature", 401),
+    };
+  }
+}
+
+export async function OPTIONS() {
+  return apiOptions();
+}
+
+export async function GET(request: NextRequest) {
+  const auth = await authenticate(request);
+  if (!auth.ok) return auth.res;
+  const rows = await findOauthClientsByOwner(auth.ownerAddress);
+  return apiSuccess({ object: "list", data: rows });
+}
+
+export async function POST(request: NextRequest) {
+  const auth = await authenticate(request);
+  if (!auth.ok) return auth.res;
+
+  let body: Record<string, unknown>;
+  try {
+    body = (await request.json()) as Record<string, unknown>;
+  } catch {
+    return apiError("invalid_request_error", "Invalid JSON body", 400);
+  }
+
+  const clientId = asNonEmptyString(body.clientId);
+  if (!clientId) {
+    return apiError("invalid_request_error", "clientId is required", 400);
+  }
+
+  const displayName = asNonEmptyString(body.displayName);
+  if (!displayName) {
+    return apiError("invalid_request_error", "displayName is required", 400);
+  }
+
+  const appUrl = asNonEmptyString(body.appUrl);
+  if (!appUrl || !/^https?:\/\//.test(appUrl)) {
+    return apiError("invalid_request_error", "appUrl must be http(s) URL", 400);
+  }
+
+  const redirectUrisRaw = body.redirectUris;
+  const redirectUris =
+    Array.isArray(redirectUrisRaw) &&
+    redirectUrisRaw.every((u) => typeof u === "string")
+      ? (redirectUrisRaw as string[])
+      : [];
+
+  // Builder fields are optional but all-or-nothing (same constraint the DB
+  // enforces). If any is provided, all three must be.
+  const granteeAddress = asNonEmptyString(body.granteeAddress);
+  const builderId = asNonEmptyString(body.builderId);
+  const publicKey = asNonEmptyString(body.publicKey);
+  const anyBuilderField =
+    granteeAddress !== null || builderId !== null || publicKey !== null;
+  const allBuilderFields =
+    granteeAddress !== null && builderId !== null && publicKey !== null;
+  if (anyBuilderField && !allBuilderFields) {
+    return apiError(
+      "invalid_request_error",
+      "granteeAddress, builderId, and publicKey must be provided together",
+      400,
+    );
+  }
+  if (granteeAddress && !isAddress(granteeAddress)) {
+    return apiError(
+      "invalid_request_error",
+      "granteeAddress must be a valid Ethereum address",
+      400,
+    );
+  }
+  if (builderId && !/^0x[a-fA-F0-9]{64}$/.test(builderId)) {
+    return apiError(
+      "invalid_request_error",
+      "builderId must be 0x-prefixed 32-byte hex",
+      400,
+    );
+  }
+  if (publicKey && !/^0x04[a-fA-F0-9]{128}$/.test(publicKey)) {
+    return apiError(
+      "invalid_request_error",
+      "publicKey must be 0x04-prefixed uncompressed",
+      400,
+    );
+  }
+
+  const row = await upsertOauthClient({
+    clientId,
+    applicationId: asNonEmptyString(body.applicationId),
+    displayName,
+    appUrl,
+    ownerAddress: auth.ownerAddress,
+    granteeAddress,
+    builderId,
+    publicKey,
+    webhookUrl: asNonEmptyString(body.webhookUrl),
+    redirectUris,
+  });
+
+  return apiSuccess(row, 201);
+}
+
+function asNonEmptyString(v: unknown): string | null {
+  if (typeof v !== "string") return null;
+  const trimmed = v.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}

--- a/connect/src/lib/auth/account-action-routes.ts
+++ b/connect/src/lib/auth/account-action-routes.ts
@@ -50,6 +50,7 @@ import type {
   LoginEvidence,
   LoginSessionAdapter,
 } from "./login-session-adapter";
+import type { ExecuteGrantResult } from "./execute-grant-via-personal-server";
 import {
   checkRedirectUri,
   createDefaultOauthClientRegistry,
@@ -57,7 +58,8 @@ import {
 } from "./oauth-client-policy";
 import { isVanaUserId } from "./vana-account";
 
-export const DEFAULT_ACCOUNT_ACTION_ISSUER = "https://account.vana.org";
+export const DEFAULT_ACCOUNT_ACTION_ISSUER =
+  process.env.VANA_ACCOUNT_ISSUER ?? "https://account.vana.org";
 
 export type CreateActionRequestInput = {
   body: unknown;
@@ -540,6 +542,21 @@ export type DecisionRouteInput = {
   sessionAdapter: LoginSessionAdapter;
   resolveVanaUser: (input: LoginEvidence) => Promise<{ user: { id: string } }>;
   findActionRequestById: (id: string) => Promise<ActionRequestRow | null>;
+  /**
+   * Look up the user's wallet address by vana_user_id, used to populate
+   * `subject_wallet_address` on consent events.
+   */
+  resolveSubjectWalletAddress?: (vanaUserId: string) => Promise<string | null>;
+  /**
+   * Execute the protocol grant on the user's Personal Server. Required when
+   * `execution_mode === "embedded_wallet_account_hosted"`. Tests inject a
+   * fake; production wires {@link executeGrantViaPersonalServer}.
+   */
+  executeGrant?: (input: {
+    vanaUserId: string;
+    clientId: string;
+    requestedData: RequestedData;
+  }) => Promise<ExecuteGrantResult>;
   persistActionDecisionBundle: (input: {
     id: string;
     decision: "approved" | "denied";
@@ -568,7 +585,7 @@ export type DecisionRouteResult =
     }
   | {
       kind: "error";
-      status: 400 | 401 | 403 | 404 | 409;
+      status: 400 | 401 | 403 | 404 | 409 | 500 | 502;
       code: string;
       message: string;
     };
@@ -653,16 +670,43 @@ export async function handleActionDecision(
     };
   }
 
-  if (
-    rawDecision === "approved" &&
-    (existing.execution_mode !== "mock" || existing.result_mode !== "mock")
-  ) {
-    return {
-      kind: "error",
-      status: 409,
-      code: "unsupported_action_mode",
-      message: "This action request cannot be approved by the mock route slice",
-    };
+  if (rawDecision === "approved") {
+    const supportedExecutionModes: ActionExecutionMode[] = [
+      "mock",
+      "embedded_wallet_account_hosted",
+    ];
+    if (!supportedExecutionModes.includes(existing.execution_mode)) {
+      return {
+        kind: "error",
+        status: 409,
+        code: "unsupported_action_mode",
+        message: `Approval flow does not support execution_mode='${existing.execution_mode}' yet`,
+      };
+    }
+    // Only mock result_mode is supported in this slice (real result_mode
+    // requires encrypted bundle delivery, tracked separately).
+    if (existing.result_mode !== "mock") {
+      return {
+        kind: "error",
+        status: 409,
+        code: "unsupported_action_mode",
+        message: `Approval flow does not support result_mode='${existing.result_mode}' yet`,
+      };
+    }
+    // Real-grant execution requires an executor and a registry (to look up
+    // builder identity). Reject early with a clear error if missing.
+    if (
+      existing.execution_mode === "embedded_wallet_account_hosted" &&
+      !input.executeGrant
+    ) {
+      return {
+        kind: "error",
+        status: 500,
+        code: "grant_executor_unavailable",
+        message:
+          "Server is misconfigured: real-grant executor not wired into the action-decision route",
+      } as DecisionRouteResult;
+    }
   }
 
   // Verify presented state against the stored hash BEFORE persisting the
@@ -718,11 +762,17 @@ export async function handleActionDecision(
       vana_user_id: vanaUserId,
       decided_at: now.toISOString(),
     };
+    const subjectWalletAddress = input.resolveSubjectWalletAddress
+      ? await input.resolveSubjectWalletAddress(vanaUserId).catch(() => null)
+      : null;
+    const clientRecord = input.registry?.resolve(deniedRequest.client_id);
     const event = buildConsentEventRow({
       request: deniedRequest,
       eventType: "action.denied",
       decision: "denied",
       vanaUserId,
+      subjectWalletAddress,
+      applicationId: clientRecord?.protocolPrincipal?.id ?? null,
       idempotencyKey: `${deniedRequest.id}:denied`,
       requestHash,
       issuer,
@@ -772,17 +822,81 @@ export async function handleActionDecision(
     vana_user_id: vanaUserId,
     decided_at: now.toISOString(),
   };
-  const result = buildMockActionResult({
-    request: approvedRequest,
-    actionCode,
-    now,
-    ttlSeconds: ACTION_CODE_TTL_SECONDS,
-  });
+
+  // For embedded-wallet account-hosted execution, mint a real grant on the
+  // user's Personal Server before persisting. Failure aborts the approval —
+  // the action request stays pending so the user can retry.
+  let authorizationReference: Record<string, unknown> | null = null;
+  let result: ActionResultRow;
+  if (existing.execution_mode === "embedded_wallet_account_hosted") {
+    // Guarded above; assert non-null for the type system.
+    const executor = input.executeGrant;
+    if (!executor) {
+      return {
+        kind: "error",
+        status: 500,
+        code: "grant_executor_unavailable",
+        message: "Real-grant executor missing",
+      };
+    }
+    const grant = await executor({
+      vanaUserId,
+      clientId: existing.client_id,
+      requestedData: existing.requested_data,
+    });
+    if (!grant.ok) {
+      return {
+        kind: "error",
+        status: grant.code === "no_personal_server" ? 409 : 502,
+        code: `grant_${grant.code}`,
+        message: grant.message,
+      };
+    }
+    authorizationReference = {
+      grantId: grant.grantId,
+      granteeAddress: grant.granteeAddress,
+      personalServer: grant.personalServer,
+    };
+    // Mock result_mode still applies for the data delivery path; real grant
+    // id rides on the result_payload alongside the marker so clients can
+    // resolve the on-chain grant after the OAuth code exchange.
+    result = buildMockActionResult({
+      request: approvedRequest,
+      actionCode,
+      now,
+      ttlSeconds: ACTION_CODE_TTL_SECONDS,
+    });
+    result = {
+      ...result,
+      result_payload: {
+        ...(result.result_payload as Record<string, unknown> | null),
+        grant_id: grant.grantId,
+        grantee_address: grant.granteeAddress,
+        personal_server: grant.personalServer,
+      },
+    };
+  } else {
+    result = buildMockActionResult({
+      request: approvedRequest,
+      actionCode,
+      now,
+      ttlSeconds: ACTION_CODE_TTL_SECONDS,
+    });
+  }
+
+  const subjectWalletAddress = input.resolveSubjectWalletAddress
+    ? await input.resolveSubjectWalletAddress(vanaUserId).catch(() => null)
+    : null;
+  const clientRecord = input.registry?.resolve(approvedRequest.client_id);
+
   const event = buildConsentEventRow({
     request: approvedRequest,
     eventType: "action.approved",
     decision: "approved",
     vanaUserId,
+    subjectWalletAddress,
+    applicationId: clientRecord?.protocolPrincipal?.id ?? null,
+    authorizationReference,
     idempotencyKey: `${approvedRequest.id}:approved`,
     requestHash,
     issuer,

--- a/connect/src/lib/auth/execute-grant-via-personal-server.ts
+++ b/connect/src/lib/auth/execute-grant-via-personal-server.ts
@@ -1,0 +1,137 @@
+/**
+ * Execute a real grant via the user's Personal Server.
+ *
+ * Replaces the mock-only path for `execution_mode === "embedded_wallet_account_hosted"`:
+ *   1. Resolve the user's PS row (vana_user_id → linked wallet → personal_servers)
+ *   2. Resolve the OIDC client to a registered builder (oauth_clients)
+ *   3. POST <ps-url>/v1/grants with Bearer access_token and { granteeAddress, scopes, expiresAt?, nonce? }
+ *   4. Return the grantId for the action result + consent event
+ *
+ * Tests inject the resolvers + http fetch as deps so this is pure.
+ */
+
+import type { OauthClientRow } from "@/lib/db/oauth-clients";
+
+export type ExecuteGrantInput = {
+  vanaUserId: string;
+  clientId: string;
+  scopes: string[];
+  expiresAt?: number;
+  nonce?: number;
+  /** Resolves the user's running Personal Server (or null if none). */
+  resolvePersonalServer: (vanaUserId: string) => Promise<{
+    serverId: string;
+    serverUrl: string;
+    accessToken: string;
+  } | null>;
+  /** Resolves the OAuth client record. Builder fields may be null. */
+  resolveOauthClient: (clientId: string) => Promise<OauthClientRow | null>;
+  /** Injectable HTTP fetch (default: global fetch). */
+  fetchImpl?: typeof fetch;
+};
+
+export type ExecuteGrantResult =
+  | {
+      ok: true;
+      grantId: string;
+      granteeAddress: string;
+      personalServer: { serverId: string; serverUrl: string };
+    }
+  | {
+      ok: false;
+      code:
+        | "no_personal_server"
+        | "client_not_found"
+        | "client_no_builder"
+        | "ps_unreachable"
+        | "ps_rejected"
+        | "no_grant_id";
+      message: string;
+    };
+
+export async function executeGrantViaPersonalServer(
+  input: ExecuteGrantInput,
+): Promise<ExecuteGrantResult> {
+  const fetchImpl = input.fetchImpl ?? fetch;
+
+  // 1. Resolve PS for the user.
+  const ps = await input.resolvePersonalServer(input.vanaUserId);
+  if (!ps) {
+    return {
+      ok: false,
+      code: "no_personal_server",
+      message:
+        "User has no running Personal Server; provision one before approving real grants.",
+    };
+  }
+
+  // 2. Resolve OAuth client + builder identity.
+  const client = await input.resolveOauthClient(input.clientId);
+  if (!client) {
+    return {
+      ok: false,
+      code: "client_not_found",
+      message: `OAuth client ${input.clientId} is not registered.`,
+    };
+  }
+  if (!client.grantee_address || !client.builder_id) {
+    return {
+      ok: false,
+      code: "client_no_builder",
+      message: `OAuth client ${input.clientId} has no on-chain builder identity; cannot mint a real grant.`,
+    };
+  }
+
+  // 3. POST to PS /v1/grants.
+  let grantId: string | undefined;
+  try {
+    const res = await fetchImpl(`${ps.serverUrl}/v1/grants`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${ps.accessToken}`,
+      },
+      body: JSON.stringify({
+        granteeAddress: client.grantee_address,
+        scopes: input.scopes,
+        ...(input.expiresAt !== undefined
+          ? { expiresAt: input.expiresAt }
+          : {}),
+        ...(input.nonce !== undefined ? { nonce: input.nonce } : {}),
+      }),
+    });
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({}));
+      const message =
+        (body as { error?: { message?: string } }).error?.message ??
+        `Personal Server returned ${res.status}`;
+      return { ok: false, code: "ps_rejected", message };
+    }
+    const body = (await res.json()) as { grantId?: string };
+    grantId = body.grantId;
+  } catch (err) {
+    return {
+      ok: false,
+      code: "ps_unreachable",
+      message: err instanceof Error ? err.message : String(err),
+    };
+  }
+
+  if (!grantId) {
+    return {
+      ok: false,
+      code: "no_grant_id",
+      message: "Personal Server did not return a grantId",
+    };
+  }
+
+  return {
+    ok: true,
+    grantId,
+    granteeAddress: client.grantee_address,
+    personalServer: {
+      serverId: ps.serverId,
+      serverUrl: ps.serverUrl,
+    },
+  };
+}

--- a/connect/src/lib/auth/oauth-client-registry-db.ts
+++ b/connect/src/lib/auth/oauth-client-registry-db.ts
@@ -1,0 +1,133 @@
+/**
+ * DB-backed implementation of {@link OauthClientRegistry}.
+ *
+ * Static `DEV_MEMORY_APP_CLIENT` is still injected as a fallback so the
+ * dev/demo flow keeps working even when the `oauth_clients` table is empty.
+ * Real registrations land in the table; the action-decision flow reads
+ * builder identity (grantee_address, builder_id) from the DB to mint real
+ * grants.
+ */
+
+import {
+  findOauthClientById,
+  hasBuilderIdentity,
+  listOauthClients,
+  type OauthClientRow,
+} from "@/lib/db/oauth-clients";
+import {
+  DEV_MEMORY_APP_CLIENT,
+  type OauthClientRecord,
+  type OauthClientRegistry,
+} from "./oauth-client-policy";
+
+export type OauthClientWithBuilder = OauthClientRecord & {
+  builder?: {
+    granteeAddress: `0x${string}`;
+    builderId: `0x${string}`;
+    publicKey: string;
+  };
+};
+
+function rowToRecord(row: OauthClientRow): OauthClientWithBuilder {
+  const record: OauthClientWithBuilder = {
+    clientId: row.client_id,
+    displayName: row.display_name,
+    redirectUris: row.redirect_uris,
+    // No allowed-origins column on the DB row today: derive from registered
+    // redirect URIs so consent policy doesn't reject legitimate cross-origin
+    // calls. Admin UI can add an explicit column later if origins ever need
+    // to diverge.
+    allowedOrigins: deriveAllowedOrigins(row.redirect_uris),
+    // First-slice OIDC scope/audience policy still lives in code; clients
+    // get the same conservative allowlist as the dev fixture.
+    allowedScopes: ["openid", "profile", "email", "offline_access"],
+    allowedAudiences: [row.client_id],
+    protocolPrincipal:
+      row.grantee_address !== null
+        ? { kind: "builder", id: row.grantee_address }
+        : undefined,
+  };
+  if (hasBuilderIdentity(row)) {
+    record.builder = {
+      granteeAddress: row.grantee_address as `0x${string}`,
+      builderId: row.builder_id as `0x${string}`,
+      publicKey: row.public_key as string,
+    };
+  }
+  return record;
+}
+
+function deriveAllowedOrigins(redirectUris: string[]): string[] {
+  const seen = new Set<string>();
+  for (const uri of redirectUris) {
+    try {
+      const parsed = new URL(uri);
+      seen.add(`${parsed.protocol}//${parsed.host}`);
+    } catch {
+      // skip malformed
+    }
+  }
+  return [...seen];
+}
+
+/**
+ * DB-first registry. The `DEV_MEMORY_APP_CLIENT` fixture is included as a
+ * fallback so the dev environment keeps working when the table is empty;
+ * any DB row with the same `client_id` overrides the fallback.
+ */
+export function createDbOauthClientRegistry(options?: {
+  fallbackClients?: readonly OauthClientRecord[];
+}): OauthClientRegistry & {
+  resolveAsync(
+    clientId: string | null | undefined,
+  ): Promise<OauthClientWithBuilder | null>;
+  listAsync(): Promise<OauthClientWithBuilder[]>;
+} {
+  const fallbacks: ReadonlyMap<string, OauthClientRecord> = new Map(
+    (options?.fallbackClients ?? [DEV_MEMORY_APP_CLIENT]).map((c) => [
+      c.clientId,
+      c,
+    ]),
+  );
+
+  return {
+    // Synchronous resolve falls back to the static map. Used by code paths
+    // that cannot afford a DB hit (Hydra consent guard runs in a hot path).
+    // For real-grant lookups, use resolveAsync.
+    resolve(clientId) {
+      if (!clientId) return null;
+      return fallbacks.get(clientId) ?? null;
+    },
+    list() {
+      return [...fallbacks.values()];
+    },
+    async resolveAsync(clientId) {
+      if (!clientId) return null;
+      try {
+        const row = await findOauthClientById(clientId);
+        if (row) return rowToRecord(row);
+      } catch (err) {
+        // Fall through to static fallback if DB is unreachable.
+        console.error("oauth_clients DB lookup failed:", err);
+      }
+      const fallback = fallbacks.get(clientId);
+      return fallback ? { ...fallback } : null;
+    },
+    async listAsync() {
+      try {
+        const rows = await listOauthClients();
+        const merged = new Map<string, OauthClientWithBuilder>();
+        for (const fallback of fallbacks.values()) {
+          merged.set(fallback.clientId, { ...fallback });
+        }
+        for (const row of rows) {
+          merged.set(row.client_id, rowToRecord(row));
+        }
+        return [...merged.values()];
+      } catch (err) {
+        console.error("oauth_clients DB list failed:", err);
+        return [...fallbacks.values()].map((c) => ({ ...c }));
+      }
+    },
+  };
+}

--- a/connect/src/lib/db/oauth-clients.ts
+++ b/connect/src/lib/db/oauth-clients.ts
@@ -1,0 +1,175 @@
+import { getSql } from "./sql";
+
+/**
+ * Persistence helpers for `oauth_clients` — the registry of apps that
+ * integrate Sign in with Vana and/or initiate account-hosted action requests.
+ *
+ * Builder fields (`grantee_address`, `builder_id`, `public_key`) are
+ * collectively optional: a Sign-in-with-Vana-only client can register
+ * without on-chain builder identity. The DB CHECK constraint enforces that
+ * the three are populated together or not at all, so callers can rely on
+ * `hasBuilderIdentity()` to decide whether real grants are reachable.
+ */
+
+function getSQL() {
+  return getSql();
+}
+
+type DbRows = Array<Record<string, unknown>>;
+
+export type OauthClientRow = {
+  client_id: string;
+  application_id: string | null;
+  display_name: string;
+  app_url: string;
+  owner_address: string;
+  grantee_address: string | null;
+  builder_id: string | null;
+  public_key: string | null;
+  webhook_url: string | null;
+  redirect_uris: string[];
+  registered_at: string;
+  updated_at: string;
+};
+
+export type OauthClientInput = {
+  clientId: string;
+  applicationId?: string | null;
+  displayName: string;
+  appUrl: string;
+  ownerAddress: string;
+  granteeAddress?: string | null;
+  builderId?: string | null;
+  publicKey?: string | null;
+  webhookUrl?: string | null;
+  redirectUris?: string[];
+};
+
+function rowToRecord(row: Record<string, unknown>): OauthClientRow {
+  return {
+    client_id: row.client_id as string,
+    application_id: (row.application_id as string | null) ?? null,
+    display_name: row.display_name as string,
+    app_url: row.app_url as string,
+    owner_address: row.owner_address as string,
+    grantee_address: (row.grantee_address as string | null) ?? null,
+    builder_id: (row.builder_id as string | null) ?? null,
+    public_key: (row.public_key as string | null) ?? null,
+    webhook_url: (row.webhook_url as string | null) ?? null,
+    redirect_uris: Array.isArray(row.redirect_uris)
+      ? (row.redirect_uris as string[])
+      : [],
+    registered_at: new Date(row.registered_at as string).toISOString(),
+    updated_at: new Date(row.updated_at as string).toISOString(),
+  };
+}
+
+/** True iff the client has the builder triple populated and real grants are available. */
+export function hasBuilderIdentity(client: OauthClientRow): boolean {
+  return (
+    client.grantee_address !== null &&
+    client.builder_id !== null &&
+    client.public_key !== null
+  );
+}
+
+export async function findOauthClientById(
+  clientId: string,
+): Promise<OauthClientRow | null> {
+  const sql = getSQL();
+  const rows = (await sql`
+    SELECT * FROM oauth_clients WHERE client_id = ${clientId} LIMIT 1
+  `) as DbRows;
+  return rows.length > 0 ? rowToRecord(rows[0]) : null;
+}
+
+export async function findOauthClientsByOwner(
+  ownerAddress: string,
+): Promise<OauthClientRow[]> {
+  const sql = getSQL();
+  const rows = (await sql`
+    SELECT * FROM oauth_clients
+    WHERE owner_address = ${ownerAddress.toLowerCase()}
+    ORDER BY registered_at DESC
+  `) as DbRows;
+  return rows.map(rowToRecord);
+}
+
+export async function listOauthClients(): Promise<OauthClientRow[]> {
+  const sql = getSQL();
+  const rows = (await sql`
+    SELECT * FROM oauth_clients ORDER BY registered_at DESC
+  `) as DbRows;
+  return rows.map(rowToRecord);
+}
+
+export async function upsertOauthClient(
+  input: OauthClientInput,
+): Promise<OauthClientRow> {
+  const sql = getSQL();
+  const redirectUrisJson = JSON.stringify(input.redirectUris ?? []);
+  const rows = (await sql`
+    INSERT INTO oauth_clients (
+      client_id, application_id, display_name, app_url, owner_address,
+      grantee_address, builder_id, public_key, webhook_url, redirect_uris
+    ) VALUES (
+      ${input.clientId},
+      ${input.applicationId ?? null},
+      ${input.displayName},
+      ${input.appUrl},
+      ${input.ownerAddress.toLowerCase()},
+      ${input.granteeAddress ?? null},
+      ${input.builderId ?? null},
+      ${input.publicKey ?? null},
+      ${input.webhookUrl ?? null},
+      ${redirectUrisJson}::jsonb
+    )
+    ON CONFLICT (client_id) DO UPDATE SET
+      application_id = EXCLUDED.application_id,
+      display_name   = EXCLUDED.display_name,
+      app_url        = EXCLUDED.app_url,
+      owner_address  = EXCLUDED.owner_address,
+      grantee_address = EXCLUDED.grantee_address,
+      builder_id     = EXCLUDED.builder_id,
+      public_key     = EXCLUDED.public_key,
+      webhook_url    = EXCLUDED.webhook_url,
+      redirect_uris  = EXCLUDED.redirect_uris,
+      updated_at     = now()
+    RETURNING *
+  `) as DbRows;
+  return rowToRecord(rows[0]);
+}
+
+export async function deleteOauthClient(clientId: string): Promise<boolean> {
+  const sql = getSQL();
+  const rows = (await sql`
+    DELETE FROM oauth_clients WHERE client_id = ${clientId} RETURNING client_id
+  `) as DbRows;
+  return rows.length > 0;
+}
+
+/**
+ * Attach builder identity to an existing client. Used by the admin
+ * register-builder flow to upgrade an identity-only client to a
+ * data-capable one.
+ */
+export async function attachBuilderToClient(
+  clientId: string,
+  builder: {
+    granteeAddress: string;
+    builderId: string;
+    publicKey: string;
+  },
+): Promise<OauthClientRow | null> {
+  const sql = getSQL();
+  const rows = (await sql`
+    UPDATE oauth_clients SET
+      grantee_address = ${builder.granteeAddress.toLowerCase()},
+      builder_id      = ${builder.builderId},
+      public_key      = ${builder.publicKey},
+      updated_at      = now()
+    WHERE client_id = ${clientId}
+    RETURNING *
+  `) as DbRows;
+  return rows.length > 0 ? rowToRecord(rows[0]) : null;
+}


### PR DESCRIPTION
Stacked on PR #112. Targets that branch so the integration lands as part of the OIDC slice.

## Summary

When a user approves an account-action with `execution_mode === "embedded_wallet_account_hosted"`, account.vana.org now mints a real on-chain grant on the user's Personal Server. Replaces the mock-only path. Also addresses the hardcoded/missing-data audit findings flagged earlier.

## What's wired

1. **`oauth_clients` registry table** (migration 007) — replaces the localStorage admin store. Builder identity (`grantee_address`, `builder_id`, `public_key`) is optional (Sign-in-with-Vana works without it) but all-or-nothing when set.
2. **Admin API** (`/api/admin/oauth-clients`) — POST upsert, GET list, DELETE; owner-auth via masterKeySignature.
3. **`executeGrantViaPersonalServer` helper** — pure function: resolves user PS + OAuth client, POSTs `<ps-url>/v1/grants` with `Bearer <control_plane_token>`.
4. **`handleActionDecision` real-grant branch** — when execution_mode is `embedded_wallet_account_hosted`, calls executor before persisting; failure aborts approval with a typed error.
5. **Consent event audit** — populates `subject_wallet_address` (primary linked wallet), `application_id` (oauth_clients.protocolPrincipal), `authorization_reference` ({grantId, granteeAddress, personalServer}). Subject wallet on denial too.
6. **`DEFAULT_ACCOUNT_ACTION_ISSUER`** reads `VANA_ACCOUNT_ISSUER` env with literal fallback.
7. **DB-backed registry** with `DEV_MEMORY_APP_CLIENT` fallback so demo flows keep working when the table is empty.

## Migration

`007_add_oauth_clients.sql` already applied to dev (`ep-red-river`) and prod (`ep-hidden-glade`) Neon branches.

## Tests

322 passed / 17 skipped (matches baseline).

## Out of scope

- Migrate device-code state from sessionStorage → DB (#20)
- Migrate passport agreement from localStorage → consent event (#21)
- Wire admin UI to use the new API (currently still writes localStorage; the API is in place)
- Action-result revocation wiring

## Test plan

- [ ] CI passes
- [ ] On account-dev: register an OAuth client with builder identity via POST /api/admin/oauth-clients
- [ ] Trigger an action request from the demo Memory App with execution_mode=embedded_wallet_account_hosted
- [ ] Approve the action — observe POST to `<user-ps>/v1/grants` succeed, `grantId` populated, `authorization_reference` set on consent event