### PR TITLE
fix(admin): drop auto-migration; legacy localStorage shown read-only with explicit dismiss

### DIFF
--- a/connect/src/app/admin/_lib/admin-apps-storage.test.ts
+++ b/connect/src/app/admin/_lib/admin-apps-storage.test.ts
@@ -1,0 +1,167 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const LEGACY_LOCAL_STORAGE_KEY = "vana.connect.admin.apps";
+
+class MemoryLocalStorage {
+  private store = new Map<string, string>();
+  getItem(key: string): string | null {
+    return this.store.has(key) ? (this.store.get(key) as string) : null;
+  }
+  setItem(key: string, value: string): void {
+    this.store.set(key, value);
+  }
+  removeItem(key: string): void {
+    this.store.delete(key);
+  }
+  clear(): void {
+    this.store.clear();
+  }
+  get length(): number {
+    return this.store.size;
+  }
+  key(index: number): string | null {
+    return [...this.store.keys()][index] ?? null;
+  }
+}
+
+function setupWindow(): MemoryLocalStorage {
+  const memory = new MemoryLocalStorage();
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: { localStorage: memory },
+  });
+  return memory;
+}
+
+function tearDownWindow(): void {
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: undefined,
+  });
+}
+
+describe("admin-apps-storage", () => {
+  let storage: MemoryLocalStorage;
+
+  beforeEach(() => {
+    storage = setupWindow();
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    tearDownWindow();
+  });
+
+  describe("readLegacyAdminApps", () => {
+    it("returns rows from localStorage without mutating", async () => {
+      const sample = [
+        {
+          id: "uuid-1",
+          name: "Localhost",
+          url: "http://localhost:3001",
+          createdAt: "2026-04-01T00:00:00.000Z",
+          builderId: "0xabc",
+          ownerAddress: "0x1234567890123456789012345678901234567890",
+        },
+      ];
+      storage.setItem(LEGACY_LOCAL_STORAGE_KEY, JSON.stringify(sample));
+
+      const mod = await import("./admin-apps-storage");
+      const got = mod.readLegacyAdminApps();
+      expect(got).toEqual(sample);
+      // Mutation guarantee: localStorage untouched.
+      expect(storage.getItem(LEGACY_LOCAL_STORAGE_KEY)).toBe(
+        JSON.stringify(sample),
+      );
+    });
+
+    it("returns empty for missing localStorage key without writing anything", async () => {
+      const mod = await import("./admin-apps-storage");
+      const got = mod.readLegacyAdminApps();
+      expect(got).toEqual([]);
+      expect(storage.length).toBe(0);
+    });
+
+    it("returns empty when JSON is malformed and does not throw", async () => {
+      storage.setItem(LEGACY_LOCAL_STORAGE_KEY, "{not json");
+      const mod = await import("./admin-apps-storage");
+      expect(mod.readLegacyAdminApps()).toEqual([]);
+      // Malformed entry left in place so the user can recover.
+      expect(storage.getItem(LEGACY_LOCAL_STORAGE_KEY)).toBe("{not json");
+    });
+
+    it("filters out non-RegisteredAdminApp shapes from a mixed array", async () => {
+      const mixed = [
+        {
+          id: "good",
+          name: "Good",
+          url: "http://example.com",
+          createdAt: "2026-04-01T00:00:00.000Z",
+        },
+        { id: "bad-no-url", name: "Bad" },
+        "not-an-object",
+        null,
+      ];
+      storage.setItem(LEGACY_LOCAL_STORAGE_KEY, JSON.stringify(mixed));
+      const mod = await import("./admin-apps-storage");
+      const got = mod.readLegacyAdminApps();
+      expect(got).toHaveLength(1);
+      expect(got[0].id).toBe("good");
+    });
+  });
+
+  describe("dismissLegacyAdminApps", () => {
+    it("removes the legacy localStorage key when called", async () => {
+      storage.setItem(
+        LEGACY_LOCAL_STORAGE_KEY,
+        JSON.stringify([
+          {
+            id: "x",
+            name: "App",
+            url: "http://example.com",
+            createdAt: "2026-04-01T00:00:00.000Z",
+          },
+        ]),
+      );
+      const mod = await import("./admin-apps-storage");
+      mod.dismissLegacyAdminApps();
+      expect(storage.getItem(LEGACY_LOCAL_STORAGE_KEY)).toBeNull();
+    });
+
+    it("does not destroy data the caller didn't explicitly dismiss", async () => {
+      // SAFETY REGRESSION: PR #126's auto-migration cleared localStorage
+      // even when every save 400'd. dismissLegacyAdminApps replaces that
+      // path with an explicit caller-driven clear. Verify the act of
+      // *reading* legacy entries never clears them.
+      const sample = [
+        {
+          id: "untouched",
+          name: "Untouched",
+          url: "http://example.com",
+          createdAt: "2026-04-01T00:00:00.000Z",
+        },
+      ];
+      storage.setItem(LEGACY_LOCAL_STORAGE_KEY, JSON.stringify(sample));
+      const mod = await import("./admin-apps-storage");
+      // Read multiple times — none should mutate.
+      mod.readLegacyAdminApps();
+      mod.readLegacyAdminApps();
+      mod.readLegacyAdminApps();
+      expect(
+        JSON.parse(storage.getItem(LEGACY_LOCAL_STORAGE_KEY) as string),
+      ).toEqual(sample);
+    });
+  });
+
+  describe("module exports", () => {
+    it("does not export migrateLegacyAdminApps", async () => {
+      // Auto-migration was removed because legacy localStorage rows lack
+      // user identity. Re-introducing this export would silently re-enable
+      // the data-loss path; the regression test catches that.
+      const mod = await import("./admin-apps-storage");
+      expect(
+        (mod as Record<string, unknown>).migrateLegacyAdminApps,
+      ).toBeUndefined();
+    });
+  });
+});

