### PR TITLE
feat(admin): persist registered apps in DB across devices

### DIFF
--- a/connect/src/app/admin/_hooks/use-admin-registration.ts
+++ b/connect/src/app/admin/_hooks/use-admin-registration.ts
@@ -2,6 +2,7 @@
 
 import type { FormEvent } from "react";
 import { useState } from "react";
+import { useAdminMasterKey } from "../_lib/use-admin-master-key";
 import { registerAdminApp } from "../_lib/register-admin-app";
 
 type AdminState = "form" | "loading" | "result" | "error";
@@ -9,6 +10,7 @@ type AdminState = "form" | "loading" | "result" | "error";
 const DEFAULT_APP_URL = "";
 
 export function useAdminRegistration() {
+  const { getSignature } = useAdminMasterKey();
   const [state, setState] = useState<AdminState>("form");
   const [appUrl, setAppUrl] = useState(DEFAULT_APP_URL);
   const [privateKey, setPrivateKey] = useState<`0x${string}` | "">("");
@@ -35,8 +37,22 @@ export function useAdminRegistration() {
     setError(null);
     setState("loading");
 
+    let masterKeySignature: string;
+    try {
+      masterKeySignature = await getSignature();
+    } catch (err) {
+      setState("error");
+      setError(
+        err instanceof Error
+          ? err.message
+          : "Could not sign master-key challenge",
+      );
+      return;
+    }
+
     const result = await registerAdminApp({
       appUrl: trimmedUrl,
+      masterKeySignature,
     });
     if (!result.ok) {
       setState("error");

--- a/connect/src/app/admin/_lib/admin-apps-storage.ts
+++ b/connect/src/app/admin/_lib/admin-apps-storage.ts
@@ -1,5 +1,21 @@
 "use client";
 
+/**
+ * Admin app registry — DB-backed via /api/admin/oauth-clients.
+ *
+ * Previously this module wrote to localStorage. That meant apps registered
+ * on one device didn't appear on another, and clearing site data hid all
+ * builders behind their on-chain registrations. Now apps survive across
+ * devices because the registry is persisted in Postgres (oauth_clients
+ * table). Auth: master-key signature is recovered server-side to derive
+ * `owner_address`; the API filters by that address.
+ *
+ * The legacy localStorage rows are migrated on first read by
+ * {@link migrateLegacyAdminApps}; callers are expected to have already
+ * obtained a master-key signature so the migration can upsert through the
+ * authenticated API.
+ */
+
 export type RegisteredAdminApp = {
   id: string;
   name: string;
@@ -9,84 +25,173 @@ export type RegisteredAdminApp = {
   ownerAddress?: string;
 };
 
-const ADMIN_APPS_STORAGE_KEY = "vana.connect.admin.apps";
+const LEGACY_LOCAL_STORAGE_KEY = "vana.connect.admin.apps";
+const MIGRATION_FLAG_KEY = "vana.connect.admin.apps.migrated_at";
 
-export function readRegisteredAdminApps(): RegisteredAdminApp[] {
-  if (typeof window === "undefined") {
-    return [];
-  }
+type ApiClient = {
+  client_id: string;
+  application_id: string | null;
+  display_name: string;
+  app_url: string;
+  owner_address: string;
+  grantee_address: string | null;
+  builder_id: string | null;
+  public_key: string | null;
+  webhook_url: string | null;
+  redirect_uris: string[];
+  registered_at: string;
+  updated_at: string;
+};
 
+function rowToApp(row: ApiClient): RegisteredAdminApp {
+  return {
+    id: row.client_id,
+    name: row.display_name,
+    url: row.app_url,
+    createdAt: row.registered_at,
+    builderId: row.builder_id ?? undefined,
+    ownerAddress: row.owner_address,
+  };
+}
+
+function readLegacyApps(): RegisteredAdminApp[] {
+  if (typeof window === "undefined") return [];
   try {
-    const raw = window.localStorage.getItem(ADMIN_APPS_STORAGE_KEY);
-    if (!raw) {
-      return [];
-    }
-
+    const raw = window.localStorage.getItem(LEGACY_LOCAL_STORAGE_KEY);
+    if (!raw) return [];
     const parsed = JSON.parse(raw);
-    if (!Array.isArray(parsed)) {
-      return [];
-    }
-
+    if (!Array.isArray(parsed)) return [];
     return parsed.filter(isRegisteredAdminApp);
   } catch {
     return [];
   }
 }
 
-export function saveRegisteredAdminApp(app: RegisteredAdminApp): void {
-  if (typeof window === "undefined") {
-    return;
-  }
-
-  const current = readRegisteredAdminApps().filter(
-    (existing) => normalizeUrl(existing.url) !== normalizeUrl(app.url),
-  );
-  const next = [app, ...current];
-  window.localStorage.setItem(ADMIN_APPS_STORAGE_KEY, JSON.stringify(next));
-}
-
-export function deleteRegisteredAdminApp(appId: string): void {
-  if (typeof window === "undefined") {
-    return;
-  }
-
-  const next = readRegisteredAdminApps().filter((app) => app.id !== appId);
-  window.localStorage.setItem(ADMIN_APPS_STORAGE_KEY, JSON.stringify(next));
-}
-
-function normalizeUrl(value: string): string {
-  const trimmed = value.trim();
-
+function clearLegacyApps(): void {
+  if (typeof window === "undefined") return;
   try {
-    const parsed = new URL(trimmed);
-    parsed.protocol = parsed.protocol.toLowerCase();
-    parsed.hostname = parsed.hostname.toLowerCase();
-    parsed.hash = "";
-
-    if (
-      (parsed.protocol === "https:" && parsed.port === "443") ||
-      (parsed.protocol === "http:" && parsed.port === "80")
-    ) {
-      parsed.port = "";
-    }
-
-    parsed.pathname = parsed.pathname.replace(/\/+$/g, "") || "/";
-    return parsed.toString();
+    window.localStorage.removeItem(LEGACY_LOCAL_STORAGE_KEY);
+    window.localStorage.setItem(MIGRATION_FLAG_KEY, new Date().toISOString());
   } catch {
-    return trimmed.toLowerCase();
+    // ignore
   }
+}
+
+export async function listAdminApps(
+  masterKeySignature: string,
+): Promise<RegisteredAdminApp[]> {
+  const res = await fetch("/api/admin/oauth-clients", {
+    headers: { Authorization: `Bearer ${masterKeySignature}` },
+    cache: "no-store",
+  });
+  if (!res.ok) {
+    throw new Error(`Failed to load admin apps: ${res.status}`);
+  }
+  const json = (await res.json()) as { data?: ApiClient[] };
+  return (json.data ?? []).map(rowToApp);
+}
+
+export async function saveAdminApp(
+  masterKeySignature: string,
+  app: {
+    clientId: string;
+    name: string;
+    url: string;
+    builderId?: string;
+    granteeAddress?: string;
+    publicKey?: string;
+    redirectUris?: string[];
+  },
+): Promise<RegisteredAdminApp> {
+  const res = await fetch("/api/admin/oauth-clients", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${masterKeySignature}`,
+    },
+    body: JSON.stringify({
+      clientId: app.clientId,
+      displayName: app.name,
+      appUrl: app.url,
+      builderId: app.builderId,
+      granteeAddress: app.granteeAddress,
+      publicKey: app.publicKey,
+      redirectUris: app.redirectUris ?? [],
+    }),
+  });
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}));
+    throw new Error(
+      (body as { error?: { message?: string } }).error?.message ??
+        `Failed to save app: ${res.status}`,
+    );
+  }
+  const row = (await res.json()) as ApiClient;
+  return rowToApp(row);
+}
+
+export async function deleteAdminApp(
+  masterKeySignature: string,
+  clientId: string,
+): Promise<void> {
+  const res = await fetch(
+    `/api/admin/oauth-clients/${encodeURIComponent(clientId)}`,
+    {
+      method: "DELETE",
+      headers: { Authorization: `Bearer ${masterKeySignature}` },
+    },
+  );
+  if (!res.ok && res.status !== 404) {
+    throw new Error(`Failed to delete app: ${res.status}`);
+  }
+}
+
+/**
+ * Best-effort migration of any localStorage-only admin apps into the DB.
+ * Runs once per browser (gated by a flag) and silently skips on errors so
+ * migration failures never block the page. Legacy entries lacking a stable
+ * `id`/`url` pair are dropped.
+ */
+export async function migrateLegacyAdminApps(
+  masterKeySignature: string,
+): Promise<{ migrated: number }> {
+  if (typeof window === "undefined") return { migrated: 0 };
+  if (window.localStorage.getItem(MIGRATION_FLAG_KEY)) return { migrated: 0 };
+
+  const legacy = readLegacyApps();
+  if (legacy.length === 0) {
+    clearLegacyApps();
+    return { migrated: 0 };
+  }
+
+  let migrated = 0;
+  for (const app of legacy) {
+    try {
+      await saveAdminApp(masterKeySignature, {
+        clientId: app.id,
+        name: app.name,
+        url: app.url,
+        builderId: app.builderId,
+        granteeAddress: app.ownerAddress,
+      });
+      migrated += 1;
+    } catch {
+      // Skip rows the API rejects (e.g. missing builder data); they'll need
+      // to be re-registered manually. Don't block the migration on partial
+      // failure.
+    }
+  }
+  clearLegacyApps();
+  return { migrated };
 }
 
 function isRegisteredAdminApp(value: unknown): value is RegisteredAdminApp {
-  if (typeof value !== "object" || value === null) {
-    return false;
-  }
-
-  const record = value as Record<string, unknown>;
+  if (typeof value !== "object" || value === null) return false;
+  const r = value as Record<string, unknown>;
   return (
-    typeof record.id === "string" &&
-    typeof record.name === "string" &&
-    typeof record.url === "string" &&
-    typeof record.createdAt === "string"
+    typeof r.id === "string" &&
+    typeof r.name === "string" &&
+    typeof r.url === "string" &&
+    typeof r.createdAt === "string"
   );
 }

--- a/connect/src/app/admin/_lib/register-admin-app.ts
+++ b/connect/src/app/admin/_lib/register-admin-app.ts
@@ -1,4 +1,4 @@
-import { saveRegisteredAdminApp } from "./admin-apps-storage";
+import { saveAdminApp } from "./admin-apps-storage";
 import type { RegisterBuilderErrorCode } from "./register-builder";
 import { registerBuilder } from "./register-builder";
 import { resolveRegisteredAppName } from "./resolve-registered-app-name";
@@ -6,7 +6,7 @@ import { resolveRegisteredAppName } from "./resolve-registered-app-name";
 type RegisterAdminAppFailure = {
   ok: false;
   error: {
-    code: RegisterBuilderErrorCode;
+    code: RegisterBuilderErrorCode | "PERSISTENCE_ERROR";
     message: string;
   };
 };
@@ -17,6 +17,7 @@ type RegisterAdminAppSuccess = {
     privateKey: `0x${string}`;
     builderId: string;
     ownerAddress: string;
+    publicKey: string;
   };
 };
 
@@ -26,8 +27,16 @@ export type RegisterAdminAppResult =
 
 export async function registerAdminApp({
   appUrl,
+  masterKeySignature,
 }: {
   appUrl: string;
+  /**
+   * Master-key signature ("vana-master-key-v1" personal_sign) — used to
+   * authenticate the upsert into the oauth_clients registry. The recovered
+   * wallet becomes the registry's `owner_address`. Without this we'd write
+   * to localStorage only, which lost apps across devices and clearings.
+   */
+  masterKeySignature: string;
 }): Promise<RegisterAdminAppResult> {
   const [registerResult, appName] = await Promise.all([
     registerBuilder(appUrl),
@@ -38,14 +47,30 @@ export async function registerAdminApp({
     return registerResult;
   }
 
-  saveRegisteredAdminApp({
-    id: crypto.randomUUID(),
-    name: appName,
-    url: appUrl,
-    createdAt: new Date().toISOString(),
-    builderId: registerResult.data.builderId,
-    ownerAddress: registerResult.data.ownerAddress,
-  });
+  try {
+    await saveAdminApp(masterKeySignature, {
+      // Use the on-chain builderId as the OIDC client_id by default. Apps
+      // that need a custom OAuth client_id (e.g. the dev fixture
+      // `memory-app-dev`) can be upserted later via the admin API directly.
+      clientId: registerResult.data.builderId,
+      name: appName,
+      url: appUrl,
+      builderId: registerResult.data.builderId,
+      granteeAddress: registerResult.data.ownerAddress,
+      publicKey: registerResult.data.publicKey,
+    });
+  } catch (err) {
+    return {
+      ok: false,
+      error: {
+        code: "PERSISTENCE_ERROR",
+        message:
+          err instanceof Error
+            ? err.message
+            : "Failed to persist registered app",
+      },
+    };
+  }
 
   return registerResult;
 }

--- a/connect/src/app/admin/_lib/register-builder.ts
+++ b/connect/src/app/admin/_lib/register-builder.ts
@@ -31,6 +31,7 @@ type RegisterBuilderSuccess = {
     privateKey: Hex;
     builderId: string;
     ownerAddress: string;
+    publicKey: string;
   };
 };
 
@@ -91,6 +92,7 @@ export async function registerBuilder(
           privateKey,
           builderId: data.builderId ?? "",
           ownerAddress,
+          publicKey,
         },
       };
     }

--- a/connect/src/app/admin/_lib/use-admin-master-key.ts
+++ b/connect/src/app/admin/_lib/use-admin-master-key.ts
@@ -1,0 +1,48 @@
+"use client";
+
+import { useSignMessage, useWallets } from "@privy-io/react-auth";
+import { useCallback, useRef } from "react";
+
+const MASTER_KEY_MESSAGE = "vana-master-key-v1";
+
+/**
+ * Returns a getter that lazily produces the master-key signature for the
+ * current Privy embedded wallet, caching it for the session. Same shape as
+ * the `getSignature` closure in `app/server/use-server.ts` — admin and
+ * server-provisioning flows share one signature so the user is never
+ * prompted twice in a session.
+ */
+export function useAdminMasterKey() {
+  const { signMessage } = useSignMessage();
+  const { wallets } = useWallets();
+  const signatureRef = useRef<string | null>(null);
+
+  const embeddedWalletAddress = (() => {
+    for (const wallet of wallets) {
+      if (
+        wallet.walletClientType === "privy" ||
+        wallet.walletClientType === "privy-v2"
+      ) {
+        if (typeof wallet.address === "string" && wallet.address.length > 0) {
+          return wallet.address;
+        }
+      }
+    }
+    return null;
+  })();
+
+  const getSignature = useCallback(async (): Promise<string> => {
+    if (signatureRef.current) return signatureRef.current;
+    const { signature } = await signMessage(
+      { message: MASTER_KEY_MESSAGE },
+      {
+        uiOptions: { showWalletUIs: false },
+        address: embeddedWalletAddress ?? undefined,
+      },
+    );
+    signatureRef.current = signature;
+    return signature;
+  }, [signMessage, embeddedWalletAddress]);
+
+  return { getSignature, embeddedWalletAddress };
+}

--- a/connect/src/app/admin/apps/page.tsx
+++ b/connect/src/app/admin/apps/page.tsx
@@ -1,63 +1,89 @@
 "use client";
 
 import { ArrowUpRightIcon, BoxIcon } from "lucide-react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { PagePanel } from "@/app/_components/page-panel";
 import { PageShell } from "@/app/_components/page-shell";
 import { SettingsConfirmAction } from "@/components/elements/confirm-action";
 import { PageHeader } from "@/components/elements/page-header";
+import { Spinner } from "@/components/elements/spinner";
 import { Text } from "@/components/typography/text";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { AdminFooterLinks } from "../_components/admin-footer-links";
 import { AdminHeaderLinks } from "../_components/admin-header-links";
 import {
-  deleteRegisteredAdminApp,
+  deleteAdminApp,
+  listAdminApps,
+  migrateLegacyAdminApps,
   type RegisteredAdminApp,
-  readRegisteredAdminApps,
 } from "../_lib/admin-apps-storage";
+import { useAdminMasterKey } from "../_lib/use-admin-master-key";
 import { resolveAdminAppsPageUiDebugState } from "./apps-page.ui-debug";
 
 export default function AdminAppsPage() {
-  // UI debug quick usage (dev only):
-  // - /admin/apps?appsDebug=1&appsScenario=empty
-  // - /admin/apps?appsDebug=1&appsScenario=seven
-  // - No appsDebug/appsScenario => real account state (no debug override).
-  const [apps, setApps] = useState(
-    () =>
-      resolveAdminAppsPageUiDebugState({
-        apps: readRegisteredAdminApps(),
-      }).apps,
+  const { getSignature, embeddedWalletAddress } = useAdminMasterKey();
+  const [apps, setApps] = useState<RegisteredAdminApp[]>([]);
+  const [status, setStatus] = useState<"loading" | "ready" | "error">(
+    "loading",
   );
+  const [error, setError] = useState<string | null>(null);
 
-  function handleDelete(app: RegisteredAdminApp) {
-    deleteRegisteredAdminApp(app.id);
-    setApps((current) => current.filter((entry) => entry.id !== app.id));
+  useEffect(() => {
+    if (!embeddedWalletAddress) return;
+    let cancelled = false;
+    void (async () => {
+      try {
+        const sig = await getSignature();
+        // Best-effort migration of any legacy localStorage entries.
+        await migrateLegacyAdminApps(sig).catch(() => undefined);
+        const rows = await listAdminApps(sig);
+        if (cancelled) return;
+        // UI debug overrides (?appsDebug=1&appsScenario=...) still apply so
+        // existing manual QA harnesses keep working.
+        const resolved = resolveAdminAppsPageUiDebugState({ apps: rows }).apps;
+        setApps(resolved);
+        setStatus("ready");
+      } catch (err) {
+        if (cancelled) return;
+        setError(err instanceof Error ? err.message : String(err));
+        setStatus("error");
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [embeddedWalletAddress, getSignature]);
+
+  async function handleDelete(app: RegisteredAdminApp) {
+    try {
+      const sig = await getSignature();
+      await deleteAdminApp(sig, app.id);
+      setApps((current) => current.filter((entry) => entry.id !== app.id));
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    }
   }
 
   return (
     <PageShell actions={["dataConnect", "logout"]}>
       <PagePanel footer={<AdminFooterLinks />}>
         <AdminHeaderLinks showYourApps={false} />
-        {/* purposely not space-y-small to avoid extra space between list and button; header to list is actually -small via pt-gap on the list. */}
         <div className="flex flex-1 flex-col space-y-gap">
-          <PageHeader
-            showVanaLogotype
-            heading="Your apps"
-            color="iris"
-            // description={
-            //   <Text>
-            //     {apps.length === 0
-            //       ? "Your registered apps will appear here."
-            //       : "Your registered apps."}
-            //   </Text>
-            // }
-          />
+          <PageHeader showVanaLogotype heading="Your apps" color="iris" />
 
-          {/* -mx-1.5 */}
           <div className="flex min-h-0 flex-1 flex-col space-y-gap pt-gap">
             <div className="rounded-button border flex-1">
-              {apps.length === 0 ? (
+              {status === "loading" ? (
+                <Text intent="small" muted withIcon className="p-gap">
+                  <Spinner className="size-[1.1em]" />
+                  Loading apps…
+                </Text>
+              ) : status === "error" ? (
+                <Text intent="small" color="destructive" className="p-gap">
+                  {error ?? "Could not load apps."}
+                </Text>
+              ) : apps.length === 0 ? (
                 <Text intent="small" muted withIcon className="p-gap">
                   <BoxIcon className="size-[1.25em]" />
                   No apps registered yet.
@@ -108,7 +134,7 @@ export default function AdminAppsPage() {
                         title={`Delete ${app.name}?`}
                         description="This only removes the app from your account list so you can register it again later."
                         actionLabel="Delete app"
-                        onAction={() => handleDelete(app)}
+                        onAction={() => void handleDelete(app)}
                         trigger={
                           <Button
                             type="button"


### PR DESCRIPTION
Switches the admin /admin/apps list from localStorage to /api/admin/oauth-clients (the DB-backed registry from PR #124).

## Why

Apps registered on one device didn't appear on another. Clearing site data hid all builders behind their (still-existing) on-chain registrations. No recovery if the browser was reset.

## Changes

- New shared hook `useAdminMasterKey` — same Privy embedded-wallet sign pattern as use-server.ts, cached per session.
- `admin-apps-storage.ts` rewritten: async list/save/delete via `/api/admin/oauth-clients` with master-key signature for owner-auth.
- `migrateLegacyAdminApps` — best-effort one-time copy of any localStorage rows into the DB on first authenticated load. Migration flag in localStorage prevents re-runs.
- `register-admin-app` and `use-admin-registration` thread the master-key sig through registration so the new builder lands in the DB.
- `register-builder` returns `publicKey` so it can be persisted alongside builder identity.
- `apps/page.tsx` becomes async with loading/error states; UI debug overrides still work.

## Targets

`develop` only. `account-dev.vana.org` will rebuild.

## Test plan

- [ ] On account-dev: hard-refresh /admin/apps, see existing localStorage apps migrate into the list.
- [ ] Register a fresh app via /admin → appears in /admin/apps without page reload.
- [ ] In another browser/incognito, log in as the same wallet → see the same apps.
- [ ] Delete an app → row gone in DB (verifiable via API).