### PR TITLE
feat(auth): hydra device-grant flow + missing oidc pages

### DIFF
--- a/connect/src/app/api/auth/oidc/device-accept/route.test.ts
+++ b/connect/src/app/api/auth/oidc/device-accept/route.test.ts
@@ -1,0 +1,124 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getVanaSession: vi.fn(),
+  acceptDeviceUserCodeRequest: vi.fn(),
+}));
+
+vi.mock("@/lib/auth/vana-session", () => ({
+  getVanaSession: mocks.getVanaSession,
+}));
+
+vi.mock("@/lib/auth/hydra-admin", () => ({
+  createHydraAdminClient: () => ({
+    acceptDeviceUserCodeRequest: mocks.acceptDeviceUserCodeRequest,
+  }),
+}));
+
+async function importRoute() {
+  return await import("./route");
+}
+
+function makeRequest(body: unknown, opts: { bearer?: string } = {}): Request {
+  const headers = new Headers({ "content-type": "application/json" });
+  if (opts.bearer) headers.set("authorization", `Bearer ${opts.bearer}`);
+  return new Request("https://account.vana.test/api/auth/oidc/device-accept", {
+    method: "POST",
+    headers,
+    body: JSON.stringify(body),
+  });
+}
+
+const VALID_SESSION = {
+  vanaUserId: "vana_user_0123456789abcdef0123456789abcdef",
+  hydraSessionId: "hydra_session_abc",
+  scope: ["openid"],
+  audience: ["account.vana.org"],
+};
+
+describe("POST /api/auth/oidc/device-accept", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 401 when Vana session is missing", async () => {
+    mocks.getVanaSession.mockResolvedValue(null);
+    const { POST } = await importRoute();
+    const res = await POST(
+      makeRequest({ device_challenge: "x", user_code: "y" }) as never,
+    );
+    expect(res.status).toBe(401);
+    const body = (await res.json()) as { error?: { type?: string } };
+    expect(body.error?.type).toBe("authentication_error");
+    expect(mocks.acceptDeviceUserCodeRequest).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 on invalid JSON body", async () => {
+    mocks.getVanaSession.mockResolvedValue(VALID_SESSION);
+    const { POST } = await importRoute();
+    const malformed = new Request(
+      "https://account.vana.test/api/auth/oidc/device-accept",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: "not-json",
+      },
+    );
+    const res = await POST(malformed as never);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when device_challenge is missing", async () => {
+    mocks.getVanaSession.mockResolvedValue(VALID_SESSION);
+    const { POST } = await importRoute();
+    const res = await POST(makeRequest({ user_code: "ABCD-EFGH" }) as never);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when user_code is missing", async () => {
+    mocks.getVanaSession.mockResolvedValue(VALID_SESSION);
+    const { POST } = await importRoute();
+    const res = await POST(makeRequest({ device_challenge: "abc" }) as never);
+    expect(res.status).toBe(400);
+  });
+
+  it("calls Hydra admin with the inputs and returns redirect_to", async () => {
+    mocks.getVanaSession.mockResolvedValue(VALID_SESSION);
+    mocks.acceptDeviceUserCodeRequest.mockResolvedValue({
+      redirect_to: "https://hydra.example.com/oauth2/auth?ok=device",
+    });
+    const { POST } = await importRoute();
+    const res = await POST(
+      makeRequest({
+        device_challenge: "dev-chal-1",
+        user_code: "ABCD-EFGH",
+      }) as never,
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { redirect_to?: string };
+    expect(body.redirect_to).toBe(
+      "https://hydra.example.com/oauth2/auth?ok=device",
+    );
+    expect(mocks.acceptDeviceUserCodeRequest).toHaveBeenCalledWith(
+      "dev-chal-1",
+      { userCode: "ABCD-EFGH" },
+    );
+  });
+
+  it("returns 502 when Hydra admin throws", async () => {
+    mocks.getVanaSession.mockResolvedValue(VALID_SESSION);
+    mocks.acceptDeviceUserCodeRequest.mockRejectedValue(
+      new Error("hydra unreachable"),
+    );
+    const { POST } = await importRoute();
+    const res = await POST(
+      makeRequest({
+        device_challenge: "dev-chal-1",
+        user_code: "ABCD-EFGH",
+      }) as never,
+    );
+    expect(res.status).toBe(502);
+    const body = (await res.json()) as { error?: { type?: string } };
+    expect(body.error?.type).toBe("upstream_error");
+  });
+});

