### PR TITLE
fix(auth): send Bearer + self-heal session on action consent page

### DIFF
--- a/connect/src/app/account/actions/[id]/page-client.test.tsx
+++ b/connect/src/app/account/actions/[id]/page-client.test.tsx
@@ -8,6 +8,7 @@ const mocks = vi.hoisted(() => ({
     authenticated: false,
     login: vi.fn(),
   },
+  identityToken: "fake-privy-id-token",
 }));
 
 vi.mock("next/navigation", () => ({
@@ -16,7 +17,20 @@ vi.mock("next/navigation", () => ({
 
 vi.mock("@privy-io/react-auth", () => ({
   usePrivy: () => mocks.privy,
+  useIdentityToken: () => ({ identityToken: mocks.identityToken }),
 }));
+
+// Pre-seed vana_access cookie so the page's session-status state machine
+// flips to "ready" without hitting the bootstrap path. The bootstrap path
+// is exercised via integration; unit tests mock the BFF cookie directly.
+function setVanaAccessCookie(value: string | null) {
+  if (typeof document === "undefined") return;
+  if (value === null) {
+    document.cookie = "vana_access=; max-age=0; path=/";
+  } else {
+    document.cookie = `vana_access=${encodeURIComponent(value)}; path=/`;
+  }
+}
 
 import { ActionRequestPageClient } from "./page-client";
 
@@ -33,6 +47,7 @@ describe("ActionRequestPageClient", () => {
     mocks.privy.ready = true;
     mocks.privy.authenticated = false;
     mocks.privy.login.mockReset();
+    setVanaAccessCookie("fake-vana-access");
     vi.unstubAllGlobals();
   });
 
@@ -99,10 +114,16 @@ describe("ActionRequestPageClient", () => {
     expect(fetchMock.mock.calls[0][0]).toBe(
       "/api/account/actions/vana_areq_test",
     );
-    expect(fetchMock.mock.calls[0][1]?.headers).toBeUndefined();
+    expect(fetchMock.mock.calls[0][1]?.headers).toEqual({
+      authorization: "Bearer fake-vana-access",
+    });
     expect(fetchMock.mock.calls[1][0]).toBe(
       "/api/account/actions/vana_areq_test/decision",
     );
+    expect(fetchMock.mock.calls[1][1]?.headers).toMatchObject({
+      authorization: "Bearer fake-vana-access",
+      "content-type": "application/json",
+    });
     expect(JSON.parse(fetchMock.mock.calls[1][1].body)).toEqual({
       decision: "approved",
       state: "client-state",

--- a/connect/src/app/account/actions/[id]/page-client.tsx
+++ b/connect/src/app/account/actions/[id]/page-client.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { usePrivy } from "@privy-io/react-auth";
+import { useIdentityToken, usePrivy } from "@privy-io/react-auth";
 import { useSearchParams } from "next/navigation";
 import { useCallback, useEffect, useState } from "react";
 import { PagePanel } from "@/app/_components/page-panel";
@@ -14,6 +14,25 @@ import {
   formatRequestedDataDisplay,
   formatStatusLabel,
 } from "@/lib/auth/action-display";
+
+/**
+ * Read the JS-readable companion cookie that mirrors `vana_session`.
+ * `getVanaSession` only accepts the cookie on read-only methods; for any
+ * state-mutating POST (e.g. action decisions) the browser must explicitly
+ * send `Authorization: Bearer <vana_access>` to satisfy the verifier.
+ */
+function readVanaAccessCookie(): string | null {
+  if (typeof document === "undefined") return null;
+  for (const part of document.cookie.split(";")) {
+    const eq = part.indexOf("=");
+    if (eq < 0) continue;
+    const k = part.slice(0, eq).trim();
+    if (k !== "vana_access") continue;
+    const v = part.slice(eq + 1).trim();
+    return v ? decodeURIComponent(v) : null;
+  }
+  return null;
+}
 
 type ActionRequestDetails = {
   action_request_id: string;
@@ -52,19 +71,66 @@ export function ActionRequestPageClient({
 }) {
   const searchParams = useSearchParams();
   const { ready, authenticated, login } = usePrivy();
+  const { identityToken } = useIdentityToken();
   const [loadState, setLoadState] = useState<LoadState>({ kind: "idle" });
   const [decisionState, setDecisionState] = useState<
     "idle" | "approving" | "denying"
   >("idle");
   const [decisionError, setDecisionError] = useState<string | null>(null);
+  const [sessionStatus, setSessionStatus] = useState<
+    "unknown" | "bootstrapping" | "ready" | "missing"
+  >("unknown");
+
+  // Self-heal vana_access cookie when Privy is signed in but the BFF session
+  // hasn't been bootstrapped on this domain (e.g. a fresh tab). Mirrors what
+  // `/login` does so action approval works without a separate sign-in step.
+  useEffect(() => {
+    if (!ready || !authenticated) {
+      setSessionStatus("unknown");
+      return;
+    }
+    if (readVanaAccessCookie()) {
+      setSessionStatus("ready");
+      return;
+    }
+    if (!identityToken) {
+      setSessionStatus("bootstrapping");
+      return;
+    }
+    let cancelled = false;
+    setSessionStatus("bootstrapping");
+    void (async () => {
+      try {
+        const res = await fetch("/api/auth/session", {
+          method: "POST",
+          headers: { authorization: `Bearer ${identityToken}` },
+        });
+        if (cancelled) return;
+        setSessionStatus(
+          res.ok && readVanaAccessCookie() ? "ready" : "missing",
+        );
+      } catch {
+        if (cancelled) return;
+        setSessionStatus("missing");
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [ready, authenticated, identityToken]);
 
   useEffect(() => {
     if (!ready || !authenticated) return;
+    if (sessionStatus !== "ready") return;
 
     const controller = new AbortController();
     setLoadState({ kind: "loading" });
+    const accessToken = readVanaAccessCookie();
     fetch(`/api/account/actions/${encodeURIComponent(actionRequestId)}`, {
       signal: controller.signal,
+      headers: accessToken
+        ? { authorization: `Bearer ${accessToken}` }
+        : undefined,
     })
       .then(async (response) => {
         const body = await response.json();
@@ -87,7 +153,7 @@ export function ActionRequestPageClient({
       });
 
     return () => controller.abort();
-  }, [actionRequestId, authenticated, ready]);
+  }, [actionRequestId, authenticated, ready, sessionStatus]);
 
   const decide = useCallback(
     async (decision: "approved" | "denied") => {
@@ -97,12 +163,19 @@ export function ActionRequestPageClient({
       setDecisionState(decision === "approved" ? "approving" : "denying");
       try {
         const state = searchParams.get("state");
+        const accessToken = readVanaAccessCookie();
+        if (!accessToken) {
+          throw new Error(
+            "Vana session is not ready yet. Refresh and try again.",
+          );
+        }
         const response = await fetch(
           `/api/account/actions/${encodeURIComponent(actionRequestId)}/decision`,
           {
             method: "POST",
             headers: {
               "content-type": "application/json",
+              authorization: `Bearer ${accessToken}`,
             },
             body: JSON.stringify({
               decision,


### PR DESCRIPTION
Mirror the device-page fix on the action consent page so the decision POST sends Authorization: Bearer (it was missing, causing 401 "Login evidence is required").