### PR TITLE
feat(grants): use OAuth2 client_credentials for PS auth

### DIFF
--- a/connect/package.json
+++ b/connect/package.json
@@ -29,6 +29,7 @@
     "lucide-react": "^0.562.0",
     "motion": "^12.29.2",
     "next": "16.1.6",
+    "oauth4webapi": "^3.8.6",
     "postgres": "^3.4.9",
     "radix-ui": "^1.4.3",
     "react": "19.2.3",

--- a/connect/pnpm-lock.yaml
+++ b/connect/pnpm-lock.yaml
@@ -46,6 +46,9 @@ importers:
       next:
         specifier: 16.1.6
         version: 16.1.6(@babel/core@7.29.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      oauth4webapi:
+        specifier: ^3.8.6
+        version: 3.8.6
       postgres:
         specifier: ^3.4.9
         version: 3.4.9
@@ -7390,6 +7393,12 @@ packages:
         integrity: sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==,
       }
     engines: { node: ">=18" }
+
+  oauth4webapi@3.8.6:
+    resolution:
+      {
+        integrity: sha512-iwemM91xz8nryHti2yTmg5fhyEMVOkOXwHNqbvcATjyajb5oQxCQzrNOA6uElRHuMhQQTKUyFKV9y/CNyg25BQ==,
+      }
 
   obj-multiplex@1.0.0:
     resolution:
@@ -15918,6 +15927,8 @@ snapshots:
     dependencies:
       path-key: 4.0.0
       unicorn-magic: 0.3.0
+
+  oauth4webapi@3.8.6: {}
 
   obj-multiplex@1.0.0:
     dependencies:

--- a/connect/src/app/api/account/actions/account-actions-runtime.ts
+++ b/connect/src/app/api/account/actions/account-actions-runtime.ts
@@ -223,7 +223,7 @@ export async function runActionDecision(
           return {
             serverId: server.id,
             serverUrl: server.url,
-            accessToken: server.control_plane_token,
+            controlPlaneSecret: server.control_plane_token,
           };
         },
         resolveOauthClient: async (clientId) => findOauthClientById(clientId),