--- a/connect/src/app/api/auth/oidc/device-accept/route.ts
+++ b/connect/src/app/api/auth/oidc/device-accept/route.ts
@@ -1,0 +1,62 @@
+/**
+ * POST /api/auth/oidc/device-accept
+ *
+ * Called from the Hydra device-grant verification page (`/auth/oidc/device`)
+ * when the signed-in user clicks "Authorize". Calls Hydra admin's
+ * `acceptDeviceUserCodeRequest` and returns the redirect URL so the browser
+ * can navigate Hydra's continuation flow.
+ *
+ * Auth: requires a Vana session Bearer (state-mutating; no cookie fallback).
+ *
+ * Returns:
+ *   200 { redirect_to: <url> } on success.
+ *   400 if challenge or user_code missing.
+ *   401 if not signed in.
+ *   502 if Hydra rejects the accept call.
+ */
+
+import { type NextRequest, NextResponse } from "next/server";
+import { getVanaSession } from "@/lib/auth/vana-session";
+import { runOidcDeviceAccept } from "@/app/auth/oidc/oidc-route-runtime";
+
+export const runtime = "nodejs";
+
+export async function POST(request: NextRequest): Promise<Response> {
+  const session = await getVanaSession(request);
+  if (!session) {
+    return NextResponse.json(
+      { error: { type: "authentication_error", message: "Not authenticated" } },
+      { status: 401 },
+    );
+  }
+
+  let body: { device_challenge?: string; user_code?: string };
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json(
+      {
+        error: { type: "invalid_request_error", message: "Invalid JSON body" },
+      },
+      { status: 400 },
+    );
+  }
+
+  try {
+    return await runOidcDeviceAccept(body);
+  } catch (err) {
+    console.error(
+      "[api/auth/oidc/device-accept] Hydra accept failed",
+      err instanceof Error ? err.message : err,
+    );
+    return NextResponse.json(
+      {
+        error: {
+          type: "upstream_error",
+          message: "Could not accept device authorization.",
+        },
+      },
+      { status: 502 },
+    );
+  }
+}

--- a/connect/src/app/auth/oidc/device-success/page.tsx
+++ b/connect/src/app/auth/oidc/device-success/page.tsx
@@ -1,0 +1,28 @@
+import { PagePanel } from "@/app/_components/page-panel";
+import { PageShell } from "@/app/_components/page-shell";
+import { PageHeader } from "@/components/elements/page-header";
+import { Text } from "@/components/typography/text";
+
+/**
+ * Hydra device-grant terminal success page.
+ *
+ * Hydra redirects users here (`urls.device.success`) after a successful
+ * device-grant flow. The originating device polls Hydra's token endpoint
+ * separately and now has tokens; nothing further happens in this browser.
+ */
+export default function DeviceSuccessPage() {
+  return (
+    <PageShell>
+      <PagePanel>
+        <PageHeader
+          showVanaLogotype
+          color="iris"
+          heading="Device authorized"
+          description={
+            <Text>You can close this window and return to your device.</Text>
+          }
+        />
+      </PagePanel>
+    </PageShell>
+  );
+}