--- a/connect/src/app/admin/_lib/admin-apps-storage.ts
+++ b/connect/src/app/admin/_lib/admin-apps-storage.ts
@@ -153,82 +153,30 @@ export async function deleteAdminApp(
   }
 }
 
-export type LegacyMigrationResult = {
-  legacyCount: number;
-  migrated: number;
-  failed: number;
-  /** True iff every legacy row was successfully persisted; safe to clear localStorage. */
-  complete: boolean;
-};
-
-/** List legacy entries without mutating anything. */
+/**
+ * List legacy entries without mutating anything.
+ *
+ * NOTE on identity: legacy localStorage entries pre-date account-scoped
+ * storage. The `ownerAddress` they carry is the **builder's own
+ * freshly-generated owner address** (a throwaway keypair from the old
+ * `register-builder` flow), NOT the logged-in user's wallet. We therefore
+ * have no reliable way to attribute a legacy row to the current user, and
+ * we deliberately do NOT auto-migrate them under the current user's
+ * identity (that would let any user on a shared browser claim another
+ * user's apps). Callers should surface them as read-only "saved on this
+ * device" hints and prompt the user to explicitly re-register them.
+ */
 export function readLegacyAdminApps(): RegisteredAdminApp[] {
   return readLegacyApps();
 }
 
 /**
- * Migration of localStorage-only admin apps into the DB.
- *
- * SAFETY: never destroys legacy localStorage entries unless every entry
- * was successfully persisted. Partial failures keep all rows in
- * localStorage so the user can retry or re-register manually. Migration
- * flag is set only on full success; until then, callers can re-trigger.
- *
- * Identity-only entries (legacy rows without the full builder triple)
- * are persisted as such — the gateway has the on-chain builder either
- * way, the row just won't carry builder identity until re-registered.
+ * Manually clear the legacy localStorage entries. Only call this when the
+ * user has explicitly confirmed dismissal — there's no auto-clear path
+ * because we cannot prove ownership of the entries.
  */