--- a/connect/src/lib/auth/execute-grant-via-personal-server.test.ts
+++ b/connect/src/lib/auth/execute-grant-via-personal-server.test.ts
@@ -1,0 +1,295 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  clearAccessTokenCacheForTests,
+  executeGrantViaPersonalServer,
+  type ExecuteGrantInput,
+} from "./execute-grant-via-personal-server";
+import type { OauthClientRow } from "@/lib/db/oauth-clients";
+
+const SERVER_URL = "https://0xfake.myvana.app";
+const CONTROL_PLANE_SECRET = "vana_ps_supersecretcontrolplane";
+const ACCESS_TOKEN = "vana_ps_issuedaccesstokenfortest";
+const GRANT_ID = "0xgrant1234";
+
+function builderClient(): OauthClientRow {
+  return {
+    client_id: "memory-app-dev",
+    application_id: "memory-app",
+    display_name: "Memory App",
+    app_url: "https://memory-app.example",
+    owner_address: "0xowneraddr",
+    grantee_address: "0xbuilderaddress",
+    builder_id: "0xbuilderid",
+    public_key: "0x04abc",
+    webhook_url: null,
+    redirect_uris: [],
+    registered_at: "2026-05-01T00:00:00.000Z",
+    updated_at: "2026-05-01T00:00:00.000Z",
+  };
+}
+
+function identityOnlyClient(): OauthClientRow {
+  return {
+    ...builderClient(),
+    grantee_address: null,
+    builder_id: null,
+    public_key: null,
+  };
+}
+
+type FakeFetch = ReturnType<typeof createFakeFetch>;
+function createFakeFetch(
+  handler: (url: string, init?: RequestInit) => Response | Promise<Response>,
+) {
+  const calls: { url: string; init?: RequestInit }[] = [];
+  const fn = async (input: string | URL | Request, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : input.toString();
+    calls.push({ url, init });
+    return handler(url, init);
+  };
+  // oauth4webapi feature-detects via Symbol; assign through Object.assign
+  return Object.assign(fn as unknown as typeof fetch, { calls });
+}
+
+/**
+ * oauth4webapi sends headers as a plain object with lowercase keys; our own
+ * fetch call to /v1/grants uses TitleCase. Read both case-insensitively so
+ * test handlers can validate auth without caring which side sent the request.
+ */
+function getHeader(
+  init: RequestInit | undefined,
+  name: string,
+): string | undefined {
+  const h = init?.headers as Record<string, string> | undefined;
+  if (!h) return undefined;
+  for (const [k, v] of Object.entries(h)) {
+    if (k.toLowerCase() === name.toLowerCase()) return v;
+  }
+  return undefined;
+}
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function happyHandler(): (url: string, init?: RequestInit) => Response {
+  return (url, init) => {
+    if (url.endsWith("/oauth/token")) {
+      // Validate the request looks like a real client_credentials flow.
+      const auth = getHeader(init, "authorization") ?? "";
+      if (!auth.startsWith("Basic ")) {
+        return jsonResponse(401, { error: "invalid_client" });
+      }
+      return jsonResponse(200, {
+        access_token: ACCESS_TOKEN,
+        token_type: "Bearer",
+        expires_in: 3600,
+      });
+    }
+    if (url.endsWith("/v1/grants")) {
+      const auth = getHeader(init, "authorization") ?? "";
+      if (auth !== `Bearer ${ACCESS_TOKEN}`) {
+        return jsonResponse(401, { error: { message: "Invalid token" } });
+      }
+      return jsonResponse(201, { grantId: GRANT_ID });
+    }
+    return jsonResponse(404, { error: "unexpected url: " + url });
+  };
+}
+
+function makeInput(
+  overrides?: Partial<ExecuteGrantInput>,
+  fetchImpl?: FakeFetch,
+): ExecuteGrantInput {
+  return {
+    vanaUserId: "vana_user_test",
+    clientId: "memory-app-dev",
+    scopes: ["chatgpt.memories"],
+    expiresAt: 0,
+    nonce: 1,
+    resolvePersonalServer: async () => ({
+      serverId: "srv_test",
+      serverUrl: SERVER_URL,
+      controlPlaneSecret: CONTROL_PLANE_SECRET,
+    }),
+    resolveOauthClient: async () => builderClient(),
+    fetchImpl: fetchImpl ?? createFakeFetch(happyHandler()),
+    now: () => 1_700_000_000_000,
+    ...overrides,
+  };
+}
+
+beforeEach(() => clearAccessTokenCacheForTests());
+afterEach(() => clearAccessTokenCacheForTests());
+
+describe("executeGrantViaPersonalServer", () => {
+  it("happy path: obtains access_token, mints grant", async () => {
+    const fetchImpl = createFakeFetch(happyHandler());
+    const result = await executeGrantViaPersonalServer(
+      makeInput(undefined, fetchImpl),
+    );
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.grantId).toBe(GRANT_ID);
+      expect(result.granteeAddress).toBe("0xbuilderaddress");
+      expect(result.personalServer.serverUrl).toBe(SERVER_URL);
+    }
+    // Token endpoint hit once, grants endpoint hit once
+    const tokenCalls = fetchImpl.calls.filter((c) =>
+      c.url.endsWith("/oauth/token"),
+    );
+    const grantCalls = fetchImpl.calls.filter((c) =>
+      c.url.endsWith("/v1/grants"),
+    );
+    expect(tokenCalls).toHaveLength(1);
+    expect(grantCalls).toHaveLength(1);
+    // Body of token call is form-encoded with grant_type=client_credentials
+    const tokenBody = tokenCalls[0].init?.body?.toString() ?? "";
+    expect(tokenBody).toContain("grant_type=client_credentials");
+    // Body of grant call is JSON with the resolved granteeAddress
+    const grantBody = JSON.parse(grantCalls[0].init?.body as string);
+    expect(grantBody.granteeAddress).toBe("0xbuilderaddress");
+    expect(grantBody.scopes).toEqual(["chatgpt.memories"]);
+  });
+
+  it("caches access_token across calls (single token request)", async () => {
+    const fetchImpl = createFakeFetch(happyHandler());
+    const a = await executeGrantViaPersonalServer(
+      makeInput(undefined, fetchImpl),
+    );
+    const b = await executeGrantViaPersonalServer(
+      makeInput(undefined, fetchImpl),
+    );
+    expect(a.ok).toBe(true);
+    expect(b.ok).toBe(true);
+    const tokenCalls = fetchImpl.calls.filter((c) =>
+      c.url.endsWith("/oauth/token"),
+    );
+    expect(tokenCalls).toHaveLength(1); // single token mint, reused for both grants
+  });
+
+  it("refreshes access_token on 401 from /v1/grants", async () => {
+    let tokensIssued = 0;
+    let grantAttempts = 0;
+    const fetchImpl = createFakeFetch((url, init) => {
+      if (url.endsWith("/oauth/token")) {
+        tokensIssued += 1;
+        return jsonResponse(200, {
+          access_token: `vana_ps_token${tokensIssued}`,
+          token_type: "Bearer",
+          expires_in: 3600,
+        });
+      }
+      if (url.endsWith("/v1/grants")) {
+        grantAttempts += 1;
+        const auth = getHeader(init, "authorization") ?? "";
+        // First call (with token1) → 401, second call (with token2) → 201
+        if (auth === "Bearer vana_ps_token1") {
+          return jsonResponse(401, { error: { message: "expired" } });
+        }
+        return jsonResponse(201, { grantId: GRANT_ID });
+      }
+      return jsonResponse(404, { error: "unexpected" });
+    });
+
+    const result = await executeGrantViaPersonalServer(
+      makeInput(undefined, fetchImpl),
+    );
+    expect(result.ok).toBe(true);
+    expect(tokensIssued).toBe(2);
+    expect(grantAttempts).toBe(2);
+  });
+
+  it("returns no_personal_server when PS resolver returns null", async () => {
+    const result = await executeGrantViaPersonalServer(
+      makeInput({ resolvePersonalServer: async () => null }),
+    );
+    expect(result).toEqual({
+      ok: false,
+      code: "no_personal_server",
+      message: expect.any(String),
+    });
+  });
+
+  it("returns client_not_found when OAuth client is unknown", async () => {
+    const result = await executeGrantViaPersonalServer(
+      makeInput({ resolveOauthClient: async () => null }),
+    );
+    expect(result).toEqual({
+      ok: false,
+      code: "client_not_found",
+      message: expect.stringContaining("memory-app-dev"),
+    });
+  });
+
+  it("returns client_no_builder when OAuth client lacks builder triple", async () => {
+    const result = await executeGrantViaPersonalServer(
+      makeInput({ resolveOauthClient: async () => identityOnlyClient() }),
+    );
+    expect(result).toEqual({
+      ok: false,
+      code: "client_no_builder",
+      message: expect.stringContaining("builder identity"),
+    });
+  });
+
+  it("returns ps_token_failed when /oauth/token returns invalid_client", async () => {
+    const fetchImpl = createFakeFetch((url) => {
+      if (url.endsWith("/oauth/token")) {
+        return jsonResponse(401, { error: "invalid_client" });
+      }
+      return jsonResponse(404, { error: "unexpected" });
+    });
+    const result = await executeGrantViaPersonalServer(
+      makeInput(undefined, fetchImpl),
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.code).toBe("ps_token_failed");
+    }
+  });
+
+  it("returns ps_rejected when /v1/grants returns 4xx (not 401) with token in hand", async () => {
+    const fetchImpl = createFakeFetch((url) => {
+      if (url.endsWith("/oauth/token")) {
+        return jsonResponse(200, {
+          access_token: ACCESS_TOKEN,
+          token_type: "Bearer",
+          expires_in: 3600,
+        });
+      }
+      return jsonResponse(400, {
+        error: { message: "Builder not registered" },
+      });
+    });
+    const result = await executeGrantViaPersonalServer(
+      makeInput(undefined, fetchImpl),
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.code).toBe("ps_rejected");
+      expect(result.message).toContain("Builder not registered");
+    }
+  });
+
+  it("returns no_grant_id when PS responds 200 without grantId", async () => {
+    const fetchImpl = createFakeFetch((url) => {
+      if (url.endsWith("/oauth/token")) {
+        return jsonResponse(200, {
+          access_token: ACCESS_TOKEN,
+          token_type: "Bearer",
+          expires_in: 3600,
+        });
+      }
+      return jsonResponse(201, { somethingElse: true });
+    });
+    const result = await executeGrantViaPersonalServer(
+      makeInput(undefined, fetchImpl),
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.code).toBe("no_grant_id");
+  });
+});

