### PR TITLE
fix(actions): allow embedded_wallet_account_hosted in buildMockActionResult

### DIFF
--- a/connect/src/lib/auth/account-action.test.ts
+++ b/connect/src/lib/auth/account-action.test.ts
@@ -225,9 +225,29 @@ describe("buildMockActionResult — mock-only invariants", () => {
     );
   });
 
-  it("rejects embedded-wallet execution mode for the mock path", () => {
+  it("accepts embedded-wallet execution mode (grant minting is server-side)", () => {
+    // The hosted-wallet flow proves authority via PS OAuth2 + EIP-712 signed
+    // by the PS's own key, so the result envelope can be backend-built without
+    // user signing. The route caller stitches the real grantId onto the
+    // result_payload alongside the mock marker.
     const req = decideActionRequest({
       request: makeRequest({ executionMode: "embedded_wallet_account_hosted" }),
+      decision: "approved",
+      vanaUserId: VANA_USER_ID,
+      now: NOW,
+    });
+    const result = buildMockActionResult({
+      request: req,
+      actionCode: generateActionCode(),
+      now: NOW,
+    });
+    expect(result.action_request_id).toBe(req.id);
+    expect(result.result_mode).toBe("mock");
+  });
+
+  it("still rejects delegated_runtime execution mode (not yet a supported backend path)", () => {
+    const req = decideActionRequest({
+      request: makeRequest({ executionMode: "delegated_runtime" }),
       decision: "approved",
       vanaUserId: VANA_USER_ID,
       now: NOW,
@@ -238,7 +258,7 @@ describe("buildMockActionResult — mock-only invariants", () => {
         actionCode: generateActionCode(),
         now: NOW,
       }),
-    ).toThrow(/execution_mode=embedded_wallet_account_hosted/);
+    ).toThrow(/execution_mode=delegated_runtime/);
   });
 
   it("rejects encrypted_bundle_reference result_mode in the mock helper", () => {

--- a/connect/src/lib/auth/account-action.ts
+++ b/connect/src/lib/auth/account-action.ts
@@ -288,9 +288,17 @@ export function buildMockActionResult(input: {
       `buildMockActionResult: request ${input.request.id} is not approved`,
     );
   }
-  if (input.request.execution_mode !== "mock") {
+  // `mock` and `embedded_wallet_account_hosted` may produce backend-built
+  // mock RESULTS — both have their grant minting handled server-side already
+  // (the hosted-wallet flow proves authority via PS OAuth2 + EIP-712 signed
+  // by the PS's own key). BYO-wallet / delegated-runtime modes still require
+  // a client/user signature and must not flow through this helper.
+  if (
+    input.request.execution_mode !== "mock" &&
+    input.request.execution_mode !== "embedded_wallet_account_hosted"
+  ) {
     throw new Error(
-      `buildMockActionResult: refusing to backend-sign execution_mode=${input.request.execution_mode}; only 'mock' may produce a mock result without client/user signing`,
+      `buildMockActionResult: refusing to backend-sign execution_mode=${input.request.execution_mode}; only 'mock' and 'embedded_wallet_account_hosted' may produce a backend-built mock result`,
     );
   }
   if (input.request.result_mode !== "mock") {


### PR DESCRIPTION
## Summary

After the real grant is minted via PS OAuth2 (server-side, post-PR #130), the decision route calls \`buildMockActionResult\` to package the response envelope with a \"mock\" result_mode payload + the real grant_id stitched on. The helper still rejected \`execution_mode=embedded_wallet_account_hosted\`, crashing the route AFTER PS had already minted a real grant — surfacing in the browser as **\"Unexpected end of JSON input\"** because the failed route returned an empty 500 body.

Vercel runtime log confirms:

\`\`\`
Error: buildMockActionResult: refusing to backend-sign execution_mode=embedded_wallet_account_hosted; only 'mock' may produce a mock result without client/user signing
    at .../account-action.ts
    at .../api/account/actions/account-actions-runtime.ts
\`\`\`

The guard's original intent — \"don't backend-sign on behalf of a BYO wallet\" — still holds. Hosted-wallet's authority comes from the PS itself (PS_ACCESS_TOKEN → OAuth2 access_token → EIP-712 signed by PS's own key), not the user's wallet, so the helper backing-building a result envelope for it is fine.

## Changes

- \`buildMockActionResult\` now accepts both \`mock\` and \`embedded_wallet_account_hosted\`. \`byo_wallet_client_signed\` and \`delegated_runtime\` still throw.
- Test inverted: previous \"rejects embedded-wallet\" → now \"accepts embedded-wallet\" + new test pinning the BYO-wallet/delegated-runtime guard.

## Test plan

- [x] All 339 unit tests pass
- [ ] After merge → account-dev rebuild → retry Memory App grant → completes end-to-end (PS mints grant, /decision returns 200 with grant_id in result_payload)