### PR TITLE
fix(actions): allow embedded_wallet_account_hosted at create-time

### DIFF
--- a/connect/src/lib/auth/account-action-routes.ts
+++ b/connect/src/lib/auth/account-action-routes.ts
@@ -208,7 +208,14 @@ export async function handleGetActionRequest(
   };
 }
 
-const SUPPORTED_EXECUTION_MODES: readonly ActionExecutionMode[] = ["mock"];
+// Create-time guard. Mirrors the relaxed approval guard in
+// {@link handleActionDecision}: `embedded_wallet_account_hosted` is now
+// supported end-to-end (real grants minted via PR #124). Result-mode is
+// still mock-only until encrypted-bundle delivery lands.
+const SUPPORTED_EXECUTION_MODES: readonly ActionExecutionMode[] = [
+  "mock",
+  "embedded_wallet_account_hosted",
+];
 const SUPPORTED_RESULT_MODES: readonly ActionResultMode[] = ["mock"];
 
 function isStringRecord(value: unknown): value is Record<string, unknown> {


### PR DESCRIPTION
PR #124 relaxed the approval guard in `handleActionDecision` but the symmetric guard in `handleCreateActionRequest` (`SUPPORTED_EXECUTION_MODES`) still rejected non-mock at request creation. Result: action requests created with `execution_mode='embedded_wallet_account_hosted'` (e.g. from the Memory App with `VANA_DEMO_ACTION_EXECUTION_MODE` set) were rejected with a 400 before they could be approved.

One-line fix: add `embedded_wallet_account_hosted` to `SUPPORTED_EXECUTION_MODES`. `SUPPORTED_RESULT_MODES` stays `['mock']` since encrypted-bundle delivery isn't implemented yet.

## Targets

`develop` only.