--- a/connect/src/lib/auth/execute-grant-via-personal-server.ts
+++ b/connect/src/lib/auth/execute-grant-via-personal-server.ts
@@ -4,12 +4,22 @@
  * Replaces the mock-only path for `execution_mode === "embedded_wallet_account_hosted"`:
  *   1. Resolve the user's PS row (vana_user_id → linked wallet → personal_servers)
  *   2. Resolve the OIDC client to a registered builder (oauth_clients)
- *   3. POST <ps-url>/v1/grants with Bearer access_token and { granteeAddress, scopes, expiresAt?, nonce? }
- *   4. Return the grantId for the action result + consent event
+ *   3. Obtain a short-lived access_token via OAuth2 client_credentials
+ *      against the PS's `/oauth/token` endpoint, using the PS row's stored
+ *      control-plane secret (PS_ACCESS_TOKEN) as the client_secret.
+ *   4. POST <ps-url>/v1/grants with Authorization: Bearer <access_token>
+ *      and { granteeAddress, scopes, expiresAt?, nonce? }
+ *   5. Return the grantId for the action result + consent event
+ *
+ * Tokens are cached per-PS-URL with the standard "refresh-30s-before-expiry"
+ * policy and refreshed on 401. This is the SLVP-style two-tier model:
+ *   PS_ACCESS_TOKEN (long-lived secret, never sent on per-request paths)
+ *     → access_token (short-lived bearer, sent on every grant call)
  *
  * Tests inject the resolvers + http fetch as deps so this is pure.
  */
 
