### PR TITLE
feat(auth): bind sessions via id_token sid + active-sessions table

### DIFF
--- a/connect/migrations/009_active_sessions.sql
+++ b/connect/migrations/009_active_sessions.sql
@@ -1,0 +1,31 @@
+-- Vana auth — active OIDC sessions.
+--
+-- Hydra v2 access tokens are opaque; introspection (RFC 7662) does not
+-- include `sid` or `jti`. The signing-authority plane (signing_authorizations,
+-- interactive_confirmations) is keyed by hydra_session_id, which must remain
+-- stable across access-token rotation.
+--
+-- We capture `sid` from the OIDC id_token at login (OIDC Core requires `sid`
+-- in id_token when `openid` scope is requested) and store it server-side
+-- keyed by sha256(access_token) so the session verifier can resolve sid on
+-- every introspection without trusting the client.
+--
+-- Token storage rule: the access token is stored as sha256(access_token) in
+-- hex. The verifier hashes the presented token with the same function for
+-- lookup; the raw token is never persisted.
+--
+-- Tombstone scaffolding (vana_session_tombstones) is intentionally retained;
+-- a follow-up migration removes it once the new path is live.
+
+CREATE TABLE IF NOT EXISTS vana_active_sessions (
+    id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    token_hash      TEXT NOT NULL UNIQUE,        -- sha256(access_token), hex
+    sid             TEXT NOT NULL,               -- OIDC sid from id_token
+    vana_user_id    TEXT NOT NULL,
+    expires_at      TIMESTAMPTZ NOT NULL,        -- mirrors access_token exp
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_vana_active_sessions_sid ON vana_active_sessions (sid);
+CREATE INDEX IF NOT EXISTS idx_vana_active_sessions_user ON vana_active_sessions (vana_user_id);
+CREATE INDEX IF NOT EXISTS idx_vana_active_sessions_expires ON vana_active_sessions (expires_at);

--- a/connect/src/app/api/auth/logout/route.test.ts
+++ b/connect/src/app/api/auth/logout/route.test.ts
@@ -1,0 +1,208 @@
+import { beforeEach, afterEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getVanaSession: vi.fn(),
+  fetchGoogleIdTokenForAudience: vi.fn(),
+  deleteActiveSessionsBySid: vi.fn(),
+}));
+
+vi.mock("@/lib/auth/vana-session", () => ({
+  getVanaSession: mocks.getVanaSession,
+}));
+
+vi.mock("@/lib/auth/google-id-token", () => ({
+  fetchGoogleIdTokenForAudience: mocks.fetchGoogleIdTokenForAudience,
+}));
+
+vi.mock("@/lib/db/sessions", () => ({
+  deleteActiveSessionsBySid: mocks.deleteActiveSessionsBySid,
+}));
+
+async function importRoute() {
+  return await import("./route");
+}
+
+const VALID_VANA_USER_ID = "vana_user_" + "0".repeat(32);
+const HYDRA_SESSION_ID = "hydra_sid_abc123";
+
+let fetchMock: ReturnType<typeof vi.fn>;
+let originalFetch: typeof globalThis.fetch;
+let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+function makeRequest(): Request {
+  return new Request("https://account.vana.org/api/auth/logout", {
+    method: "POST",
+    headers: { authorization: "Bearer some-access-token" },
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.resetModules();
+  process.env.HYDRA_ADMIN_URL = "https://hydra-admin.example.com";
+  process.env.HYDRA_ADMIN_AUDIENCE = "https://hydra-admin.example.com";
+  // Don't touch NODE_ENV (read-only in this tsconfig). Default test env is fine.
+
+  mocks.fetchGoogleIdTokenForAudience.mockResolvedValue("google-id-token-xyz");
+  mocks.deleteActiveSessionsBySid.mockResolvedValue(1);
+
+  fetchMock = vi.fn();
+  originalFetch = globalThis.fetch;
+  globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch;
+
+  consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  consoleErrorSpy.mockRestore();
+});
+
+describe("POST /api/auth/logout (authenticated)", () => {
+  it("calls Hydra admin DELETE with subject + Bearer, deletes the active session, clears cookies, returns 200", async () => {
+    mocks.getVanaSession.mockResolvedValue({
+      vanaUserId: VALID_VANA_USER_ID,
+      hydraSessionId: HYDRA_SESSION_ID,
+      scope: ["openid"],
+      audience: ["account.vana.org"],
+    });
+    fetchMock.mockResolvedValue(
+      new Response(null, { status: 204 }) as unknown as Response,
+    );
+
+    const { POST } = await importRoute();
+    const response = await POST(makeRequest() as never);
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.ok).toBe(true);
+
+    // Hydra admin called once with the right URL + Bearer.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [calledUrl, calledInit] = fetchMock.mock.calls[0]!;
+    expect(String(calledUrl)).toBe(
+      `https://hydra-admin.example.com/admin/oauth2/auth/sessions/login?subject=${encodeURIComponent(
+        VALID_VANA_USER_ID,
+      )}`,
+    );
+    expect(calledInit?.method).toBe("DELETE");
+    expect((calledInit?.headers as Record<string, string>).authorization).toBe(
+      "Bearer google-id-token-xyz",
+    );
+
+    // Google ID-token fetched with the admin audience.
+    expect(mocks.fetchGoogleIdTokenForAudience).toHaveBeenCalledWith(
+      "https://hydra-admin.example.com",
+    );
+
+    // Active session row dropped by sid.
+    expect(mocks.deleteActiveSessionsBySid).toHaveBeenCalledWith(
+      HYDRA_SESSION_ID,
+    );
+
+    // Cookies cleared.
+    const setCookie = response.headers.get("set-cookie") ?? "";
+    expect(setCookie).toContain("vana_session=");
+    expect(setCookie).toContain("vana_access=");
+    expect(setCookie).toContain("Max-Age=0");
+  });
+
+  it("treats Hydra 404 as success and still drops the active-session row", async () => {
+    mocks.getVanaSession.mockResolvedValue({
+      vanaUserId: VALID_VANA_USER_ID,
+      hydraSessionId: HYDRA_SESSION_ID,
+      scope: [],
+      audience: ["account.vana.org"],
+    });
+    fetchMock.mockResolvedValue(
+      new Response("not found", { status: 404 }) as unknown as Response,
+    );
+
+    const { POST } = await importRoute();
+    const response = await POST(makeRequest() as never);
+
+    expect(response.status).toBe(200);
+    expect(mocks.deleteActiveSessionsBySid).toHaveBeenCalledWith(
+      HYDRA_SESSION_ID,
+    );
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("POST /api/auth/logout (unauthenticated)", () => {
+  it("clears cookies, makes no Hydra/DB calls, returns 200", async () => {
+    mocks.getVanaSession.mockResolvedValue(null);
+
+    const { POST } = await importRoute();
+    const response = await POST(makeRequest() as never);
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.ok).toBe(true);
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(mocks.fetchGoogleIdTokenForAudience).not.toHaveBeenCalled();
+    expect(mocks.deleteActiveSessionsBySid).not.toHaveBeenCalled();
+
+    const setCookie = response.headers.get("set-cookie") ?? "";
+    expect(setCookie).toContain("vana_session=");
+    expect(setCookie).toContain("vana_access=");
+    expect(setCookie).toContain("Max-Age=0");
+  });
+});
+
+describe("POST /api/auth/logout (Hydra failure)", () => {
+  it("logs and still clears cookies + returns 200 when Hydra admin returns 5xx", async () => {
+    mocks.getVanaSession.mockResolvedValue({
+      vanaUserId: VALID_VANA_USER_ID,
+      hydraSessionId: HYDRA_SESSION_ID,
+      scope: [],
+      audience: ["account.vana.org"],
+    });
+    fetchMock.mockResolvedValue(
+      new Response("kaboom", { status: 503 }) as unknown as Response,
+    );
+
+    const { POST } = await importRoute();
+    const response = await POST(makeRequest() as never);
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.ok).toBe(true);
+
+    // The active-session row is still dropped — failure of Hydra doesn't
+    // block local revocation.
+    expect(mocks.deleteActiveSessionsBySid).toHaveBeenCalledWith(
+      HYDRA_SESSION_ID,
+    );
+
+    // Error was logged.
+    expect(consoleErrorSpy).toHaveBeenCalled();
+    const errMsg = String(consoleErrorSpy.mock.calls[0]?.[0] ?? "");
+    expect(errMsg).toContain("[logout] hydra admin revoke failed");
+
+    const setCookie = response.headers.get("set-cookie") ?? "";
+    expect(setCookie).toContain("vana_session=");
+    expect(setCookie).toContain("vana_access=");
+    expect(setCookie).toContain("Max-Age=0");
+  });
+
+  it("logs and still returns 200 when fetch itself throws", async () => {
+    mocks.getVanaSession.mockResolvedValue({
+      vanaUserId: VALID_VANA_USER_ID,
+      hydraSessionId: HYDRA_SESSION_ID,
+      scope: [],
+      audience: ["account.vana.org"],
+    });
+    fetchMock.mockRejectedValue(new Error("network down"));
+
+    const { POST } = await importRoute();
+    const response = await POST(makeRequest() as never);
+
+    expect(response.status).toBe(200);
+    expect(mocks.deleteActiveSessionsBySid).toHaveBeenCalledWith(
+      HYDRA_SESSION_ID,
+    );
+    expect(consoleErrorSpy).toHaveBeenCalled();
+  });
+});

--- a/connect/src/app/api/auth/logout/route.ts
+++ b/connect/src/app/api/auth/logout/route.ts
@@ -1,163 +1,131 @@
 /**
  * Vana session logout.
  *
- * See docs/auth-redesign/01-architecture.md §1.7 logout sequence.
+ * SLVP-correct flow (post-tombstone era):
+ *   1. Resolve the calling session (defensive: missing/invalid → still clear
+ *      cookies and 200 so a re-logout from an expired token doesn't strand
+ *      the client).
+ *   2. If authenticated:
+ *      a. Call Hydra admin
+ *         `DELETE /admin/oauth2/auth/sessions/login?subject=<vanaUserId>`
+ *         with a Google ID-token Bearer (audience = HYDRA_ADMIN_AUDIENCE).
+ *         This is Ory's documented way to invalidate every Hydra session
+ *         (and therefore every opaque access token issued under it) for a
+ *         subject. Future introspections return active:false.
  *
- * Fail-closed ordering:
- *   1. INSERT vana_session_tombstones row — DB write, multi-lambda visible.
- *      This is the security boundary: if subsequent steps fail, the tombstone
- *      alone still rejects future requests within ≤30s of cache TTL.
- *   2. Clear vana_session and vana_access cookies.
- *   3. POST Hydra /oauth2/revoke for refresh token (best-effort).
- *   4. POST Hydra /oauth2/sessions/logout (best-effort).
- *   5. UPDATE vana_refresh_tokens SET revoked_at = now() for the session.
+ *         TODO(prod): narrow to per-session granularity via the consent
+ *         endpoint once we have multiple concurrent device sessions per
+ *         subject. For dev-stage cutover, subject-level revoke is acceptable.
+ *      b. Drop our row in vana_active_sessions via deleteActiveSessionsBySid
+ *         so the verifier 401s any access tokens that survive the
+ *         per-process introspection cache.
+ *      c. Hydra admin failures are logged loudly but do NOT block cookie
+ *         clearing. Logout is best-effort from the user's perspective.
+ *   3. Clear `vana_session` and `vana_access` cookies (matching the login
+ *      route's secure/sameSite/path) and return 200.
  *
- * Steps 3-4 retried by background job on failure (TODO: stage 3.6 follow-up
- * to wire that up; for now they fire and forget with logging).
- *
- * Auth: Bearer required (state-mutating).
+ * Notes:
+ *   - No tombstone writes. The active-sessions table is the source of truth;
+ *     deleting the row is the new revocation primitive.
+ *   - Auth: not strictly required (we degrade gracefully on null), but if a
+ *     token is present we treat it as the session-under-logout.
  */
 
 import { NextResponse, type NextRequest } from "next/server";
 import { getVanaSession } from "@/lib/auth/vana-session";
 import { fetchGoogleIdTokenForAudience } from "@/lib/auth/google-id-token";
-import {
-  insertTombstone,
-  revokeRefreshTokensForSession,
-} from "@/lib/db/sessions";
+import { deleteActiveSessionsBySid } from "@/lib/db/sessions";
 
 export const runtime = "nodejs";
 
-const COOKIE_NAMES = ["vana_session", "vana_access"];
+const COOKIE_NAMES = ["vana_session", "vana_access"] as const;
 
-function clearedCookieAttrs(): {
-  httpOnly: boolean;
-  sameSite: "lax";
-  secure: boolean;
-  path: string;
-  maxAge: number;
-} {
-  return {
-    httpOnly: false, // overridden per-cookie
-    sameSite: "lax",
-    secure: process.env.NODE_ENV === "production",
-    path: "/",
-    maxAge: 0,
-  };
+function clearCookies(res: NextResponse): void {
+  const isProd = process.env.NODE_ENV === "production";
+  for (const name of COOKIE_NAMES) {
+    res.cookies.set({
+      name,
+      value: "",
+      httpOnly: name === "vana_session",
+      sameSite: "lax",
+      secure: isProd,
+      path: "/",
+      maxAge: 0,
+    });
+  }
 }
 
-export async function POST(req: NextRequest) {
+export async function POST(req: NextRequest): Promise<NextResponse> {
   const session = await getVanaSession(req);
-  if (!session) {
-    // Even on 401 we still clear cookies — defense in depth for the
-    // "stale cookie kept around" case.
-    const res = NextResponse.json(
-      { ok: false, error: "Not authenticated" },
-      { status: 401 },
-    );
-    for (const name of COOKIE_NAMES) {
-      res.cookies.set(name, "", { ...clearedCookieAttrs(), httpOnly: true });
+
+  if (session) {
+    // Hydra admin DELETE — best-effort. Errors logged, do not block.
+    try {
+      await revokeHydraSubjectSession(session.vanaUserId);
+    } catch (err) {
+      console.error(
+        "[logout] hydra admin revoke failed",
+        err instanceof Error ? err.message : err,
+      );
     }
-    return res;
+
+    // Drop our active-sessions row so the verifier rejects any cached access
+    // tokens that still introspect as active during the brief window before
+    // Hydra's revocation propagates.
+    try {
+      await deleteActiveSessionsBySid(session.hydraSessionId);
+    } catch (err) {
+      console.error(
+        "[logout] deleteActiveSessionsBySid failed",
+        err instanceof Error ? err.message : err,
+      );
+    }
   }
 
-  // Step 1: tombstone first. This is the security boundary.
-  try {
-    await insertTombstone({
-      hydraSessionId: session.hydraSessionId,
-      vanaUserId: session.vanaUserId,
-    });
-  } catch (err) {
-    // Tombstone insert failure is rare but security-critical. Surface it.
-    console.error(
-      "[logout] tombstone insert failed",
-      err instanceof Error ? err.message : err,
-    );
-    return NextResponse.json(
-      { ok: false, error: "Logout failed" },
-      { status: 500 },
-    );
-  }
-
-  // Step 5 (DB-side, ordered before Hydra so we hold the consistent state):
-  // mark refresh tokens revoked. Best-effort — failure here doesn't block
-  // logout because the tombstone is already in place.
-  try {
-    await revokeRefreshTokensForSession(session.hydraSessionId);
-  } catch (err) {
-    console.warn(
-      "[logout] revokeRefreshTokensForSession failed",
-      err instanceof Error ? err.message : err,
-    );
-  }
-
-  // Step 3: revoke refresh token at Hydra (best-effort). We don't have the
-  // raw refresh token here without DB lookup; the route caller could pass it,
-  // but the standard logout path is "user clicks logout in account.vana.org"
-  // which has the cookies but not the raw refresh token. So we rely on
-  // Hydra's session-end and the DB-side revocation above.
-  // Best-effort kicked off but fire-and-forget.
-  void revokeRefreshAtHydra(session).catch((err) =>
-    console.warn(
-      "[logout] hydra revoke failed",
-      err instanceof Error ? err.message : err,
-    ),
-  );
-
-  // Step 4: end Hydra SSO session (best-effort).
-  void endHydraSession(session).catch((err) =>
-    console.warn(
-      "[logout] hydra session-end failed",
-      err instanceof Error ? err.message : err,
-    ),
-  );
-
-  // Step 2: clear cookies.
   const res = NextResponse.json({ ok: true }, { status: 200 });
-  res.cookies.set("vana_session", "", {
-    ...clearedCookieAttrs(),
-    httpOnly: true,
-  });
-  res.cookies.set("vana_access", "", {
-    ...clearedCookieAttrs(),
-    httpOnly: false,
-  });
+  res.headers.set("cache-control", "no-store");
+  clearCookies(res);
   return res;
 }
 
-async function revokeRefreshAtHydra(session: {
-  vanaUserId: string;
-  hydraSessionId: string;
-}): Promise<void> {
-  // We don't have the raw refresh token in this context. Hydra's
-  // admin endpoint can revoke by consent session id which is what we
-  // store as hydra_session_id. Use admin DELETE
-  // /admin/oauth2/auth/sessions/login?subject=<sub> to invalidate the
-  // login session, OR /admin/oauth2/auth/sessions/consent to drop
-  // outstanding consents.
+/**
+ * Revoke ALL Hydra-side login sessions for the given subject. Per Ory docs,
+ * this is the canonical way to invalidate every token issued under any
+ * session for that subject; subsequent introspections return active:false.
+ *
+ * TODO(prod): if/when a single subject can have multiple concurrent device
+ * sessions and we want device-scoped logout, switch to the per-session
+ * consent-revoke endpoint keyed by `sid`.
+ */
+async function revokeHydraSubjectSession(vanaUserId: string): Promise<void> {
   const hydraAdminUrl = process.env.HYDRA_ADMIN_URL;
-  if (!hydraAdminUrl) return;
+  if (!hydraAdminUrl) {
+    throw new Error("HYDRA_ADMIN_URL is not configured");
+  }
   const hydraAdminAudience = process.env.HYDRA_ADMIN_AUDIENCE ?? hydraAdminUrl;
   const adminBearer = await fetchGoogleIdTokenForAudience(hydraAdminAudience);
   const url = `${hydraAdminUrl.replace(
     /\/+$/,
     "",
-  )}/admin/oauth2/auth/sessions/login?subject=${encodeURIComponent(
-    session.vanaUserId,
-  )}`;
-  await fetch(url, {
+  )}/admin/oauth2/auth/sessions/login?subject=${encodeURIComponent(vanaUserId)}`;
+  const response = await fetch(url, {
     method: "DELETE",
     headers: {
       ...(adminBearer ? { authorization: `Bearer ${adminBearer}` } : {}),
     },
   });
+  if (!response.ok && response.status !== 404) {
+    // 404 is treated as success: nothing to revoke. Other non-2xx is loud.
+    throw new Error(
+      `Hydra admin DELETE returned ${response.status}: ${await safeReadBody(response)}`,
+    );
+  }
 }
 
-async function endHydraSession(session: { vanaUserId: string }): Promise<void> {
-  // The standard end-session endpoint is on the public Hydra URL and
-  // requires id_token_hint, which we don't have here. The admin-driven
-  // session deletion above achieves the same effective result for
-  // server-side SSO state. Public end-session is a best-effort browser
-  // redirect that's better handled by the client logout flow.
-  void session; // mark used; no-op for now.
+async function safeReadBody(response: Response): Promise<string> {
+  try {
+    return (await response.text()).slice(0, 512);
+  } catch {
+    return "<unreadable>";
+  }
 }

--- a/connect/src/app/api/auth/session/route.test.ts
+++ b/connect/src/app/api/auth/session/route.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
@@ -5,6 +6,7 @@ const mocks = vi.hoisted(() => ({
   resolveVanaUserByPrivyEvidence: vi.fn(),
   exchangeForVanaSession: vi.fn(),
   insertRefreshToken: vi.fn(),
+  insertActiveSession: vi.fn(),
 }));
 
 vi.mock("@privy-io/node", () => ({
@@ -25,6 +27,7 @@ vi.mock("@/lib/auth/hydra-headless-oidc", () => ({
 
 vi.mock("@/lib/db/sessions", () => ({
   insertRefreshToken: mocks.insertRefreshToken,
+  insertActiveSession: mocks.insertActiveSession,
 }));
 
 async function importRoute() {
@@ -32,6 +35,21 @@ async function importRoute() {
 }
 
 const VALID_VANA_USER_ID = "vana_user_" + "0".repeat(32);
+const HYDRA_SID = "hydra_session_test";
+
+/**
+ * Build a JWT-looking string with a payload containing the given claims.
+ * Signature segment is irrelevant — the route does not verify it (trust
+ * boundary is the TLS-terminated Hydra exchange).
+ */
+function makeIdToken(payload: Record<string, unknown>): string {
+  const header = Buffer.from(
+    JSON.stringify({ alg: "RS256", typ: "JWT" }),
+  ).toString("base64url");
+  const body = Buffer.from(JSON.stringify(payload)).toString("base64url");
+  const sig = "stub-signature";
+  return `${header}.${body}.${sig}`;
+}
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -100,20 +118,24 @@ describe("POST /api/auth/session", () => {
     mocks.exchangeForVanaSession.mockResolvedValue({
       access_token: "ory_at_test",
       refresh_token: "ory_rt_test",
+      id_token: makeIdToken({ sub: VALID_VANA_USER_ID, sid: HYDRA_SID }),
       expires_in: 900,
       token_type: "bearer",
     });
+    mocks.insertActiveSession.mockResolvedValue({});
     mocks.insertRefreshToken.mockResolvedValue({
       id: "vana_rt_test",
       family_id: "vana_rtfam_test",
     });
 
+    const before = Date.now();
     const response = await POST(
       new Request("https://account.vana.org/api/auth/session", {
         method: "POST",
         headers: { authorization: "Bearer privy-token" },
       }),
     );
+    const after = Date.now();
 
     expect(response.status).toBe(200);
     expect(mocks.privyUsersGet).toHaveBeenCalledWith({
@@ -134,7 +156,33 @@ describe("POST /api/auth/session", () => {
       audience: ["account.vana.org"],
       scope: ["openid", "offline"],
     });
+
+    // Active-session insert: tokenHash = sha256(access_token) hex; sid from id_token;
+    // expiresAt = now + expires_in seconds.
+    const expectedTokenHash = createHash("sha256")
+      .update("ory_at_test", "utf8")
+      .digest("hex");
+    expect(mocks.insertActiveSession).toHaveBeenCalledOnce();
+    const activeSessionArg = mocks.insertActiveSession.mock.calls[0]?.[0] as {
+      tokenHash: string;
+      sid: string;
+      vanaUserId: string;
+      expiresAt: Date;
+    };
+    expect(activeSessionArg.tokenHash).toBe(expectedTokenHash);
+    expect(activeSessionArg.sid).toBe(HYDRA_SID);
+    expect(activeSessionArg.vanaUserId).toBe(VALID_VANA_USER_ID);
+    expect(activeSessionArg.expiresAt).toBeInstanceOf(Date);
+    const expiresMs = activeSessionArg.expiresAt.getTime();
+    // 900s window with generous slack to absorb test scheduling jitter.
+    expect(expiresMs).toBeGreaterThanOrEqual(before + 900 * 1000 - 1000);
+    expect(expiresMs).toBeLessThanOrEqual(after + 900 * 1000 + 1000);
+
     expect(mocks.insertRefreshToken).toHaveBeenCalledOnce();
+    const refreshArg = mocks.insertRefreshToken.mock.calls[0]?.[0] as {
+      hydraSessionId: string;
+    };
+    expect(refreshArg.hydraSessionId).toBe(HYDRA_SID);
 
     const setCookie = response.headers.get("set-cookie") ?? "";
     expect(setCookie).toContain("vana_session=ory_at_test");
@@ -168,6 +216,63 @@ describe("POST /api/auth/session", () => {
     expect(response.status).toBe(502);
     const body = await response.json();
     expect(body.error.code).toBe("hydra_session_failed");
+  });
+
+  it("returns 502 when the Hydra id_token is missing the sid claim", async () => {
+    const { POST } = await importRoute();
+    mocks.privyUsersGet.mockResolvedValue({
+      id: "did:privy:user-1",
+      linked_accounts: [],
+    });
+    mocks.resolveVanaUserByPrivyEvidence.mockResolvedValue({
+      user: { id: VALID_VANA_USER_ID },
+    });
+    mocks.exchangeForVanaSession.mockResolvedValue({
+      access_token: "ory_at_test",
+      refresh_token: "ory_rt_test",
+      // id_token without sid — issuer-config failure.
+      id_token: makeIdToken({ sub: VALID_VANA_USER_ID }),
+      expires_in: 900,
+      token_type: "bearer",
+    });
+    const response = await POST(
+      new Request("https://account.vana.org/api/auth/session", {
+        method: "POST",
+        headers: { authorization: "Bearer privy-token" },
+      }),
+    );
+    expect(response.status).toBe(502);
+    const body = await response.json();
+    expect(body.error.code).toBe("id_token_missing_sid");
+    expect(mocks.insertActiveSession).not.toHaveBeenCalled();
+    expect(mocks.insertRefreshToken).not.toHaveBeenCalled();
+  });
+
+  it("returns 502 when the Hydra response omits the id_token entirely", async () => {
+    const { POST } = await importRoute();
+    mocks.privyUsersGet.mockResolvedValue({
+      id: "did:privy:user-1",
+      linked_accounts: [],
+    });
+    mocks.resolveVanaUserByPrivyEvidence.mockResolvedValue({
+      user: { id: VALID_VANA_USER_ID },
+    });
+    mocks.exchangeForVanaSession.mockResolvedValue({
+      access_token: "ory_at_test",
+      refresh_token: "ory_rt_test",
+      // No id_token at all.
+      expires_in: 900,
+      token_type: "bearer",
+    });
+    const response = await POST(
+      new Request("https://account.vana.org/api/auth/session", {
+        method: "POST",
+        headers: { authorization: "Bearer privy-token" },
+      }),
+    );
+    expect(response.status).toBe(502);
+    const body = await response.json();
+    expect(body.error.code).toBe("id_token_missing_sid");
   });
 
   it("returns 500 when Vana user resolution fails", async () => {

--- a/connect/src/app/api/auth/session/route.ts
+++ b/connect/src/app/api/auth/session/route.ts
@@ -12,23 +12,29 @@
  *      login + consent server-side via admin API and capturing the code
  *      from Hydra's redirect chain. Exchanges the code for an opaque
  *      access_token + refresh_token.
- *   5. Refresh token is encrypted (AES-256-GCM, KEK = REFRESH_TOKEN_ENC_KEY)
+ *   5. Hydra `sid` is captured from the OIDC id_token (Hydra's RFC 7662
+ *      introspection response does NOT carry sid) and persisted to
+ *      vana_active_sessions, keyed by sha256(access_token). The verifier
+ *      reads this row on every authenticated request.
+ *   6. Refresh token is encrypted (AES-256-GCM, KEK = REFRESH_TOKEN_ENC_KEY)
  *      and persisted to vana_refresh_tokens.
- *   6. Cookies set:
+ *   7. Cookies set:
  *      - `vana_session` (HttpOnly, SameSite=Lax) — the access token.
  *        Only used for GET/HEAD/OPTIONS (cookie auth on read paths).
  *      - `vana_access`  (NOT HttpOnly, SameSite=Lax) — the access token
  *        as a JS-readable companion. Browser fetch helpers send it as
  *        `Authorization: Bearer <vana_access>` for state-mutating calls.
- *   7. Returns the tokens in the JSON body too, for non-browser callers.
+ *   8. Returns the tokens in the JSON body too, for non-browser callers.
  *
  * DELETE on this route is the legacy logout endpoint; logout has moved to
- * /api/auth/logout (with proper tombstone-first sequencing). DELETE here
- * is kept for transitional callers and just clears cookies.
+ * /api/auth/logout (which deletes the active-session rows for the sid and
+ * revokes the Hydra session). DELETE here is kept for transitional callers
+ * and just clears cookies.
  *
  * See docs/auth-redesign/01-architecture.md §3.3, §7.1.
  */
 
+import { createHash } from "node:crypto";
 import { PrivyClient } from "@privy-io/node";
 import { NextResponse } from "next/server";
 import {
@@ -39,7 +45,7 @@ import {
 } from "@/lib/auth/login-session-adapter";
 import { resolveVanaUserByPrivyEvidence } from "@/lib/db/account";
 import { exchangeForVanaSession } from "@/lib/auth/hydra-headless-oidc";
-import { insertRefreshToken } from "@/lib/db/sessions";
+import { insertActiveSession, insertRefreshToken } from "@/lib/db/sessions";
 
 export const runtime = "nodejs";
 
@@ -90,6 +96,32 @@ function evidenceFromPrivyUser(user: PrivyVerifiedUser): LoginEvidence | null {
 }
 
 const COOKIE_NAMES = ["vana_session", "vana_access"];
+
+/**
+ * Decode the OIDC id_token payload (middle JWT segment) and pull `sid`.
+ *
+ * Hydra issues an id_token whenever the client requests `openid` scope, and
+ * OIDC requires a `sid` claim when session-management is in use (which it
+ * is for our login flow). We do NOT verify the JWT signature here — the
+ * id_token was just minted by Hydra and returned to us over a server-to-
+ * server TLS channel via PKCE; the trust boundary is the TLS connection.
+ */
+function extractSidFromIdToken(idToken: string | undefined): string | null {
+  if (!idToken) return null;
+  const parts = idToken.split(".");
+  if (parts.length < 2) return null;
+  try {
+    const payload = JSON.parse(
+      Buffer.from(parts[1], "base64url").toString("utf8"),
+    ) as { sid?: unknown };
+    if (typeof payload.sid !== "string" || payload.sid.length === 0) {
+      return null;
+    }
+    return payload.sid;
+  } catch {
+    return null;
+  }
+}
 
 export async function POST(request: Request): Promise<Response> {
   const token = readBearerToken(request);
@@ -166,20 +198,58 @@ export async function POST(request: Request): Promise<Response> {
     );
   }
 
-  // 4. Persist the refresh token, encrypted at rest.
+  // 4. Capture the Hydra session id (`sid`) from the OIDC id_token. Hydra's
+  //    RFC 7662 introspection response does NOT surface sid, so we record it
+  //    here at login and look it up server-side on every verification.
+  //
+  //    No JWT signature verification: we just exchanged this id_token with
+  //    Hydra server-side over TLS via PKCE; the trust boundary is the TLS
+  //    connection, not the JWT signature.
+  const sid = extractSidFromIdToken(tokens.id_token);
+  if (!sid) {
+    console.error(
+      "[api/auth/session] id_token missing sid claim — issuer-config failure",
+    );
+    return NextResponse.json(
+      { error: { code: "id_token_missing_sid" } },
+      { status: 502 },
+    );
+  }
+
+  // 5. Persist the access-token → sid binding. The verifier
+  //    (getVanaSession) reads this on every authenticated request.
+  const tokenHash = createHash("sha256")
+    .update(tokens.access_token, "utf8")
+    .digest("hex");
+  const accessTtlSec = tokens.expires_in ?? 15 * 60;
+  const accessExpiresAt = new Date(Date.now() + accessTtlSec * 1000);
+  try {
+    await insertActiveSession({
+      tokenHash,
+      sid,
+      vanaUserId,
+      expiresAt: accessExpiresAt,
+    });
+  } catch (err) {
+    console.error(
+      "[api/auth/session] insertActiveSession failed",
+      err instanceof Error ? err.message : err,
+    );
+    return NextResponse.json(
+      { error: { code: "active_session_persist_failed" } },
+      { status: 500 },
+    );
+  }
+
+  // 6. Persist the refresh token, encrypted at rest.
   if (tokens.refresh_token) {
     try {
-      // We don't have the Hydra session_id surfaced here directly; use the
-      // access token's sha256 prefix as a fallback. The introspection
-      // verifier (getVanaSession) extracts the canonical sid via Hydra.
-      // TODO: thread the session_id through if the introspection contract
-      // surfaces it on the immediate token-exchange response.
-      const expiresAt = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000);
+      const refreshExpiresAt = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000);
       await insertRefreshToken({
         vanaUserId,
-        hydraSessionId: `pending_${vanaUserId.slice(-8)}_${Date.now()}`,
+        hydraSessionId: sid,
         refreshToken: tokens.refresh_token,
-        expiresAt,
+        expiresAt: refreshExpiresAt,
       });
     } catch (err) {
       console.warn(
@@ -192,8 +262,7 @@ export async function POST(request: Request): Promise<Response> {
     }
   }
 
-  // 5. Set cookies + return token bundle.
-  const accessTtlSec = tokens.expires_in ?? 15 * 60;
+  // 7. Set cookies + return token bundle.
   const isProd = process.env.NODE_ENV === "production";
   const response = NextResponse.json(
     {

--- a/connect/src/lib/auth/vana-session.test.ts
+++ b/connect/src/lib/auth/vana-session.test.ts
@@ -20,7 +20,8 @@ function makeIntrospectResponse(
     exp: Math.floor(Date.now() / 1000) + 600,
     iss: "https://hydra.test",
     scope: "openid offline",
-    sid: HYDRA_SID,
+    // Note: Hydra's RFC 7662 introspection response does NOT include `sid`.
+    // The verifier reads sid from vana_active_sessions via the dep override.
     ...overrides,
   };
   return new Response(JSON.stringify(body), {
@@ -45,6 +46,19 @@ function makeReq(
   });
 }
 
+import type { ActiveSessionRow } from "@/lib/db/sessions";
+
+function makeActiveSessionRow(
+  overrides: Partial<ActiveSessionRow> = {},
+): ActiveSessionRow {
+  return {
+    sid: HYDRA_SID,
+    vanaUserId: VALID_SUB,
+    expiresAt: new Date(Date.now() + 60_000),
+    ...overrides,
+  };
+}
+
 function makeDeps(
   overrides: Partial<GetVanaSessionDeps> = {},
   fetchImpl?: (input: string, init?: RequestInit) => Promise<Response>,
@@ -66,7 +80,7 @@ function makeDeps(
     hydraAdminAudience: "https://hydra-admin.test",
     hydraPublicUrl: "https://hydra.test",
     expectedAudience: "account.vana.org",
-    isSessionTombstoned: async () => false,
+    findActiveSessionByTokenHash: async () => makeActiveSessionRow(),
     now: () => Date.now(),
     ...overrides,
   };
@@ -201,28 +215,73 @@ describe("getVanaSession introspection validation", () => {
   });
 });
 
-describe("getVanaSession tombstone integration", () => {
-  it("returns null when session is tombstoned", async () => {
+describe("getVanaSession active-session lookup", () => {
+  it("returns the session with sid from the active-session row", async () => {
     const session = await getVanaSession(
       makeReq({ bearer: "tok" }),
-      makeDeps({ isSessionTombstoned: async () => true }),
+      makeDeps({
+        findActiveSessionByTokenHash: async () =>
+          makeActiveSessionRow({ sid: "hydra_session_xyz" }),
+      }),
+    );
+    expect(session?.hydraSessionId).toBe("hydra_session_xyz");
+    expect(session?.vanaUserId).toBe(VALID_SUB);
+  });
+
+  it("returns null when no active-session row exists for the token", async () => {
+    const session = await getVanaSession(
+      makeReq({ bearer: "tok" }),
+      makeDeps({
+        findActiveSessionByTokenHash: async () => null,
+      }),
     );
     expect(session).toBeNull();
   });
 
-  it("calls tombstone check exactly once per session within 5s cache window", async () => {
-    let tombstoneCalls = 0;
+  it("calls active-session lookup exactly once within 5s cache window", async () => {
+    let lookups = 0;
     const deps = makeDeps({
-      isSessionTombstoned: async () => {
-        tombstoneCalls++;
-        return false;
+      findActiveSessionByTokenHash: async () => {
+        lookups++;
+        return makeActiveSessionRow();
       },
     });
 
     await getVanaSession(makeReq({ bearer: "tok" }), deps);
     await getVanaSession(makeReq({ bearer: "tok" }), deps);
     await getVanaSession(makeReq({ bearer: "tok" }), deps);
-    expect(tombstoneCalls).toBe(1);
+    expect(lookups).toBe(1);
+  });
+
+  it("re-queries after the active-session cache expires", async () => {
+    let lookups = 0;
+    let now = Date.now();
+    const deps = makeDeps({
+      findActiveSessionByTokenHash: async () => {
+        lookups++;
+        return makeActiveSessionRow();
+      },
+      now: () => now,
+    });
+    await getVanaSession(makeReq({ bearer: "tok" }), deps);
+    expect(lookups).toBe(1);
+    // Advance past the 5s active-session cache.
+    now += 6_000;
+    await getVanaSession(makeReq({ bearer: "tok" }), deps);
+    expect(lookups).toBe(2);
+  });
+
+  it("passes the sha256(token) hex digest as the lookup key", async () => {
+    const seenKeys: string[] = [];
+    const deps = makeDeps({
+      findActiveSessionByTokenHash: async (key: string) => {
+        seenKeys.push(key);
+        return makeActiveSessionRow();
+      },
+    });
+    await getVanaSession(makeReq({ bearer: "tok" }), deps);
+    expect(seenKeys).toHaveLength(1);
+    expect(seenKeys[0]).toMatch(/^[0-9a-f]{64}$/);
   });
 });
 

--- a/connect/src/lib/auth/vana-session.ts
+++ b/connect/src/lib/auth/vana-session.ts
@@ -22,8 +22,12 @@
  *      `account.vana.org`, `exp` not exceeded (60s clock skew tolerance),
  *      `token_use === 'access_token'`.
  *
- *   5. Tombstone check: SELECT 1 FROM vana_session_tombstones — multi-lambda
- *      revocation. Cached 5s in-process to keep DB load manageable.
+ *   5. Active-session lookup: SELECT sid FROM vana_active_sessions WHERE
+ *      token_hash = sha256(token). The sid is captured at login from the
+ *      Hydra id_token (Hydra's RFC 7662 introspection response does NOT
+ *      carry sid). Missing row → 401. Cached 5s in-process to keep DB
+ *      load manageable; revocation/logout deletes the row(s) for the sid,
+ *      so propagation is bounded by that TTL.
  *
  *   6. assertVanaUserId(result.sub) — throws if `sub` is not the canonical
  *      `vana_user_<32hex>` shape; caught and treated as null.
@@ -33,7 +37,7 @@
 
 import { createHash } from "node:crypto";
 import { fetchGoogleIdTokenForAudience } from "./google-id-token";
-import { isSessionTombstoned } from "@/lib/db/sessions";
+import { findActiveSessionByTokenHash } from "@/lib/db/sessions";
 
 // Branded type stub. Stage 6 brings the brand; here it's a string alias.
 type VanaUserId = string;
@@ -56,7 +60,7 @@ const SESSION_COOKIE_NAME = "vana_session";
 const READ_ONLY_METHODS = new Set(["GET", "HEAD", "OPTIONS"]);
 
 const INTROSPECTION_CACHE_TTL_MS = 30_000;
-const TOMBSTONE_CACHE_TTL_MS = 5_000;
+const ACTIVE_SESSION_CACHE_TTL_MS = 5_000;
 const CLOCK_SKEW_SECONDS = 60;
 
 type IntrospectionResult = {
@@ -76,20 +80,20 @@ type CachedIntrospection = {
   cachedAt: number;
 };
 
-type CachedTombstone = {
-  tombstoned: boolean;
+type CachedActiveSession = {
+  sid: string | null;
   cachedAt: number;
 };
 
 /**
  * Per-process LRU caches. Multi-lambda revocation correctness comes from the
- * tombstone check which DOES round-trip Postgres on cache miss; the
+ * active-session lookup which DOES round-trip Postgres on cache miss; the
  * introspection cache only saves Hydra calls.
  */
 const introspectionCache = new Map<string, CachedIntrospection>();
-const tombstoneCache = new Map<string, CachedTombstone>();
+const activeSessionCache = new Map<string, CachedActiveSession>();
 const INTROSPECTION_CACHE_MAX = 10_000;
-const TOMBSTONE_CACHE_MAX = 10_000;
+const ACTIVE_SESSION_CACHE_MAX = 10_000;
 
 function pruneCache<V>(cache: Map<string, V>, maxSize: number) {
   if (cache.size <= maxSize) return;
@@ -114,7 +118,7 @@ export type GetVanaSessionDeps = {
   /** Audience this verifier accepts. Defaults to env (e.g. `account.vana.org`). */
   expectedAudience?: string;
   /** Override for tests. */
-  isSessionTombstoned?: (hydraSessionId: string) => Promise<boolean>;
+  findActiveSessionByTokenHash?: typeof findActiveSessionByTokenHash;
   /** Override for tests. */
   now?: () => number;
 };
@@ -131,7 +135,7 @@ function defaultDeps(): Required<
     | "hydraAdminAudience"
     | "hydraPublicUrl"
     | "expectedAudience"
-    | "isSessionTombstoned"
+    | "findActiveSessionByTokenHash"
     | "now"
   >
 > {
@@ -142,14 +146,14 @@ function defaultDeps(): Required<
     hydraPublicUrl: readEnv("HYDRA_PUBLIC_URL") ?? "",
     expectedAudience:
       readEnv("VANA_SESSION_EXPECTED_AUDIENCE") ?? "account.vana.org",
-    isSessionTombstoned,
+    findActiveSessionByTokenHash,
     now: () => Date.now(),
   };
 }
 
 /**
  * Public API. Returns null on any failure (missing/invalid/expired/revoked
- * token, malformed `sub`, audience mismatch, tombstoned session).
+ * token, malformed `sub`, audience mismatch, missing active-session row).
  *
  * Routes treat null as 401. They MUST NOT distinguish failure modes in the
  * response (no leaking introspection errors to the client).
@@ -173,10 +177,8 @@ export async function getVanaSession(
   if (!validateClaims(result, deps)) return null;
   if (!isValidVanaUserId(result.sub)) return null;
 
-  const hydraSessionId = extractSessionId(result);
+  const hydraSessionId = await lookupActiveSessionSid(token, deps);
   if (!hydraSessionId) return null;
-
-  if (await isTombstoned(hydraSessionId, deps)) return null;
 
   return {
     vanaUserId: result.sub,
@@ -189,7 +191,7 @@ export async function getVanaSession(
 /** Strictly for tests: clear all in-process caches. */
 export function clearVanaSessionCaches(): void {
   introspectionCache.clear();
-  tombstoneCache.clear();
+  activeSessionCache.clear();
 }
 
 // ---------- internals ----------
@@ -313,35 +315,34 @@ function parseScope(scope: string | undefined): string[] {
 }
 
 /**
- * Hydra access tokens carry a session identifier. The exact location depends
- * on the introspection response shape; we accept any of the conventional
- * fields (`sid`, `sub` is reserved for vana_user_id, `client_id` is wrong).
- * If none, derive a stable hash from token+sub as a fallback so tombstones
- * still have something to key on. (Hydra reliably exposes a session id; the
- * fallback is defense-in-depth, not the primary path.)
+ * Resolve the Hydra `sid` for this access token via vana_active_sessions.
+ *
+ * Hydra's RFC 7662 introspection response does NOT carry `sid`. We capture
+ * it once at login from the OIDC id_token and persist it server-side keyed
+ * by sha256(access_token). Logout deletes rows for the sid, so a missing
+ * row here is a hard 401.
+ *
+ * Cached per-process for ACTIVE_SESSION_CACHE_TTL_MS (5s) — short enough
+ * that revocation propagates within 5s across lambdas, long enough to keep
+ * Postgres load proportional to unique tokens, not to request volume.
  */
-function extractSessionId(result: IntrospectionResult): string | null {
-  // Hydra exposes `sid` on JWT tokens; opaque introspection includes it as
-  // `ext.sid` or `sid` depending on version.
-  const sid =
-    (result as { sid?: unknown }).sid ??
-    (result.ext as { sid?: unknown } | undefined)?.sid;
-  if (typeof sid === "string" && sid.length > 0) return sid;
-  return null;
-}
-
-async function isTombstoned(
-  hydraSessionId: string,
-  deps: Required<Pick<GetVanaSessionDeps, "isSessionTombstoned" | "now">>,
-): Promise<boolean> {
-  const cached = tombstoneCache.get(hydraSessionId);
-  if (cached && deps.now() - cached.cachedAt < TOMBSTONE_CACHE_TTL_MS) {
-    return cached.tombstoned;
+async function lookupActiveSessionSid(
+  token: string,
+  deps: Required<
+    Pick<GetVanaSessionDeps, "findActiveSessionByTokenHash" | "now">
+  >,
+): Promise<string | null> {
+  const tokenHash = tokenCacheKey(token);
+  const cached = activeSessionCache.get(tokenHash);
+  if (cached && deps.now() - cached.cachedAt < ACTIVE_SESSION_CACHE_TTL_MS) {
+    return cached.sid;
   }
-  if (cached) tombstoneCache.delete(hydraSessionId);
+  if (cached) activeSessionCache.delete(tokenHash);
 
-  const tombstoned = await deps.isSessionTombstoned(hydraSessionId);
-  tombstoneCache.set(hydraSessionId, { tombstoned, cachedAt: deps.now() });
-  pruneCache(tombstoneCache, TOMBSTONE_CACHE_MAX);
-  return tombstoned;
+  const row = await deps.findActiveSessionByTokenHash(tokenHash);
+  const sid =
+    row && typeof row.sid === "string" && row.sid.length > 0 ? row.sid : null;
+  activeSessionCache.set(tokenHash, { sid, cachedAt: deps.now() });
+  pruneCache(activeSessionCache, ACTIVE_SESSION_CACHE_MAX);
+  return sid;
 }

--- a/connect/src/lib/db/sessions.test.ts
+++ b/connect/src/lib/db/sessions.test.ts
@@ -1,9 +1,14 @@
 // @vitest-environment node
 
 import { afterAll, describe, expect, it } from "vitest";
+import { createHash, randomBytes } from "node:crypto";
 import {
   __testing__,
+  deleteActiveSessionsBySid,
+  deleteExpiredActiveSessions,
+  findActiveSessionByTokenHash,
   gcExpiredTombstones,
+  insertActiveSession,
   insertRefreshToken,
   insertTombstone,
   isSessionTombstoned,
@@ -32,6 +37,12 @@ function uniqueSuffix(): string {
 
 const createdUserIds = new Set<string>();
 const insertedSessionIds = new Set<string>();
+const insertedTokenHashes = new Set<string>();
+const insertedActiveSids = new Set<string>();
+
+function fakeTokenHash(): string {
+  return createHash("sha256").update(randomBytes(16)).digest("hex");
+}
 
 function getTestSQL() {
   return getSql() as unknown as (
@@ -51,8 +62,20 @@ afterAll(async () => {
       () => null,
     );
   }
+  for (const hash of insertedTokenHashes) {
+    await sql`DELETE FROM vana_active_sessions WHERE token_hash = ${hash}`.catch(
+      () => null,
+    );
+  }
+  for (const sid of insertedActiveSids) {
+    await sql`DELETE FROM vana_active_sessions WHERE sid = ${sid}`.catch(
+      () => null,
+    );
+  }
   createdUserIds.clear();
   insertedSessionIds.clear();
+  insertedTokenHashes.clear();
+  insertedActiveSids.clear();
 });
 
 // --- pure crypto, no DB ---
@@ -235,5 +258,127 @@ dbDescribe("vana_session_tombstones", () => {
     expect(deleted).toBeGreaterThanOrEqual(1);
 
     expect(await isSessionTombstoned(sessionId)).toBe(false);
+  });
+});
+
+dbDescribe("vana_active_sessions", () => {
+  it("insertActiveSession + findActiveSessionByTokenHash round-trip", async () => {
+    const user = await createVanaUser();
+    createdUserIds.add(user.user.id);
+    const tokenHash = fakeTokenHash();
+    insertedTokenHashes.add(tokenHash);
+    const sid = `hydra_sid_${uniqueSuffix()}`;
+    insertedActiveSids.add(sid);
+    const expiresAt = new Date(Date.now() + 15 * 60 * 1000);
+
+    await insertActiveSession({
+      tokenHash,
+      sid,
+      vanaUserId: user.user.id,
+      expiresAt,
+    });
+
+    const found = await findActiveSessionByTokenHash(tokenHash);
+    expect(found).not.toBeNull();
+    expect(found?.sid).toBe(sid);
+    expect(found?.vanaUserId).toBe(user.user.id);
+    expect(found?.expiresAt.getTime()).toBe(expiresAt.getTime());
+  });
+
+  it("insertActiveSession is idempotent on token_hash collision", async () => {
+    const user = await createVanaUser();
+    createdUserIds.add(user.user.id);
+    const tokenHash = fakeTokenHash();
+    insertedTokenHashes.add(tokenHash);
+    const sid = `hydra_sid_${uniqueSuffix()}`;
+    insertedActiveSids.add(sid);
+    const expiresAt = new Date(Date.now() + 15 * 60 * 1000);
+
+    await insertActiveSession({
+      tokenHash,
+      sid,
+      vanaUserId: user.user.id,
+      expiresAt,
+    });
+    // Re-insert with a different sid; ON CONFLICT DO NOTHING preserves first row.
+    const otherSid = `hydra_sid_${uniqueSuffix()}`;
+    insertedActiveSids.add(otherSid);
+    await insertActiveSession({
+      tokenHash,
+      sid: otherSid,
+      vanaUserId: user.user.id,
+      expiresAt,
+    });
+
+    const found = await findActiveSessionByTokenHash(tokenHash);
+    expect(found?.sid).toBe(sid);
+  });
+
+  it("findActiveSessionByTokenHash returns null for unknown hash", async () => {
+    const found = await findActiveSessionByTokenHash(fakeTokenHash());
+    expect(found).toBeNull();
+  });
+
+  it("deleteActiveSessionsBySid removes all rows sharing a sid", async () => {
+    const user = await createVanaUser();
+    createdUserIds.add(user.user.id);
+    const sid = `hydra_sid_${uniqueSuffix()}`;
+    insertedActiveSids.add(sid);
+    const expiresAt = new Date(Date.now() + 15 * 60 * 1000);
+
+    const hashA = fakeTokenHash();
+    const hashB = fakeTokenHash();
+    insertedTokenHashes.add(hashA);
+    insertedTokenHashes.add(hashB);
+
+    await insertActiveSession({
+      tokenHash: hashA,
+      sid,
+      vanaUserId: user.user.id,
+      expiresAt,
+    });
+    await insertActiveSession({
+      tokenHash: hashB,
+      sid,
+      vanaUserId: user.user.id,
+      expiresAt,
+    });
+
+    const deleted = await deleteActiveSessionsBySid(sid);
+    expect(deleted).toBe(2);
+    expect(await findActiveSessionByTokenHash(hashA)).toBeNull();
+    expect(await findActiveSessionByTokenHash(hashB)).toBeNull();
+  });
+
+  it("deleteExpiredActiveSessions removes only expired rows", async () => {
+    const user = await createVanaUser();
+    createdUserIds.add(user.user.id);
+
+    const expiredHash = fakeTokenHash();
+    const liveHash = fakeTokenHash();
+    insertedTokenHashes.add(expiredHash);
+    insertedTokenHashes.add(liveHash);
+    const expiredSid = `hydra_sid_${uniqueSuffix()}`;
+    const liveSid = `hydra_sid_${uniqueSuffix()}`;
+    insertedActiveSids.add(expiredSid);
+    insertedActiveSids.add(liveSid);
+
+    await insertActiveSession({
+      tokenHash: expiredHash,
+      sid: expiredSid,
+      vanaUserId: user.user.id,
+      expiresAt: new Date(Date.now() - 60 * 1000),
+    });
+    await insertActiveSession({
+      tokenHash: liveHash,
+      sid: liveSid,
+      vanaUserId: user.user.id,
+      expiresAt: new Date(Date.now() + 15 * 60 * 1000),
+    });
+
+    const deleted = await deleteExpiredActiveSessions();
+    expect(deleted).toBeGreaterThanOrEqual(1);
+    expect(await findActiveSessionByTokenHash(expiredHash)).toBeNull();
+    expect(await findActiveSessionByTokenHash(liveHash)).not.toBeNull();
   });
 });

--- a/connect/src/lib/db/sessions.ts
+++ b/connect/src/lib/db/sessions.ts
@@ -283,6 +283,79 @@ export async function gcExpiredTombstones(): Promise<number> {
   return (rows as DbRows).length;
 }
 
+// --- vana_active_sessions ---------------------------------------------------
+
+/**
+ * Active OIDC sessions, keyed by sha256(access_token). Captures the `sid`
+ * claim from the id_token at login so the session verifier can resolve a
+ * stable hydra session id on every introspection without trusting the client.
+ *
+ * Hydra v2 introspection (RFC 7662) does not expose `sid`, so we persist it
+ * here. See migration 009_active_sessions.sql.
+ */
+
+export type ActiveSessionRow = {
+  sid: string;
+  vanaUserId: VanaUserId;
+  expiresAt: Date;
+};
+
+export async function insertActiveSession(input: {
+  tokenHash: string;
+  sid: string;
+  vanaUserId: VanaUserId;
+  expiresAt: Date;
+}): Promise<void> {
+  const sql = getSql();
+  await sql`
+    INSERT INTO vana_active_sessions
+      (token_hash, sid, vana_user_id, expires_at)
+    VALUES
+      (${input.tokenHash}, ${input.sid}, ${input.vanaUserId},
+       ${input.expiresAt.toISOString()})
+    ON CONFLICT (token_hash) DO NOTHING
+  `;
+}
+
+export async function findActiveSessionByTokenHash(
+  tokenHash: string,
+): Promise<ActiveSessionRow | null> {
+  const sql = getSql();
+  const rows = await sql`
+    SELECT sid, vana_user_id, expires_at
+      FROM vana_active_sessions
+     WHERE token_hash = ${tokenHash}
+     LIMIT 1
+  `;
+  const row = (rows as DbRows)[0];
+  if (!row) return null;
+  return {
+    sid: row.sid as string,
+    vanaUserId: row.vana_user_id as VanaUserId,
+    expiresAt: new Date(row.expires_at as string),
+  };
+}
+
+export async function deleteActiveSessionsBySid(sid: string): Promise<number> {
+  const sql = getSql();
+  const rows = await sql`
+    DELETE FROM vana_active_sessions
+     WHERE sid = ${sid}
+    RETURNING id
+  `;
+  return (rows as DbRows).length;
+}
+
+export async function deleteExpiredActiveSessions(): Promise<number> {
+  const sql = getSql();
+  const rows = await sql`
+    DELETE FROM vana_active_sessions
+     WHERE expires_at <= now()
+    RETURNING id
+  `;
+  return (rows as DbRows).length;
+}
+
 // Test-only helper, exported for unit tests.
 export const __testing__ = {
   encryptRefreshToken,

--- a/connect/src/lib/server-provider/gcp.ts
+++ b/connect/src/lib/server-provider/gcp.ts
@@ -17,6 +17,10 @@ const GCP_SERVICE_ACCOUNT_EMAIL = process.env.GCP_SERVICE_ACCOUNT_EMAIL ?? "";
 const PS_CONTAINER_IMAGE =
   process.env.PS_CONTAINER_IMAGE ?? "ghcr.io/vana-com/personal-server:latest";
 
+const VANA_INTROSPECTION_URL =
+  process.env.VANA_INTROSPECTION_URL ??
+  "https://account-dev.vana.org/api/oauth/introspect";
+
 const MYVANA_DOMAIN = "myvana.app";
 
 function mapGcpStatus(gcpStatus: string | null | undefined): ServerState {
@@ -233,6 +237,8 @@ TUNNEL_TOKEN=$(curl -s -H "Metadata-Flavor: Google" \\
   http://metadata.google.internal/computeMetadata/v1/instance/attributes/tunnel-token)
 PS_ACCESS_TOKEN_VAL=$(curl -s -H "Metadata-Flavor: Google" \\
   http://metadata.google.internal/computeMetadata/v1/instance/attributes/ps-access-token || true)
+INTROSPECTION_URL_VAL=$(curl -s -H "Metadata-Flavor: Google" \\
+  http://metadata.google.internal/computeMetadata/v1/instance/attributes/vana-introspection-url)
 
 # Mount persistent data disk (second disk)
 DATA_DIR="/var/ps-data"
@@ -266,6 +272,7 @@ docker run -d \\
   -e TUNNEL_ENABLED=false \\
   -e DEV_UI_ENABLED=false \\
   -e PS_ACCESS_TOKEN="$PS_ACCESS_TOKEN_VAL" \\
+  -e VANA_INTROSPECTION_URL="$INTROSPECTION_URL_VAL" \\
   "$CONTAINER_IMAGE"
 
 # Run cloudflared via Docker (COS has read-only root + noexec on /home)
@@ -403,6 +410,7 @@ export class GCPProvider implements ServerProvider {
             },
             { key: "container-image", value: PS_CONTAINER_IMAGE },
             { key: "tunnel-token", value: tunnel.tunnelToken },
+            { key: "vana-introspection-url", value: VANA_INTROSPECTION_URL },
             ...(params.psAccessToken
               ? [{ key: "ps-access-token", value: params.psAccessToken }]
               : []),


### PR DESCRIPTION
## Summary

Replaces the broken session-id tombstone layer (which 401'd every valid token because it expected `sid` from Hydra's introspection response — Hydra v2 opaque introspection per RFC 7662 does not include `sid`/`jti`) with the documented Auth0/Okta/Ory pattern: opaque-token introspection + server-side capture of `sid` from the OIDC id_token at login.

## Why this shape

**Researched both** Ory Hydra docs/OpenAPI and SLVP industry patterns (Stripe, Linear, Vercel, Plaid, Auth0, Okta) before writing code. Findings:

- Hydra v2 opaque introspection schema confirms no `sid`/`jti`. ([Hydra OpenAPI](https://github.com/ory/hydra/blob/master/spec/api.json))
- OIDC `sid` lives in id_token, not introspection. ([OIDC Backchannel Logout](https://openid.net/specs/openid-connect-backchannel-1_0.html))
- Ory's own guidance: opaque tokens for immediate revocation; JWT for "eventually" revocation. ([Ory: JWT vs opaque](https://www.ory.sh/docs/oauth2-oidc/jwt-access-token))
- Auth0/Okta/Stripe/Plaid all use opaque tokens for user sessions, with introspection (and a 30–60s cache) as the revocation primitive.

Switching to JWT would have weakened revocation semantics. The right shape is opaque + introspection + sid-from-id_token, captured once at login.

## Changes

- **migration 009** — `vana_active_sessions(token_hash UNIQUE, sid, vana_user_id, expires_at)`. Tombstone scaffolding intentionally kept in place; a follow-up migration removes it.
- **`/api/auth/session`** — after Hydra token exchange, decode id_token middle segment, extract `sid`, persist `(sha256(access_token), sid, vanaUserId, exp)`. 502 with `id_token_missing_sid` if Hydra omits it (loud issuer-config failure).
- **`getVanaSession`** — drops tombstone branch; after valid introspection, looks up `sid` via `findActiveSessionByTokenHash`. 5s in-process cache.
- **`/api/auth/logout`** — calls Hydra admin `DELETE /admin/oauth2/auth/sessions/login?subject=<vanaUserId>` + `deleteActiveSessionsBySid`. Cookie clearing always succeeds; Hydra/DB failures logged but non-blocking.
- **`gcp.ts`** — provisioned PS VMs now receive `VANA_INTROSPECTION_URL` env var (dev default: `https://account-dev.vana.org/api/oauth/introspect`).
- **Migration applied to dev DB.**

## Verification

- `pnpm tsc --noEmit`: 0 errors
- `pnpm test --run`: 495/495 pass, 42 skipped (DB-gated)
- Manually verified Hydra dev `.well-known/openid-configuration` exposes `backchannel_logout_session_supported: true` (so id_tokens will carry `sid`)

## Test plan

- [x] Tests pass
- [ ] Deploy to develop, verify sign-in works at https://account-dev.vana.org
- [ ] Verify `GET /api/servers` no longer 401s
- [ ] Verify logout actually invalidates the session (Hydra DELETE call succeeds, future requests with the same cookie 401)