### PR TITLE
fix(admin): drive BuilderRegistration chainId from env

### DIFF
--- a/connect/src/app/admin/_lib/register-builder.ts
+++ b/connect/src/app/admin/_lib/register-builder.ts
@@ -1,10 +1,17 @@
 import type { Address, Hex } from "viem";
 import { generatePrivateKey, privateKeyToAccount } from "viem/accounts";
 
+/**
+ * EIP-712 domain for BuilderRegistration. The chainId must match the
+ * gateway's expected chain — Vana mainnet (1480) for prod, Moksha testnet
+ * (14800) for dev — otherwise the gateway rejects the signature with
+ * "Invalid signature: signature verification failed". Mirrors the
+ * `NEXT_PUBLIC_VANA_CHAIN_ID` pattern in `register-on-chain.ts`.
+ */
 const BUILDERS_DOMAIN = {
   name: "Vana Data Portability",
   version: "1",
-  chainId: BigInt(1480),
+  chainId: BigInt(process.env.NEXT_PUBLIC_VANA_CHAIN_ID ?? 1480),
   verifyingContract: "0x8325C0A0948483EdA023A1A2Fd895e62C5131234" as Address,
 } as const;
 


### PR DESCRIPTION
## Summary

EIP-712 signatures for /v1/builders were hardcoded with chainId 1480 (Vana mainnet), but the dev gateway expects chainId 14800 (Moksha testnet). On account-dev, the dev gateway rejected POST /v1/builders with 401 "Invalid signature: signature verification failed", blocking new builder registrations.

Reads `chainId` from `NEXT_PUBLIC_VANA_CHAIN_ID` (same pattern as `lib/server-provider/register-on-chain.ts`), falling back to 1480.

Companion env-var change: deleted the encrypted versions of `NEXT_PUBLIC_VANA_CHAIN_ID` on Vercel and replaced with plain values, since `NEXT_PUBLIC_*` vars must be plain to be inlined into the client bundle. Production stays on 1480; preview and development now use 14800 to match the dev gateway.

## Test plan
- [ ] After merge → account-dev rebuild → /admin → register Memory App at https://vana-connect-mobile-dev.vercel.app/demo/login-with-vana → succeeds (POST /v1/builders returns 201, not 401)
- [ ] Builder appears on dev gateway: \`curl https://data-gateway-env-dev-opendatalabs.vercel.app/v1/builders/<grantee>\` returns 200
- [ ] Re-key DB row to client_id=memory-app-dev, retry grant flow end-to-end