+import * as oauth from "oauth4webapi";
 import type { OauthClientRow } from "@/lib/db/oauth-clients";
 
 export type ExecuteGrantInput = {
@@ -22,12 +32,19 @@ export type ExecuteGrantInput = {
   resolvePersonalServer: (vanaUserId: string) => Promise<{
     serverId: string;
     serverUrl: string;
-    accessToken: string;
+    /**
+     * The PS's long-lived control-plane secret (PS_ACCESS_TOKEN).
+     * Used as the OAuth2 `client_secret` in the client_credentials grant
+     * against the PS's `/oauth/token` endpoint. Never sent as a Bearer.
+     */
+    controlPlaneSecret: string;
   } | null>;
   /** Resolves the OAuth client record. Builder fields may be null. */
   resolveOauthClient: (clientId: string) => Promise<OauthClientRow | null>;
   /** Injectable HTTP fetch (default: global fetch). */
   fetchImpl?: typeof fetch;
+  /** Optional clock seam for tests. Returns ms since epoch. */
+  now?: () => number;
 };
 
 export type ExecuteGrantResult =
@@ -44,15 +61,92 @@ export type ExecuteGrantResult =
         | "client_not_found"
         | "client_no_builder"
         | "ps_unreachable"
+        | "ps_token_failed"
         | "ps_rejected"
         | "no_grant_id";
       message: string;
     };
 
