### PR TITLE
fix(admin): never auto-clear localStorage; explicit migrate button

### DIFF
--- a/connect/src/app/admin/_lib/admin-apps-storage.ts
+++ b/connect/src/app/admin/_lib/admin-apps-storage.ts
@@ -26,7 +26,11 @@ export type RegisteredAdminApp = {
 };
 
 const LEGACY_LOCAL_STORAGE_KEY = "vana.connect.admin.apps";
-const MIGRATION_FLAG_KEY = "vana.connect.admin.apps.migrated_at";
+// Bump this version when the migration logic changes so previously-marked
+// browsers retry the import (otherwise a silent failure leaves apps stuck
+// in localStorage forever).
+const MIGRATION_FLAG_KEY = "vana.connect.admin.apps.migrated_at.v2";
+const LEGACY_MIGRATION_FLAG_KEYS = ["vana.connect.admin.apps.migrated_at"];
 
 type ApiClient = {
   client_id: string;
@@ -71,6 +75,9 @@ function clearLegacyApps(): void {
   if (typeof window === "undefined") return;
   try {
     window.localStorage.removeItem(LEGACY_LOCAL_STORAGE_KEY);
+    for (const stale of LEGACY_MIGRATION_FLAG_KEYS) {
+      window.localStorage.removeItem(stale);
+    }
     window.localStorage.setItem(MIGRATION_FLAG_KEY, new Date().toISOString());
   } catch {
     // ignore
@@ -146,43 +153,82 @@ export async function deleteAdminApp(
   }
 }
 
+export type LegacyMigrationResult = {
+  legacyCount: number;
+  migrated: number;
+  failed: number;
+  /** True iff every legacy row was successfully persisted; safe to clear localStorage. */
+  complete: boolean;
+};
+
+/** List legacy entries without mutating anything. */
+export function readLegacyAdminApps(): RegisteredAdminApp[] {
+  return readLegacyApps();
+}
+
 /**
- * Best-effort migration of any localStorage-only admin apps into the DB.
- * Runs once per browser (gated by a flag) and silently skips on errors so
- * migration failures never block the page. Legacy entries lacking a stable
- * `id`/`url` pair are dropped.
+ * Migration of localStorage-only admin apps into the DB.
+ *
+ * SAFETY: never destroys legacy localStorage entries unless every entry
+ * was successfully persisted. Partial failures keep all rows in
+ * localStorage so the user can retry or re-register manually. Migration
+ * flag is set only on full success; until then, callers can re-trigger.
+ *
+ * Identity-only entries (legacy rows without the full builder triple)
+ * are persisted as such — the gateway has the on-chain builder either
+ * way, the row just won't carry builder identity until re-registered.
  */
 export async function migrateLegacyAdminApps(
   masterKeySignature: string,
-): Promise<{ migrated: number }> {
-  if (typeof window === "undefined") return { migrated: 0 };
-  if (window.localStorage.getItem(MIGRATION_FLAG_KEY)) return { migrated: 0 };
+): Promise<LegacyMigrationResult> {
+  if (typeof window === "undefined") {
+    return { legacyCount: 0, migrated: 0, failed: 0, complete: true };
+  }
+  if (window.localStorage.getItem(MIGRATION_FLAG_KEY)) {
+    return { legacyCount: 0, migrated: 0, failed: 0, complete: true };
+  }
 
   const legacy = readLegacyApps();
   if (legacy.length === 0) {
-    clearLegacyApps();
-    return { migrated: 0 };
+    // Nothing to migrate — flag and clear stale flags, but don't touch the
+    // localStorage app key (it's already empty).
+    if (typeof window !== "undefined") {
+      try {
+        for (const stale of LEGACY_MIGRATION_FLAG_KEYS) {
+          window.localStorage.removeItem(stale);
+        }
+        window.localStorage.setItem(
+          MIGRATION_FLAG_KEY,
+          new Date().toISOString(),
+        );
+      } catch {
+        // ignore
+      }
+    }
+    return { legacyCount: 0, migrated: 0, failed: 0, complete: true };
   }
 
   let migrated = 0;
+  let failed = 0;
   for (const app of legacy) {
     try {
       await saveAdminApp(masterKeySignature, {
         clientId: app.id,
         name: app.name,
         url: app.url,
-        builderId: app.builderId,
-        granteeAddress: app.ownerAddress,
       });
       migrated += 1;
     } catch {
-      // Skip rows the API rejects (e.g. missing builder data); they'll need
-      // to be re-registered manually. Don't block the migration on partial
-      // failure.
+      failed += 1;
     }
   }
-  clearLegacyApps();
-  return { migrated };
+
+  const complete = failed === 0;
+  if (complete) {
+    // Only safe to drop localStorage when every row is in the DB.
+    clearLegacyApps();
+  }
+  return { legacyCount: legacy.length, migrated, failed, complete };
 }
 
 function isRegisteredAdminApp(value: unknown): value is RegisteredAdminApp {

--- a/connect/src/app/admin/apps/page.tsx
+++ b/connect/src/app/admin/apps/page.tsx
@@ -16,6 +16,7 @@ import {
   deleteAdminApp,
   listAdminApps,
   migrateLegacyAdminApps,
+  readLegacyAdminApps,
   type RegisteredAdminApp,
 } from "../_lib/admin-apps-storage";
 import { useAdminMasterKey } from "../_lib/use-admin-master-key";
@@ -28,19 +29,24 @@ export default function AdminAppsPage() {
     "loading",
   );
   const [error, setError] = useState<string | null>(null);
+  const [legacyApps, setLegacyApps] = useState<RegisteredAdminApp[]>([]);
+  const [migrationBusy, setMigrationBusy] = useState(false);
+  const [migrationMessage, setMigrationMessage] = useState<string | null>(null);
 
   useEffect(() => {
     if (!embeddedWalletAddress) return;
     let cancelled = false;
     void (async () => {
       try {
+        // Surface any legacy localStorage entries so the user can choose to
+        // migrate them (rather than running the destructive cleanup
+        // automatically). NEVER auto-clears localStorage.
+        if (!cancelled) {
+          setLegacyApps(readLegacyAdminApps());
+        }
         const sig = await getSignature();
-        // Best-effort migration of any legacy localStorage entries.
-        await migrateLegacyAdminApps(sig).catch(() => undefined);
         const rows = await listAdminApps(sig);
         if (cancelled) return;
-        // UI debug overrides (?appsDebug=1&appsScenario=...) still apply so
-        // existing manual QA harnesses keep working.
         const resolved = resolveAdminAppsPageUiDebugState({ apps: rows }).apps;
         setApps(resolved);
         setStatus("ready");
@@ -65,12 +71,66 @@ export default function AdminAppsPage() {
     }
   }
 
+  async function handleMigrate() {
+    setMigrationBusy(true);
+    setMigrationMessage(null);
+    try {
+      const sig = await getSignature();
+      const result = await migrateLegacyAdminApps(sig);
+      // Refresh both lists from source-of-truth.
+      setLegacyApps(readLegacyAdminApps());
+      const rows = await listAdminApps(sig);
+      setApps(resolveAdminAppsPageUiDebugState({ apps: rows }).apps);
+      if (result.complete && result.migrated > 0) {
+        setMigrationMessage(`Migrated ${result.migrated} app(s).`);
+      } else if (result.failed > 0) {
+        setMigrationMessage(
+          `Migrated ${result.migrated} of ${result.legacyCount}. ${result.failed} failed and remain on this device.`,
+        );
+      }
+    } catch (err) {
+      setMigrationMessage(
+        err instanceof Error ? err.message : "Migration failed.",
+      );
+    } finally {
+      setMigrationBusy(false);
+    }
+  }
+
   return (
     <PageShell actions={["dataConnect", "logout"]}>
       <PagePanel footer={<AdminFooterLinks />}>
         <AdminHeaderLinks showYourApps={false} />
         <div className="flex flex-1 flex-col space-y-gap">
           <PageHeader showVanaLogotype heading="Your apps" color="iris" />
+
+          {legacyApps.length > 0 && (
+            <div
+              className={cn(
+                "rounded-button border bg-muted/40",
+                "px-3 py-2.5 flex items-center gap-3",
+              )}
+            >
+              <Text intent="small" muted className="flex-1">
+                {legacyApps.length} app(s) saved on this device. Move them to
+                your account so they appear on every device.
+              </Text>
+              <Button
+                type="button"
+                variant="outline"
+                size="xs"
+                disabled={migrationBusy}
+                onClick={() => void handleMigrate()}
+              >
+                {migrationBusy ? "Moving…" : "Move to account"}
+              </Button>
+            </div>
+          )}
+          {migrationMessage && (
+            <Text intent="fine" muted>
+              {migrationMessage}
+            </Text>
+          )}
 
           <div className="flex min-h-0 flex-1 flex-col space-y-gap pt-gap">
             <div className="rounded-button border flex-1">


### PR DESCRIPTION
Follow-up to PR #126.

## Why

PR #126's auto-migration on first /admin/apps load called `clearLegacyApps()` unconditionally after the migration loop, even if every save 400'd (for example because legacy rows had partial builder identity that violated the all-or-nothing DB CHECK constraint). Result: legacy apps were destroyed without making it into the DB. Already happened to one user.

## Changes

- **No more auto-migration on page load.** `/admin/apps` only displays the existing localStorage entries via `readLegacyAdminApps()` and surfaces a banner: "N apps saved on this device. Move them to your account so they appear on every device." with a "Move to account" button.
- **Migration is non-destructive on partial failure.** `migrateLegacyAdminApps` now returns `{ legacyCount, migrated, failed, complete }` and only clears localStorage when `complete === true` (every row persisted successfully). If any save fails, all rows stay in localStorage so the user can retry.
- **Migration flag bumped to v2.** Browsers that ran the broken v1 migration will be re-evaluated under the safe policy. (Cleared rows can't be recovered, but no further loss occurs.)
- **Identity-only migration.** Legacy rows lack `publicKey` (it wasn't captured pre-PR-#126), so they can't carry the full builder triple. They migrate as identity-only entries; the on-chain builder still exists if the user wants to re-bind.

## Tested

- Typecheck clean.
- 322 tests pass.

## Targets

`develop` only.