### PR TITLE
fix(auth): self-heal vana_access cookie on device verification page

### DIFF
--- a/connect/src/app/auth/oidc/device/page.tsx
+++ b/connect/src/app/auth/oidc/device/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { usePrivy } from "@privy-io/react-auth";
+import { useIdentityToken, usePrivy } from "@privy-io/react-auth";
 import { useSearchParams } from "next/navigation";
 import { Suspense, useCallback, useEffect, useMemo, useState } from "react";
 import { PagePanel } from "@/app/_components/page-panel";
@@ -46,15 +46,19 @@ function readVanaAccessCookie(): string | null {
 
 type AcceptStatus = "idle" | "submitting" | "approved" | "error";
 
+type SessionStatus = "unknown" | "bootstrapping" | "ready" | "missing";
+
 function DeviceVerificationContent() {
   const searchParams = useSearchParams();
   const { ready, authenticated } = usePrivy();
+  const { identityToken } = useIdentityToken();
 
   const deviceChallenge = searchParams.get("device_challenge");
   const userCode = searchParams.get("user_code");
 
   const [status, setStatus] = useState<AcceptStatus>("idle");
   const [error, setError] = useState<string | null>(null);
+  const [sessionStatus, setSessionStatus] = useState<SessionStatus>("unknown");
 
   const isLoggedIn = ready && authenticated;
 
@@ -78,6 +82,68 @@ function DeviceVerificationContent() {
     window.location.href = `/login?return_to=${encodeURIComponent(here)}`;
   }, [deviceChallenge, userCode]);
 
+  // Self-heal the Vana session cookie when Privy is authenticated but
+  // `vana_access` is missing. This happens whenever a user lands on this
+  // page already signed in via Privy on another tab, but their browser has
+  // never POSTed to `/api/auth/session` on this domain (e.g., a fresh tab
+  // following Hydra's redirect rather than a `/login` round-trip).
+  //
+  // We mirror exactly what `/login` does: POST the Privy id_token; on
+  // success the BFF mints the Hydra session and sets vana_access + vana_session.
+  useEffect(() => {
+    if (!isLoggedIn) {
+      setSessionStatus("unknown");
+      return;
+    }
+    if (readVanaAccessCookie()) {
+      setSessionStatus("ready");
+      return;
+    }
+    if (!identityToken) {
+      // Privy is authenticated but the id_token hasn't been minted yet.
+      // useIdentityToken updates as Privy resolves it; this effect re-runs.
+      setSessionStatus("bootstrapping");
+      return;
+    }
+
+    let cancelled = false;
+    setSessionStatus("bootstrapping");
+    void (async () => {
+      try {
+        const res = await fetch("/api/auth/session", {
+          method: "POST",
+          headers: { authorization: `Bearer ${identityToken}` },
+        });
+        if (cancelled) return;
+        if (!res.ok) {
+          setSessionStatus("missing");
+          setError(
+            "Could not establish Vana session. Please sign in again from /login.",
+          );
+          return;
+        }
+        // Cookie is set on the response; double-check it landed before flipping
+        // to "ready" so a downstream cookie-blocking config doesn't hang the
+        // user on a Spinner forever.
+        if (readVanaAccessCookie()) {
+          setSessionStatus("ready");
+        } else {
+          setSessionStatus("missing");
+          setError(
+            "Vana session cookie was not stored. Check your browser's third-party-cookie settings.",
+          );
+        }
+      } catch (err) {
+        if (cancelled) return;
+        setSessionStatus("missing");
+        setError(err instanceof Error ? err.message : String(err));
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [isLoggedIn, identityToken]);
+
   const handleAuthorize = useCallback(async () => {
     if (!deviceChallenge || !userCode) return;
     setStatus("submitting");
@@ -85,11 +151,7 @@ function DeviceVerificationContent() {
     try {
       const accessToken = readVanaAccessCookie();
       if (!accessToken) {
-        // Vana session bootstrap hasn't completed yet (Privy is signed in but
-        // the BFF hasn't issued vana_access). Drive the bootstrap by hitting
-        // /api/auth/session — but the page's normal Privy flow already does
-        // that on mount; if we're here without it, surface the gap.
-        throw new Error("Vana session not ready yet — refresh and try again.");
+        throw new Error("Vana session is not ready yet.");
       }
       const res = await fetch("/api/auth/oidc/device-accept", {
         method: "POST",
@@ -204,9 +266,18 @@ function DeviceVerificationContent() {
               size="lg"
               fullWidth
               onClick={handleAuthorize}
-              disabled={status === "submitting" || status === "approved"}
+              disabled={
+                sessionStatus !== "ready" ||
+                status === "submitting" ||
+                status === "approved"
+              }
             >
-              {status === "submitting" ? (
+              {sessionStatus === "bootstrapping" ||
+              sessionStatus === "unknown" ? (
+                <>
+                  <Spinner /> Preparing...
+                </>
+              ) : status === "submitting" ? (
                 <>
                   <Spinner /> Authorizing...
                 </>


### PR DESCRIPTION
When a user lands on /auth/oidc/device already signed in via Privy but without the vana_access cookie, the page used to dead-end on "Vana session not ready yet — refresh and try again." Refreshing didn't help because nothing on the page bootstrapped the cookie.

Mirror what /login does: when isLoggedIn but vana_access is absent, POST the Privy id_token to /api/auth/session — the BFF mints the Hydra session and sets vana_access + vana_session.

Track state via a sessionStatus state machine so the Authorize button shows "Preparing..." while bootstrap is in flight, "Authorize device" when ready, and a real error if cookie storage is blocked.

## Test plan
- [x] tsc clean
- [ ] After deploy, land on /auth/oidc/device while signed in via Privy on another tab; page bootstraps Vana session and Authorize becomes clickable.