+type CachedToken = {
+  accessToken: string;
+  /** ms since epoch when the token expires. */
+  expiresAtMs: number;
+};
+
+/**
+ * Per-PS-URL token cache. The Lambda runtime is not guaranteed to be a
+ * single process, so this cache is best-effort: a token may be re-issued
+ * on a fresh container, but the PS endpoint is idempotent on issuance and
+ * tolerates the extra round-trip.
+ */
+const tokenCache = new Map<string, CachedToken>();
+
+const TOKEN_REFRESH_SAFETY_SECONDS = 30;
+
+/**
+ * Obtain (and cache) an access token via the OAuth2 client_credentials
+ * grant against `<serverUrl>/oauth/token`. Refresh ahead of expiry by
+ * {@link TOKEN_REFRESH_SAFETY_SECONDS}.
+ */
+async function getAccessToken(input: {
+  serverUrl: string;
+  controlPlaneSecret: string;
+  fetchImpl: typeof fetch;
+  now: () => number;
+  forceRefresh?: boolean;
+}): Promise<string> {
+  const cached = tokenCache.get(input.serverUrl);
+  if (
+    !input.forceRefresh &&
+    cached &&
+    cached.expiresAtMs > input.now() + TOKEN_REFRESH_SAFETY_SECONDS * 1000
+  ) {
+    return cached.accessToken;
+  }
+
+  const issuer = new URL(input.serverUrl);
+  const as: oauth.AuthorizationServer = {
+    issuer: issuer.origin,
+    token_endpoint: `${issuer.origin}/oauth/token`,
+  };
+  const client: oauth.Client = {
+    client_id: "control-plane",
+    token_endpoint_auth_method: "client_secret_basic",
+  };
+  const clientAuth = oauth.ClientSecretBasic(input.controlPlaneSecret);
+
+  const response = await oauth.clientCredentialsGrantRequest(
+    as,
+    client,
+    clientAuth,
+    new URLSearchParams(),
+    { [oauth.customFetch]: input.fetchImpl },
+  );
+  const result = await oauth.processClientCredentialsResponse(
+    as,
+    client,
+    response,
+  );
+
+  const accessToken =
+    typeof result.access_token === "string" ? result.access_token : null;
+  if (!accessToken) {
+    throw new Error("OAuth2 token response missing access_token");
+  }
+  const expiresInSeconds =
+    typeof result.expires_in === "number" ? result.expires_in : 3600;
+  tokenCache.set(input.serverUrl, {
+    accessToken,
+    expiresAtMs: input.now() + expiresInSeconds * 1000,
+  });
+  return accessToken;
+}
+
 export async function executeGrantViaPersonalServer(
   input: ExecuteGrantInput,
 ): Promise<ExecuteGrantResult> {
   const fetchImpl = input.fetchImpl ?? fetch;
+  const now = input.now ?? (() => Date.now());
 
   // 1. Resolve PS for the user.
   const ps = await input.resolvePersonalServer(input.vanaUserId);
@@ -82,14 +176,13 @@ export async function executeGrantViaPersonalServer(
     };
   }
 