-export async function migrateLegacyAdminApps(
-  masterKeySignature: string,
-): Promise<LegacyMigrationResult> {
-  if (typeof window === "undefined") {
-    return { legacyCount: 0, migrated: 0, failed: 0, complete: true };
-  }
-  if (window.localStorage.getItem(MIGRATION_FLAG_KEY)) {
-    return { legacyCount: 0, migrated: 0, failed: 0, complete: true };
-  }
-
-  const legacy = readLegacyApps();
-  if (legacy.length === 0) {
-    // Nothing to migrate — flag and clear stale flags, but don't touch the
-    // localStorage app key (it's already empty).
-    if (typeof window !== "undefined") {
-      try {
-        for (const stale of LEGACY_MIGRATION_FLAG_KEYS) {
-          window.localStorage.removeItem(stale);
-        }
-        window.localStorage.setItem(
-          MIGRATION_FLAG_KEY,
-          new Date().toISOString(),
-        );
-      } catch {
-        // ignore
-      }
-    }
-    return { legacyCount: 0, migrated: 0, failed: 0, complete: true };
-  }
-
-  let migrated = 0;
-  let failed = 0;
-  for (const app of legacy) {
-    try {
-      await saveAdminApp(masterKeySignature, {
-        clientId: app.id,
-        name: app.name,
-        url: app.url,
-      });
-      migrated += 1;
-    } catch {
-      failed += 1;
-    }
-  }
-
-  const complete = failed === 0;
-  if (complete) {
-    // Only safe to drop localStorage when every row is in the DB.
-    clearLegacyApps();
-  }
-  return { legacyCount: legacy.length, migrated, failed, complete };
+export function dismissLegacyAdminApps(): void {
+  clearLegacyApps();
 }
 
 function isRegisteredAdminApp(value: unknown): value is RegisteredAdminApp {

--- a/connect/src/app/admin/apps/page.tsx
+++ b/connect/src/app/admin/apps/page.tsx
@@ -14,8 +14,8 @@ import { AdminFooterLinks } from "../_components/admin-footer-links";
 import { AdminHeaderLinks } from "../_components/admin-header-links";
 import {
   deleteAdminApp,
+  dismissLegacyAdminApps,
   listAdminApps,
-  migrateLegacyAdminApps,
   readLegacyAdminApps,
   type RegisteredAdminApp,
 } from "../_lib/admin-apps-storage";
@@ -30,8 +30,6 @@ export default function AdminAppsPage() {
   );
   const [error, setError] = useState<string | null>(null);
   const [legacyApps, setLegacyApps] = useState<RegisteredAdminApp[]>([]);
-  const [migrationBusy, setMigrationBusy] = useState(false);
-  const [migrationMessage, setMigrationMessage] = useState<string | null>(null);
 
   useEffect(() => {
     if (!embeddedWalletAddress) return;
@@ -71,30 +69,9 @@ export default function AdminAppsPage() {
     }
   }
 
-  async function handleMigrate() {
-    setMigrationBusy(true);
-    setMigrationMessage(null);
-    try {
-      const sig = await getSignature();
-      const result = await migrateLegacyAdminApps(sig);
-      // Refresh both lists from source-of-truth.
-      setLegacyApps(readLegacyAdminApps());
-      const rows = await listAdminApps(sig);
-      setApps(resolveAdminAppsPageUiDebugState({ apps: rows }).apps);
-      if (result.complete && result.migrated > 0) {
-        setMigrationMessage(`Migrated ${result.migrated} app(s).`);
-      } else if (result.failed > 0) {
-        setMigrationMessage(
-          `Migrated ${result.migrated} of ${result.legacyCount}. ${result.failed} failed and remain on this device.`,
-        );
-      }
-    } catch (err) {
-      setMigrationMessage(
-        err instanceof Error ? err.message : "Migration failed.",
-      );
-    } finally {
-      setMigrationBusy(false);
-    }
+  function handleDismissLegacy() {
+    dismissLegacyAdminApps();
+    setLegacyApps([]);
   }
 
   return (
@@ -108,28 +85,39 @@ export default function AdminAppsPage() {
             <div
               className={cn(
                 "rounded-button border bg-muted/40",
-                "px-3 py-2.5 flex items-center gap-3",
+                "px-3 py-2.5 flex flex-col gap-2",
               )}
             >
-              <Text intent="small" muted className="flex-1">
-                {legacyApps.length} app(s) saved on this device. Move them to
-                your account so they appear on every device.
+              <Text intent="small" muted>
+                Found {legacyApps.length} app(s) saved on this device from a
+                previous version of the admin tool. We can&apos;t verify they
+                belong to your account, so they aren&apos;t shown above.
+                Re-register any you still want, or dismiss this notice.
               </Text>
-              <Button
-                type="button"
-                variant="outline"
-                size="xs"
-                disabled={migrationBusy}
-                onClick={() => void handleMigrate()}
-              >
-                {migrationBusy ? "Moving…" : "Move to account"}
-              </Button>
+              <ul className="space-y-1">
+                {legacyApps.map((app) => (
+                  <li key={app.id}>
+                    <Text intent="fine" muted withIcon truncate>
+                      <BoxIcon className="size-[1em]" />
+                      {app.name} — {app.url}
+                    </Text>
+                  </li>
+                ))}
+              </ul>
+              <div className="flex gap-2 pt-1">
+                <SettingsConfirmAction
+                  title="Dismiss device-only apps?"
+                  description="Removes the device-only entries from this browser. The on-chain builders still exist; they're just not surfaced here. You can always re-register an app to see it again."
+                  actionLabel="Dismiss"
+                  onAction={handleDismissLegacy}
+                  trigger={
+                    <Button type="button" variant="outline" size="xs">
+                      Dismiss
+                    </Button>
+                  }
+                />
+              </div>
             </div>
-          )}
-          {migrationMessage && (
-            <Text intent="fine" muted>
-              {migrationMessage}
-            </Text>
           )}
 
           <div className="flex min-h-0 flex-1 flex-col space-y-gap pt-gap">


### PR DESCRIPTION
Follow-up to #126 / #127.

## Why

Even with #127's safer migration, the legacy localStorage rows can't be safely auto-claimed under the current user's identity. The original `register-builder` flow recorded the **builder's own freshly-generated owner address** in `ownerAddress`, not the human user's wallet — so we have no way to verify which user registered an app, which means a different user logging into the same browser could inherit the previous user's apps.

## Changes

- **No migration path.** Removed `migrateLegacyAdminApps`. The banner now surfaces legacy entries read-only with their URLs visible, and offers an explicit "Dismiss" button (with confirm) for the user to drop them. The user is told to re-register any apps they still want under their account.
- **Tests added** (`admin-apps-storage.test.ts`) covering: read is non-mutating, malformed JSON survives, mixed shapes filter, dismiss clears localStorage, and a regression-test that the deleted `migrateLegacyAdminApps` export stays gone.

## Tested

- 329 tests pass (was 322; +7 new).
- Typecheck clean for touched files.

## Targets

`develop` only.