### PR TITLE
fix(admin): use NEXT_PUBLIC_DATA_GATEWAY_URL for builder registration

### DIFF
--- a/connect/src/app/admin/_lib/register-builder.ts
+++ b/connect/src/app/admin/_lib/register-builder.ts
@@ -17,7 +17,15 @@ const BUILDER_REGISTRATION_TYPES = {
   ],
 } as const;
 
-const GATEWAY_URL = "https://data-gateway.vana.org";
+/**
+ * Gateway URL for builder registration. Falls back to prod for backwards
+ * compatibility with existing prod deployments; non-prod environments
+ * should set NEXT_PUBLIC_DATA_GATEWAY_URL on Vercel to keep registrations
+ * scoped to the matching gateway env (PS reads its gateway from server
+ * config and dev/prod gateways are distinct deployments).
+ */
+const GATEWAY_URL =
+  process.env.NEXT_PUBLIC_DATA_GATEWAY_URL ?? "https://data-gateway.vana.org";
 
 export type RegisterBuilderErrorCode =
   | "ALREADY_REGISTERED"


### PR DESCRIPTION
## Summary

`registerBuilder()` was hardcoded to the prod gateway, so /admin on `account-dev.vana.org` was registering builders on prod even though Personal Servers in the dev environment query the dev gateway. Result: builders registered via account-dev were invisible to dev PS, and grant minting failed with `BUILDER_NOT_REGISTERED`.

This switches the URL to the existing `NEXT_PUBLIC_DATA_GATEWAY_URL` env var (already used by `use-server.ts`), with a prod fallback so unconfigured environments continue to behave as before.

The matching env var on Vercel Preview has been set to `https://data-gateway-env-dev-opendatalabs.vercel.app` so account-dev now talks to the dev gateway end-to-end. Production env still points at prod gateway.

## Test plan
- [x] Local typecheck clean
- [ ] After merge → account-dev rebuild → re-register Memory App via /admin → confirm new builder appears on dev gateway
- [ ] Then retry grant from Memory App; should now succeed end-to-end (PS finds the builder)