### PR TITLE
fix(server): wait for VM gone before disk delete + show deprovision progress

### DIFF
--- a/connect/src/app/server/page.tsx
+++ b/connect/src/app/server/page.tsx
@@ -217,10 +217,15 @@ function ServerPageContent() {
                 variant="ghost"
                 size="sm"
                 onClick={() => void deprovision()}
+                disabled={status === "deprovisioning"}
                 className="text-destructive-foreground hover:text-destructive-foreground"
               >
                 <Trash2Icon aria-hidden />
-                Remove Server
+                {status === "deprovisioning"
+                  ? "Removing..."
+                  : status === "deprovision_failed"
+                    ? "Retry remove"
+                    : "Remove Server"}
               </Button>
             </div>
           )}
@@ -361,6 +366,8 @@ function getStatusInfo(status: ServerStatus): {
       return { tone: "success", label: "Running" };
     case "provisioning":
       return { tone: "accent", label: "Provisioning..." };
+    case "deprovisioning":
+      return { tone: "accent", label: "Removing..." };
     case "stopped":
       return { tone: "warning", label: "Stopped" };
     case "deprovision_failed":

--- a/connect/src/app/server/use-server.ts
+++ b/connect/src/app/server/use-server.ts
@@ -48,6 +48,7 @@ export type ServerStatus =
   | "loading"
   | "idle"
   | "provisioning"
+  | "deprovisioning"
   | "running"
   | "stopped"
   | "deprovision_failed"
@@ -190,6 +191,10 @@ export function useServer() {
   const deprovision = useCallback(async () => {
     if (!server) return;
     setError(null);
+    // Reflect the in-flight deprovision in the UI immediately. The DELETE
+    // can take 30-60s (VM teardown + disk delete + tunnel/DNS cleanup).
+    // Without this, users see no feedback and assume the click was lost.
+    setStatus("deprovisioning");
     try {
       const res = await fetch(`/api/servers/${server.id}`, {
         method: "DELETE",
@@ -207,6 +212,7 @@ export function useServer() {
       stopPolling();
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));
+      setStatus("deprovision_failed");
     }
   }, [server, stopPolling]);
 

--- a/connect/src/lib/server-provider/gcp.ts
+++ b/connect/src/lib/server-provider/gcp.ts
@@ -543,10 +543,13 @@ export class GCPProvider implements ServerProvider {
           zone: GCP_ZONE,
           instance: serverId,
         });
-        // Poll until the VM is fully deleted (typically <15s for a stopped instance).
-        // The Compute v1 SDK exposes operation.promise() via the long-running
-        // operation client returned alongside InstancesClient; for older
-        // versions, fall back to manual polling via the zone operations endpoint.
+        // Wait for the LRO promise (the SDK's standard completion signal),
+        // then ALSO poll instances.get() until 404. The LRO completing means
+        // GCP accepted the delete, not that the resource is fully torn down —
+        // the VM can briefly still appear in get() while STOPPING, and the
+        // attached disk is not releasable until the VM resource is gone.
+        // Without the get-poll, the disk delete in step 3 races teardown and
+        // fails with RESOURCE_IN_USE_BY_ANOTHER_RESOURCE.
         const op = operation as unknown as {
           promise?: () => Promise<unknown>;
         };
@@ -554,13 +557,33 @@ export class GCPProvider implements ServerProvider {
           try {
             await op.promise();
           } catch (waitErr) {
-            // The VM may have been deleted between our delete call and the
-            // wait — that's a "stopped" code we can ignore.
             const code = errCode(waitErr);
             if (code !== 5 && code !== 404) {
               recordError("vm-wait", waitErr);
             }
           }
+        }
+        // Deterministic: poll instances.get() until 404 (VM gone). Up to 60s.
+        // Each check is a single API call; no exponential backoff to keep the
+        // total latency bounded near the function's max-duration budget.
+        const deadline = Date.now() + 60_000;
+        while (Date.now() < deadline) {
+          try {
+            await this.client.get({
+              project: this.project,
+              zone: GCP_ZONE,
+              instance: serverId,
+            });
+          } catch (getErr) {
+            const code = errCode(getErr);
+            if (code === 5 || code === 404) {
+              // VM is gone — disk is now releasable.
+              break;
+            }
+            // Any other error is logged but we keep polling — transient
+            // network blips shouldn't bail the deprovision.
+          }
+          await new Promise((resolve) => setTimeout(resolve, 1500));
         }
       } catch (err: unknown) {
         const code = errCode(err);


### PR DESCRIPTION
Real failure today: deprovision left row in `deprovision_failed` with `RESOURCE_IN_USE_BY_ANOTHER_RESOURCE` on disk delete despite the existing 5-retry backoff. Root cause: SDK LRO promise resolves before `instances.get()` stops returning the VM; disk attached during that window. Fix polls `instances.get()` until 404 (60s deadline) before disk delete.

UI: "Remove Server" button no longer leaves users wondering — adds `deprovisioning` status with "Removing..." pill, disabled button, "Retry remove" label on failure.