### PR TITLE
feat(auth): register data-connect Hydra client in consent policy

### DIFF
--- a/connect/src/lib/auth/oauth-client-policy.test.ts
+++ b/connect/src/lib/auth/oauth-client-policy.test.ts
@@ -3,6 +3,7 @@ import {
   checkOrigin,
   checkRedirectUri,
   createDefaultOauthClientRegistry,
+  DATA_CONNECT_CLIENT,
   DEV_MEMORY_APP_CLIENT,
   evaluateConsentPolicy,
   type OauthClientRecord,
@@ -25,6 +26,12 @@ describe("createDefaultOauthClientRegistry", () => {
     const registry = createDefaultOauthClientRegistry();
     const resolved = registry.resolve("memory-app-dev");
     expect(resolved).toEqual(DEV_MEMORY_APP_CLIENT);
+  });
+
+  it("registers the data-connect client by default", () => {
+    const registry = createDefaultOauthClientRegistry();
+    const resolved = registry.resolve("data-connect");
+    expect(resolved).toEqual(DATA_CONNECT_CLIENT);
   });
 
   it("returns null for unknown, blank, null, or undefined client ids", () => {
@@ -67,6 +74,22 @@ describe("evaluateConsentPolicy", () => {
       client: DEV_MEMORY_APP_CLIENT,
       grantScope: ["openid", "profile"],
       grantAudience: ["memory-app-dev"],
+    });
+  });
+
+  it("allows the data-connect device-grant scope/audience pair", () => {
+    const decision = evaluateConsentPolicy({
+      registry,
+      clientId: "data-connect",
+      requestedScope: ["openid", "offline"],
+      requestedAudience: ["account.vana.org"],
+    });
+
+    expect(decision).toEqual({
+      kind: "allow",
+      client: DATA_CONNECT_CLIENT,
+      grantScope: ["openid", "offline"],
+      grantAudience: ["account.vana.org"],
     });
   });
 

--- a/connect/src/lib/auth/oauth-client-policy.ts
+++ b/connect/src/lib/auth/oauth-client-policy.ts
@@ -74,7 +74,30 @@ export const DEV_MEMORY_APP_CLIENT: OauthClientRecord = {
   allowedAudiences: ["memory-app-dev"],
 };
 
-const DEFAULT_CLIENTS: readonly OauthClientRecord[] = [DEV_MEMORY_APP_CLIENT];
+/**
+ * Static registry for the Vana data-connect desktop app. Public client (no
+ * secret) using the OAuth 2.0 device authorization grant (RFC 8628). Hydra
+ * registers it with `client_id="data-connect"`, scope `"openid offline"`,
+ * audience `["account.vana.org"]`, and `token_endpoint_auth_method=none`.
+ *
+ * No redirectUris/allowedOrigins — the device flow does not use redirects;
+ * the desktop app polls the token endpoint after the user approves on the
+ * verification page. The redirect-URI / origin guards in this module are
+ * not consulted on the device-grant path; they're for the auth-code flow.
+ */
+export const DATA_CONNECT_CLIENT: OauthClientRecord = {
+  clientId: "data-connect",
+  displayName: "Vana data-connect",
+  redirectUris: [],
+  allowedOrigins: [],
+  allowedScopes: ["openid", "offline", "offline_access"],
+  allowedAudiences: ["account.vana.org"],
+};
+
+const DEFAULT_CLIENTS: readonly OauthClientRecord[] = [
+  DEV_MEMORY_APP_CLIENT,
+  DATA_CONNECT_CLIENT,
+];
 
 /**
  * Build an in-memory registry from a list of client records. Defaults to the


### PR DESCRIPTION
data-connect drives Hydra's RFC 8628 device-grant against `client_id="data-connect"`, scope `"openid offline"`, audience `"account.vana.org"`. The consent handler was rejecting it with "Unknown OAuth client: data-connect" because the policy registry only knew the dev Memory App.

Add DATA_CONNECT_CLIENT alongside DEV_MEMORY_APP_CLIENT in the static default registry. Matches what Hydra has registered on the dev admin endpoint:
- token_endpoint_auth_method: none (public client)
- grant_types: device_code, refresh_token
- scope: openid offline
- audience: account.vana.org

## Test plan
- [x] Tests pass.
- [ ] Run data-connect Connect with Vana flow end-to-end after deploy.