-  // 3. POST to PS /v1/grants.
-  let grantId: string | undefined;
-  try {
-    const res = await fetchImpl(`${ps.serverUrl}/v1/grants`, {
+  // 3. Obtain (or reuse) an access token via OAuth2 client_credentials.
+  const submitGrant = async (accessToken: string): Promise<Response> => {
+    return fetchImpl(`${ps.serverUrl}/v1/grants`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        Authorization: `Bearer ${ps.accessToken}`,
+        Authorization: `Bearer ${accessToken}`,
       },
       body: JSON.stringify({
         granteeAddress: client.grantee_address,
@@ -100,15 +193,43 @@ export async function executeGrantViaPersonalServer(
         ...(input.nonce !== undefined ? { nonce: input.nonce } : {}),
       }),
     });
-    if (!res.ok) {
-      const body = await res.json().catch(() => ({}));
-      const message =
-        (body as { error?: { message?: string } }).error?.message ??
-        `Personal Server returned ${res.status}`;
-      return { ok: false, code: "ps_rejected", message };
+  };
+
+  let accessToken: string;
+  try {
+    accessToken = await getAccessToken({
+      serverUrl: ps.serverUrl,
+      controlPlaneSecret: ps.controlPlaneSecret,
+      fetchImpl,
+      now,
+    });
+  } catch (err) {
+    return {
+      ok: false,
+      code: "ps_token_failed",
+      message:
+        err instanceof Error
+          ? `Failed to obtain access token from PS: ${err.message}`
+          : "Failed to obtain access token from PS",
+    };
+  }
+
+  // 4. POST /v1/grants. On 401, refresh the token once and retry — handles
+  // the case where the cached token was revoked or expired faster than its
+  // declared TTL (PS supports server-side revocation).
+  let res: Response;
+  try {
+    res = await submitGrant(accessToken);
+    if (res.status === 401) {
+      const refreshed = await getAccessToken({
+        serverUrl: ps.serverUrl,
+        controlPlaneSecret: ps.controlPlaneSecret,
+        fetchImpl,
+        now,
+        forceRefresh: true,
+      });
+      res = await submitGrant(refreshed);
     }
-    const body = (await res.json()) as { grantId?: string };
-    grantId = body.grantId;
   } catch (err) {
     return {
       ok: false,
@@ -117,7 +238,15 @@ export async function executeGrantViaPersonalServer(
     };
   }
 
-  if (!grantId) {
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}));
+    const message =
+      (body as { error?: { message?: string } }).error?.message ??
+      `Personal Server returned ${res.status}`;
+    return { ok: false, code: "ps_rejected", message };
+  }
+  const body = (await res.json()) as { grantId?: string };
+  if (!body.grantId) {
     return {
       ok: false,
       code: "no_grant_id",
@@ -127,11 +256,13 @@ export async function executeGrantViaPersonalServer(
 
   return {
     ok: true,
-    grantId,
+    grantId: body.grantId,
     granteeAddress: client.grantee_address,
-    personalServer: {
-      serverId: ps.serverId,
-      serverUrl: ps.serverUrl,
-    },
+    personalServer: { serverId: ps.serverId, serverUrl: ps.serverUrl },
   };
+}
+
+/** Test-only: clears the per-PS-URL access-token cache. */
+export function clearAccessTokenCacheForTests() {
+  tokenCache.clear();
 }


### PR DESCRIPTION
## Summary

Replaces sending the long-lived `PS_ACCESS_TOKEN` directly as a Bearer on `/v1/grants` with a standards-conformant two-tier flow:

- `PS_ACCESS_TOKEN` is the OAuth2 `client_secret` for `client_id=control-plane`, exchanged at `/oauth/token` for a short-lived `access_token`.
- `access_token` is what's actually sent as `Authorization: Bearer …` on per-request paths.

This pairs with [personal-server-ts#82](https://github.com/vana-com/personal-server-ts/pull/82) (merged), which ships the RFC 6749 token endpoint on the PS side.

### Changes

- `executeGrantViaPersonalServer` now uses [`oauth4webapi`](https://github.com/panva/oauth4webapi) to mint short-lived access tokens via OAuth2 `client_credentials`.
- Per-PS-URL token cache with 30s safety window before declared expiry.
- 401 from `/v1/grants` triggers a single force-refresh + retry, handling PS-side revocation gracefully.
- Renamed input field `accessToken` → `controlPlaneSecret` to reflect what it actually is (OAuth2 `client_secret`, not a Bearer).
- New unit tests for: happy path, token caching, 401 refresh retry, full error matrix.

### Why

- **SLVP-ideal**: Stripe/Linear/Vercel/Plaid auth their internal services this way. Long-lived secrets stay in vaults; short-lived bearers ride per-request.
- **No CLI regression**: PS still accepts CLI session tokens via the existing token store; CLI `/oauth/token` device-code flow is in place too (PR #82).
- **Production unaffected**: New code path only matters once a deployed PS exposes `/oauth/token`. Existing PS deployments keep working until they pull the new image.

## Test plan

- [x] `pnpm test` — all 338 tests pass (9 new for `executeGrantViaPersonalServer`)
- [x] `tsc --noEmit` — clean (only pre-existing CSS-import error, unrelated)
- [x] `pnpm install --frozen-lockfile` succeeds with pinned `pnpm@10.29.2`
- [ ] After merge: redeploy PS image to a dev account with `vanaorg/personal-server:latest`, retry a real grant from `account-dev.vana.org`, confirm `/oauth/token` round-trip + grant success