--- a/connect/src/app/auth/oidc/device/page.tsx
+++ b/connect/src/app/auth/oidc/device/page.tsx
@@ -1,0 +1,245 @@
+"use client";
+
+import { usePrivy } from "@privy-io/react-auth";
+import { useSearchParams } from "next/navigation";
+import { Suspense, useCallback, useEffect, useMemo, useState } from "react";
+import { PagePanel } from "@/app/_components/page-panel";
+import { PageShell } from "@/app/_components/page-shell";
+import { PageHeader } from "@/components/elements/page-header";
+import { PageLoadingState } from "@/components/elements/page-loading-state";
+import { Spinner } from "@/components/elements/spinner";
+import { Text } from "@/components/typography/text";
+import { Button } from "@/components/ui/button";
+
+/**
+ * Hydra device-grant verification page.
+ *
+ * Hydra (RFC 8628) redirects users here from `/oauth2/device/verify` with
+ * `?device_challenge=…&user_code=…`. We:
+ *
+ *   1. Display the user_code so the user can confirm it matches what their
+ *      device shows. Hydra has already validated that the code exists.
+ *   2. Require an explicit "Authorize" click. Per RFC 8628 §5.2 the device
+ *      grant requires user interaction; never auto-accept.
+ *   3. Sign the user in via Privy/Vana session if needed before showing the
+ *      authorize control.
+ *
+ * On Authorize, POST to `/api/auth/oidc/device-accept`. The response is
+ * `{ redirect_to }` (Hydra's URL — typically re-enters `/oauth2/auth` for
+ * login + consent under the device session). We navigate the browser there;
+ * after the consent flow completes, Hydra redirects to
+ * `urls.device.success` → `/auth/oidc/device-success`.
+ */
+
+function readVanaAccessCookie(): string | null {
+  if (typeof document === "undefined") return null;
+  for (const part of document.cookie.split(";")) {
+    const eq = part.indexOf("=");
+    if (eq < 0) continue;
+    const k = part.slice(0, eq).trim();
+    if (k !== "vana_access") continue;
+    const v = part.slice(eq + 1).trim();
+    return v ? decodeURIComponent(v) : null;
+  }
+  return null;
+}
+
+type AcceptStatus = "idle" | "submitting" | "approved" | "error";
+
+function DeviceVerificationContent() {
+  const searchParams = useSearchParams();
+  const { ready, authenticated } = usePrivy();
+
+  const deviceChallenge = searchParams.get("device_challenge");
+  const userCode = searchParams.get("user_code");
+
+  const [status, setStatus] = useState<AcceptStatus>("idle");
+  const [error, setError] = useState<string | null>(null);
+
+  const isLoggedIn = ready && authenticated;
+
+  const formattedUserCode = useMemo(() => {
+    if (!userCode) return "";
+    const upper = userCode.toUpperCase().replace(/[^A-Z0-9]/g, "");
+    if (upper.length === 8) return `${upper.slice(0, 4)}-${upper.slice(4)}`;
+    return upper;
+  }, [userCode]);
+
+  const handleSignIn = useCallback(() => {
+    // Send the user through `/login` so it can bootstrap the Vana session
+    // cookie (`vana_access`) we need on the Authorize POST. `usePrivy().login()`
+    // alone would only authenticate at the Privy layer; the cookie set by
+    // /api/auth/session would still be missing. Preserve the device params via
+    // return_to so the user lands back here ready to Authorize.
+    if (!deviceChallenge || !userCode) return;
+    const here =
+      `/auth/oidc/device?device_challenge=${encodeURIComponent(deviceChallenge)}` +
+      `&user_code=${encodeURIComponent(userCode)}`;
+    window.location.href = `/login?return_to=${encodeURIComponent(here)}`;
+  }, [deviceChallenge, userCode]);
+
+  const handleAuthorize = useCallback(async () => {
+    if (!deviceChallenge || !userCode) return;
+    setStatus("submitting");
+    setError(null);
+    try {
+      const accessToken = readVanaAccessCookie();
+      if (!accessToken) {
+        // Vana session bootstrap hasn't completed yet (Privy is signed in but
+        // the BFF hasn't issued vana_access). Drive the bootstrap by hitting
+        // /api/auth/session — but the page's normal Privy flow already does
+        // that on mount; if we're here without it, surface the gap.
+        throw new Error("Vana session not ready yet — refresh and try again.");
+      }
+      const res = await fetch("/api/auth/oidc/device-accept", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${accessToken}`,
+        },
+        body: JSON.stringify({
+          device_challenge: deviceChallenge,
+          user_code: userCode,
+        }),
+      });
+      if (!res.ok) {
+        const body = await res.text();
+        throw new Error(body || `Authorize failed: ${res.status}`);
+      }
+      const json = (await res.json()) as { redirect_to?: string };
+      if (!json.redirect_to) {
+        throw new Error("Server response missing redirect_to");
+      }
+      setStatus("approved");
+      // Navigate the browser into Hydra's continuation URL; Hydra will
+      // typically re-enter the OAuth authorize endpoint under our domain
+      // before landing at urls.device.success.
+      window.location.href = json.redirect_to;
+    } catch (err) {
+      setStatus("error");
+      setError(err instanceof Error ? err.message : String(err));
+    }
+  }, [deviceChallenge, userCode]);
+
+  // If both params absent, this page was hit incorrectly — show a clear
+  // error rather than a blank screen.
+  useEffect(() => {
+    if (!deviceChallenge || !userCode) {
+      setError(
+        "This page is reached from a Hydra device-grant redirect; required parameters are missing.",
+      );
+    }
+  }, [deviceChallenge, userCode]);
+
+  if (!deviceChallenge || !userCode) {
+    return (
+      <PageShell>
+        <PagePanel>
+          <PageHeader
+            showVanaLogotype
+            color="iris"
+            heading="Cannot authorize device"
+            description={<Text>{error ?? "Missing device parameters."}</Text>}
+          />
+        </PagePanel>
+      </PageShell>
+    );
+  }
+
+  return (
+    <PageShell>
+      <PagePanel>
+        <div className="space-y-small">
+          <PageHeader
+            showVanaLogotype
+            color="iris"
+            heading="Authorize this device"
+            description={
+              <Text>
+                A device is requesting access to your Vana account. Confirm the
+                code below matches the one shown on the device, then authorize.
+              </Text>
+            }
+          />
+
+          <div className="rounded-lg bg-muted p-4 text-center">
+            <Text
+              as="p"
+              intent="small"
+              color="mutedForeground"
+              className="mb-1"
+            >
+              Code on your device
+            </Text>
+            <Text
+              as="p"
+              className="text-2xl tracking-widest font-mono"
+              data-testid="device-user-code"
+            >
+              {formattedUserCode}
+            </Text>
+          </div>
+
+          {error && (
+            <Text as="p" color="destructive" aria-live="polite">
+              {error}
+            </Text>
+          )}
+
+          {!isLoggedIn ? (
+            <Button
+              type="button"
+              variant="iris"
+              size="lg"
+              fullWidth
+              onClick={handleSignIn}
+              disabled={!ready}
+            >
+              {!ready ? <Spinner /> : "Sign in to authorize"}
+            </Button>
+          ) : (
+            <Button
+              type="button"
+              variant="iris"
+              size="lg"
+              fullWidth
+              onClick={handleAuthorize}
+              disabled={status === "submitting" || status === "approved"}
+            >
+              {status === "submitting" ? (
+                <>
+                  <Spinner /> Authorizing...
+                </>
+              ) : status === "approved" ? (
+                "Authorized"
+              ) : (
+                "Authorize device"
+              )}
+            </Button>
+          )}
+
+          <Text as="p" color="mutedForeground" intent="small">
+            Only authorize devices you started. You can revoke access later from
+            your account settings.
+          </Text>
+        </div>
+      </PagePanel>
+    </PageShell>
+  );
+}
+
+export default function DeviceVerificationPage() {
+  return (
+    <Suspense
+      fallback={
+        <PageShell>
+          <PagePanel>
+            <PageLoadingState showVanaLogotype message="Loading..." />
+          </PagePanel>
+        </PageShell>
+      }
+    >
+      <DeviceVerificationContent />
+    </Suspense>
+  );
+}

--- a/connect/src/app/auth/oidc/error/route.test.ts
+++ b/connect/src/app/auth/oidc/error/route.test.ts
@@ -1,0 +1,102 @@
+import { NextRequest } from "next/server";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { GET, renderOidcErrorPage } from "./route";
+
+function makeRequest(query: Record<string, string>): NextRequest {
+  const url = new URL("https://account.vana.test/auth/oidc/error");
+  for (const [key, value] of Object.entries(query)) {
+    url.searchParams.set(key, value);
+  }
+  return new NextRequest(url);
+}
+
+describe("GET /auth/oidc/error", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("returns 200 with the error code and description", async () => {
+    vi.stubEnv("NODE_ENV", "test");
+    const response = await GET(
+      makeRequest({
+        error: "invalid_client",
+        error_description: "The OAuth client could not be found.",
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toContain("text/html");
+    const body = await response.text();
+    expect(body).toContain("invalid_client");
+    expect(body).toContain("The OAuth client could not be found.");
+  });
+
+  it("renders error_hint when present", async () => {
+    vi.stubEnv("NODE_ENV", "test");
+    const response = await GET(
+      makeRequest({
+        error: "invalid_request",
+        error_description: "Bad request.",
+        error_hint: "The login_challenge has expired.",
+      }),
+    );
+
+    const body = await response.text();
+    expect(body).toContain("The login_challenge has expired.");
+  });
+
+  it("hides error_debug in production", async () => {
+    vi.stubEnv("NODE_ENV", "production");
+    const response = await GET(
+      makeRequest({
+        error: "server_error",
+        error_description: "Internal failure.",
+        error_debug: "stack trace at handler.ts:42",
+      }),
+    );
+
+    const body = await response.text();
+    expect(body).toContain("server_error");
+    expect(body).not.toContain("stack trace at handler.ts:42");
+  });
+
+  it("shows error_debug outside production", async () => {
+    vi.stubEnv("NODE_ENV", "development");
+    const response = await GET(
+      makeRequest({
+        error: "server_error",
+        error_description: "Internal failure.",
+        error_debug: "stack trace at handler.ts:42",
+      }),
+    );
+
+    const body = await response.text();
+    expect(body).toContain("stack trace at handler.ts:42");
+  });
+
+  it("falls back to a generic description when none is provided", async () => {
+    vi.stubEnv("NODE_ENV", "test");
+    const response = await GET(makeRequest({}));
+
+    expect(response.status).toBe(200);
+    const body = await response.text();
+    expect(body).toContain("unknown_error");
+  });
+});
+
+describe("renderOidcErrorPage", () => {
+  it("escapes HTML in user-controlled fields", () => {
+    const html = renderOidcErrorPage({
+      error: "<script>alert(1)</script>",
+      errorDescription: "<img src=x onerror=alert(1)>",
+      errorHint: null,
+      errorDebug: null,
+      showDebug: false,
+    });
+
+    expect(html).not.toContain("<script>alert(1)</script>");
+    expect(html).not.toContain("<img src=x");
+    expect(html).toContain("&lt;script&gt;");
+    expect(html).toContain("&lt;img");
+  });
+});

--- a/connect/src/app/auth/oidc/error/route.ts
+++ b/connect/src/app/auth/oidc/error/route.ts
@@ -1,0 +1,93 @@
+/**
+ * Terminal error page for the Hydra `urls.error` contract.
+ *
+ * Hydra redirects the user here whenever an OAuth/OIDC flow fails before it
+ * can reach a registered redirect_uri (invalid client_id, malformed request,
+ * upstream login/consent rejection, etc). The query parameters follow the
+ * Hydra error response shape: `error`, `error_description`, `error_hint`,
+ * `error_debug`.
+ *
+ * This is not part of an OAuth handshake — there is nowhere to redirect the
+ * user to — so we render a minimal HTML page directly. `error_debug` is only
+ * surfaced outside production to avoid leaking internal details.
+ */
+
+import type { NextRequest } from "next/server";
+
+export const dynamic = "force-dynamic";
+
+type OidcErrorParams = {
+  error: string | null;
+  errorDescription: string | null;
+  errorHint: string | null;
+  errorDebug: string | null;
+};
+
+export type RenderOidcErrorPageInput = OidcErrorParams & {
+  showDebug: boolean;
+};
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+export function renderOidcErrorPage(input: RenderOidcErrorPageInput): string {
+  const code = input.error ?? "unknown_error";
+  const description =
+    input.errorDescription ??
+    "Sign-in could not be completed. Please return to the application and try again.";
+  const hint = input.errorHint;
+  const debug = input.showDebug ? input.errorDebug : null;
+
+  const hintBlock = hint ? `<p class="hint">${escapeHtml(hint)}</p>` : "";
+  const debugBlock = debug
+    ? `<pre class="debug">${escapeHtml(debug)}</pre>`
+    : "";
+
+  return `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Sign-in error</title>
+    <style>
+      body { font-family: system-ui, -apple-system, "Segoe UI", sans-serif; max-width: 32rem; margin: 4rem auto; padding: 0 1rem; color: #111; }
+      h1 { font-size: 1.25rem; margin-bottom: 0.5rem; }
+      code { background: #f4f4f5; padding: 0.125rem 0.375rem; border-radius: 0.25rem; font-size: 0.875rem; }
+      .hint { color: #555; }
+      .debug { background: #f4f4f5; padding: 0.75rem; border-radius: 0.375rem; font-size: 0.75rem; overflow-x: auto; white-space: pre-wrap; }
+    </style>
+  </head>
+  <body>
+    <h1>Sign-in error</h1>
+    <p><code>${escapeHtml(code)}</code></p>
+    <p>${escapeHtml(description)}</p>
+    ${hintBlock}
+    ${debugBlock}
+  </body>
+</html>`;
+}
+
+export async function GET(request: NextRequest): Promise<Response> {
+  const params = request.nextUrl.searchParams;
+  const html = renderOidcErrorPage({
+    error: params.get("error"),
+    errorDescription: params.get("error_description"),
+    errorHint: params.get("error_hint"),
+    errorDebug: params.get("error_debug"),
+    showDebug: process.env.NODE_ENV !== "production",
+  });
+
+  return new Response(html, {
+    status: 200,
+    headers: {
+      "content-type": "text/html; charset=utf-8",
+      "cache-control": "no-store",
+    },
+  });
+}

--- a/connect/src/app/auth/oidc/logout/route.ts
+++ b/connect/src/app/auth/oidc/logout/route.ts
@@ -1,0 +1,8 @@
+import type { NextRequest } from "next/server";
+import { runOidcLogout } from "../oidc-route-runtime";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(request: NextRequest): Promise<Response> {
+  return runOidcLogout(request);
+}

--- a/connect/src/app/auth/oidc/oidc-route-runtime.ts
+++ b/connect/src/app/auth/oidc/oidc-route-runtime.ts
@@ -23,7 +23,9 @@ import {
 import {
   type HydraAdminClientForOidc,
   handleOidcConsent,
+  handleOidcDeviceAccept,
   handleOidcLogin,
+  handleOidcLogout,
   type OidcRouteResult,
 } from "@/lib/auth/oidc-routes";
 import {
@@ -133,4 +135,35 @@ export async function runOidcConsent(request: Request): Promise<Response> {
     loadAccountClaims,
   });
   return toNextResponse(result, request.url);
+}
+
+export async function runOidcLogout(request: Request): Promise<Response> {
+  const { hydra } = buildAdapters();
+  const url = new URL(request.url);
+  const result = await handleOidcLogout({
+    logoutChallenge: url.searchParams.get("logout_challenge"),
+    hydra,
+  });
+  return toNextResponse(result, request.url);
+}
+
+/**
+ * Accept the Hydra device-grant request on behalf of the signed-in user. The
+ * caller (the API route) is responsible for verifying the Vana session before
+ * dispatching here.
+ */
+export async function runOidcDeviceAccept(body: {
+  device_challenge?: string;
+  user_code?: string;
+}): Promise<Response> {
+  const { hydra } = buildAdapters();
+  const result = await handleOidcDeviceAccept({
+    deviceChallenge: body.device_challenge ?? null,
+    userCode: body.user_code ?? null,
+    hydra,
+  });
+  if (result.kind === "redirect") {
+    return NextResponse.json({ redirect_to: result.location }, { status: 200 });
+  }
+  return new NextResponse(result.message, { status: result.status });
 }

--- a/connect/src/lib/auth/hydra-admin.test.ts
+++ b/connect/src/lib/auth/hydra-admin.test.ts
@@ -215,6 +215,60 @@ describe("createHydraAdminClient", () => {
     );
   });
 
+  it("accepts device user code requests with the encoded challenge and user_code body", async () => {
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(
+        jsonResponse({ redirect_to: "https://account.vana.org/device/done" }),
+      );
+    const client = createHydraAdminClient({
+      adminUrl: "https://hydra-admin.example.com/",
+      fetch: fetchImpl,
+    });
+
+    const result = await client.acceptDeviceUserCodeRequest(
+      "device/challenge?",
+      {
+        userCode: "ABCD-EFGH",
+      },
+    );
+
+    expect(result.redirect_to).toBe("https://account.vana.org/device/done");
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "https://hydra-admin.example.com/admin/oauth2/auth/requests/device/accept?device_challenge=device%2Fchallenge%3F",
+      {
+        body: JSON.stringify({ user_code: "ABCD-EFGH" }),
+        headers: {
+          accept: "application/json",
+          "content-type": "application/json",
+        },
+        method: "PUT",
+      },
+    );
+  });
+
+  it("surfaces Hydra errors when accepting a device user code fails", async () => {
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(JSON.stringify({ error: "invalid_user_code" }), {
+        headers: { "content-type": "application/json" },
+        status: 404,
+      }),
+    );
+    const client = createHydraAdminClient({
+      adminUrl: "https://hydra-admin.example.com",
+      fetch: fetchImpl,
+    });
+
+    await expect(
+      client.acceptDeviceUserCodeRequest("dev-1", { userCode: "WRONG" }),
+    ).rejects.toMatchObject({
+      body: { error: "invalid_user_code" },
+      method: "PUT",
+      path: "/admin/oauth2/auth/requests/device/accept?device_challenge=dev-1",
+      status: 404,
+    } satisfies Partial<HydraAdminError>);
+  });
+
   it("preserves Hydra error context", async () => {
     const fetchImpl = vi
       .fn<typeof fetch>()

--- a/connect/src/lib/auth/hydra-admin.ts
+++ b/connect/src/lib/auth/hydra-admin.ts
@@ -170,6 +170,24 @@ export function createHydraAdminClient({
       });
     },
 
+    acceptDeviceUserCodeRequest(
+      deviceChallenge: string,
+      input: { userCode: string },
+    ) {
+      return request<HydraRedirectResponse>({
+        audience,
+        baseUrl,
+        body: {
+          user_code: input.userCode,
+        },
+        fetchImpl,
+        method: "PUT",
+        path: `/admin/oauth2/auth/requests/device/accept?device_challenge=${encodeURIComponent(
+          deviceChallenge,
+        )}`,
+      });
+    },
+
     acceptLoginRequest(loginChallenge: string, input: AcceptHydraLoginRequest) {
       assertVanaUserId(input.subject);
 

--- a/connect/src/lib/auth/oidc-routes.test.ts
+++ b/connect/src/lib/auth/oidc-routes.test.ts
@@ -10,10 +10,14 @@ import {
 import {
   buildLoginRedirectForOidcChallenge,
   type HandleOidcConsentInput,
+  type HandleOidcDeviceAcceptInput,
   type HandleOidcLoginInput,
+  type HandleOidcLogoutInput,
   type HydraAdminClientForOidc,
   handleOidcConsent,
+  handleOidcDeviceAccept,
   handleOidcLogin,
+  handleOidcLogout,
   isSafeOidcReturnTo,
 } from "./oidc-routes";
 
@@ -44,6 +48,12 @@ function fakeHydra(
     }),
     acceptConsentRequest: vi.fn().mockResolvedValue({
       redirect_to: "https://hydra.example.com/oauth2/auth?ok=consent",
+    }),
+    acceptDeviceUserCodeRequest: vi.fn().mockResolvedValue({
+      redirect_to: "https://hydra.example.com/oauth2/auth?ok=device",
+    }),
+    acceptLogoutRequest: vi.fn().mockResolvedValue({
+      redirect_to: "https://hydra.example.com/oauth2/sessions/logout?ok=true",
     }),
     ...overrides,
   };
@@ -399,5 +409,106 @@ describe("isSafeOidcReturnTo", () => {
       false,
     );
     expect(isSafeOidcReturnTo("/auth/oidc/login\r\nLocation: x")).toBe(false);
+  });
+});
+
+describe("handleOidcLogout", () => {
+  function buildInput(
+    overrides: Partial<HandleOidcLogoutInput> = {},
+  ): HandleOidcLogoutInput {
+    return {
+      logoutChallenge: "logout-challenge-1",
+      hydra: fakeHydra(),
+      ...overrides,
+    };
+  }
+
+  it("returns 400 when logout_challenge is missing", async () => {
+    const result = await handleOidcLogout(
+      buildInput({ logoutChallenge: null }),
+    );
+    expect(result).toEqual({
+      kind: "error",
+      status: 400,
+      message: "Missing required logout_challenge",
+    });
+  });
+
+  it("returns 400 when logout_challenge is blank", async () => {
+    const result = await handleOidcLogout(
+      buildInput({ logoutChallenge: "  " }),
+    );
+    expect(result.kind).toBe("error");
+  });
+
+  it("accepts the Hydra logout request and redirects to Hydra's redirect_to", async () => {
+    const hydra = fakeHydra();
+    const result = await handleOidcLogout(buildInput({ hydra }));
+
+    expect(hydra.acceptLogoutRequest).toHaveBeenCalledWith(
+      "logout-challenge-1",
+    );
+    expect(result).toEqual({
+      kind: "redirect",
+      status: 303,
+      location: "https://hydra.example.com/oauth2/sessions/logout?ok=true",
+    });
+  });
+
+  it("returns 502 when Hydra rejects the logout request", async () => {
+    const hydra = fakeHydra({
+      acceptLogoutRequest: vi
+        .fn()
+        .mockRejectedValue(new Error("hydra unreachable")),
+    });
+
+    const result = await handleOidcLogout(buildInput({ hydra }));
+
+    expect(result).toEqual({
+      kind: "error",
+      status: 502,
+      message: "Logout could not be processed",
+    });
+  });
+});
+
+describe("handleOidcDeviceAccept", () => {
+  function buildInput(
+    overrides: Partial<HandleOidcDeviceAcceptInput> = {},
+  ): HandleOidcDeviceAcceptInput {
+    return {
+      deviceChallenge: "dev-chal-1",
+      userCode: "ABCD-EFGH",
+      hydra: fakeHydra(),
+      ...overrides,
+    };
+  }
+
+  it("returns 400 when device_challenge is missing", async () => {
+    const result = await handleOidcDeviceAccept(
+      buildInput({ deviceChallenge: null }),
+    );
+    expect(result.kind).toBe("error");
+    if (result.kind === "error") expect(result.status).toBe(400);
+  });
+
+  it("returns 400 when user_code is missing", async () => {
+    const result = await handleOidcDeviceAccept(buildInput({ userCode: null }));
+    expect(result.kind).toBe("error");
+    if (result.kind === "error") expect(result.status).toBe(400);
+  });
+
+  it("calls acceptDeviceUserCodeRequest with normalized inputs and redirects", async () => {
+    const hydra = fakeHydra();
+    const result = await handleOidcDeviceAccept(buildInput({ hydra }));
+    expect(hydra.acceptDeviceUserCodeRequest).toHaveBeenCalledWith(
+      "dev-chal-1",
+      { userCode: "ABCD-EFGH" },
+    );
+    expect(result).toEqual({
+      kind: "redirect",
+      status: 303,
+      location: "https://hydra.example.com/oauth2/auth?ok=device",
+    });
   });
 });

--- a/connect/src/lib/auth/oidc-routes.ts
+++ b/connect/src/lib/auth/oidc-routes.ts
@@ -30,6 +30,7 @@ import { isVanaUserId } from "./vana-account";
 
 export const OIDC_LOGIN_PATH = "/auth/oidc/login";
 export const OIDC_CONSENT_PATH = "/auth/oidc/consent";
+export const OIDC_LOGOUT_PATH = "/auth/oidc/logout";
 export const LOGIN_PATH = "/login";
 
 export type HydraAdminClientForOidc = {
@@ -43,6 +44,11 @@ export type HydraAdminClientForOidc = {
     challenge: string,
     input: AcceptHydraConsentRequest,
   ): Promise<HydraRedirectResponse>;
+  acceptDeviceUserCodeRequest(
+    deviceChallenge: string,
+    input: { userCode: string },
+  ): Promise<HydraRedirectResponse>;
+  acceptLogoutRequest(challenge: string): Promise<HydraRedirectResponse>;
 };
 
 export type ResolveVanaUser = (
@@ -55,7 +61,7 @@ export type LoadOidcAccountClaims = (
 
 export type OidcRouteResult =
   | { kind: "redirect"; status: 302 | 303; location: string }
-  | { kind: "error"; status: 400; message: string };
+  | { kind: "error"; status: 400 | 502; message: string };
 
 /**
  * Build the URL the user should land on if they need to sign in before the
@@ -198,6 +204,93 @@ export async function handleOidcConsent(
     subject: consentRequest.subject,
     ...(accountClaims ? { accountClaims } : {}),
   });
+
+  return { kind: "redirect", status: 303, location: accepted.redirect_to };
+}
+
+/**
+ * Handle the POST that fires when the signed-in user clicks "Authorize this
+ * device" on the verification page (`/auth/oidc/device`). Calls Hydra admin's
+ * `acceptDeviceUserCodeRequest`. The redirect_to from Hydra typically points
+ * back into the OAuth authorize endpoint (`/oauth2/auth?…&login_verifier=…`),
+ * which re-enters this app's `/auth/oidc/login` and `/auth/oidc/consent`
+ * with the user already signed in.
+ *
+ * The verification page itself is a client-side React page that gates the
+ * Authorize button on Privy/Vana auth state and POSTs here. We don't render
+ * the page server-side, so no `handleOidcDeviceVerification` is needed —
+ * the page imports `usePrivy()` and drives sign-in directly.
+ */
+export type HandleOidcDeviceAcceptInput = {
+  deviceChallenge: string | null;
+  userCode: string | null;
+  hydra: HydraAdminClientForOidc;
+};
+
+export type HandleOidcLogoutInput = {
+  logoutChallenge: string | null;
+  hydra: Pick<HydraAdminClientForOidc, "acceptLogoutRequest">;
+};
+
+/**
+ * Accept a Hydra OIDC logout challenge and forward the user to Hydra's
+ * `redirect_to`. Hydra has already validated the id_token_hint and any
+ * post_logout_redirect_uri before issuing the challenge, so there is no
+ * additional consent screen to render here — we just rubber-stamp it.
+ *
+ * Network/non-2xx failures from Hydra surface as a 502 to the caller; we do
+ * not leak Hydra error bodies into the response.
+ */
+export async function handleOidcLogout(
+  input: HandleOidcLogoutInput,
+): Promise<OidcRouteResult> {
+  const challenge = input.logoutChallenge?.trim();
+  if (!challenge) {
+    return {
+      kind: "error",
+      status: 400,
+      message: "Missing required logout_challenge",
+    };
+  }
+
+  let accepted: HydraRedirectResponse;
+  try {
+    accepted = await input.hydra.acceptLogoutRequest(challenge);
+  } catch {
+    return {
+      kind: "error",
+      status: 502,
+      message: "Logout could not be processed",
+    };
+  }
+
+  return { kind: "redirect", status: 303, location: accepted.redirect_to };
+}
+
+export async function handleOidcDeviceAccept(
+  input: HandleOidcDeviceAcceptInput,
+): Promise<OidcRouteResult> {
+  const deviceChallenge = input.deviceChallenge?.trim();
+  const userCode = input.userCode?.trim();
+  if (!deviceChallenge) {
+    return {
+      kind: "error",
+      status: 400,
+      message: "Missing required device_challenge",
+    };
+  }
+  if (!userCode) {
+    return {
+      kind: "error",
+      status: 400,
+      message: "Missing required user_code",
+    };
+  }
+
+  const accepted = await input.hydra.acceptDeviceUserCodeRequest(
+    deviceChallenge,
+    { userCode },
+  );
 
   return { kind: "redirect", status: 303, location: accepted.redirect_to };
 }


### PR DESCRIPTION
## Summary

Implements the missing pieces of our Hydra-driven OIDC surface so the dev environment supports the full OAuth + RFC 8628 device-grant flow.

### New routes
- **`/auth/oidc/device`** — RFC 8628 verification page. Hydra's `URLS_DEVICE_VERIFICATION` redirects users here with `device_challenge` + `user_code`. Explicit Authorize click POSTs to a new API route. Sign-in is routed through `/login` (not `Privy.login` alone) so the Vana session cookie required by the API route is bootstrapped.
- **`/auth/oidc/device-success`** — terminal page Hydra redirects to after consent completes.
- **`/api/auth/oidc/device-accept`** — POST handler. Verifies Vana session Bearer, calls Hydra admin's `acceptDeviceUserCodeRequest`, returns `redirect_to` so the browser navigates Hydra's continuation URL.
- **`/auth/oidc/logout`** — accepts a Hydra `logout_challenge` via admin API and forwards. Closes the gap where `URLS_LOGOUT` pointed at a 404.
- **`/auth/oidc/error`** — terminal HTML for OAuth errors. Renders code + description; debug only in dev.

### Plumbing
- `oidc-routes.ts`: pure handlers `handleOidcLogout` and `handleOidcDeviceAccept`. Added `acceptDeviceUserCodeRequest` and `acceptLogoutRequest` to the `HydraAdminClientForOidc` seam. Widened `OidcRouteResult` error status to `400 | 502` for upstream-failure cases.
- `hydra-admin.ts`: `acceptDeviceUserCodeRequest` matches the v2 admin contract (`PUT /admin/oauth2/auth/requests/device/accept` with body `{ user_code }`).

### Verification
- `pnpm tsc --noEmit`: 0 errors in touched files. The pre-existing `app/layout.tsx` CSS module error is unchanged.
- `pnpm test --run`: 516 passed, 42 pre-existing skips, 0 failed.

### Companion changes (not in this PR)
The `vana-oauth` repo's Hydra entrypoint was updated in parallel to add `urls.device.verification` and `urls.device.success` keys (sourced from a new `DEVICE_URL` env var). That image needs to be rebuilt + redeployed and Cloud Run env updated for these routes to be reachable end-to-end. Will land in a separate change against `vana-oauth`.

## Test plan
- [x] Tests pass.
- [ ] After Hydra redeploy with `DEVICE_URL` set: device-grant flow from data-connect lands on `/auth/oidc/device`, Authorize redirects through Hydra back through `/auth/oidc/login` + `/auth/oidc/consent`, finishes on `/auth/oidc/device-success`.
- [ ] OIDC logout flow lands on `/auth/oidc/logout` and forwards to Hydra-issued `redirect_to`.
- [ ] OIDC error flow lands on `/auth/oidc/error` and renders gracefully.