### PR TITLE
fix(server): bootstrap Vana session on /server page; gate provision until ready

### DIFF
--- a/connect/src/app/server/page.tsx
+++ b/connect/src/app/server/page.tsx
@@ -53,9 +53,11 @@ function ServerPageContent() {
     provision,
     deprovision,
     refresh,
+    sessionStatus,
+    sessionError,
   } = useServer();
 
-  if (status === "loading") {
+  if (status === "loading" || sessionStatus === "bootstrapping") {
     return (
       <PageShell actions={["dataConnect", "logout"]}>
         <PagePanel>
@@ -92,10 +94,23 @@ function ServerPageContent() {
                   variant="iris"
                   size="lg"
                   onClick={() => void provision()}
+                  disabled={sessionStatus !== "ready"}
                 >
                   <ServerIcon aria-hidden />
-                  Provision Server
+                  {sessionStatus === "missing"
+                    ? "Sign in required"
+                    : "Provision Server"}
                 </LoadingButton>
+                {sessionStatus === "missing" && sessionError ? (
+                  <Text
+                    as="p"
+                    intent="small"
+                    color="destructive"
+                    align="center"
+                  >
+                    {sessionError}
+                  </Text>
+                ) : null}
               </div>
             </ServerCard>
           </div>

--- a/connect/src/app/server/use-server.test.ts
+++ b/connect/src/app/server/use-server.test.ts
@@ -17,17 +17,28 @@ const mocks = vi.hoisted(() => ({
 vi.mock("@privy-io/react-auth", () => ({
   useSignMessage: () => ({ signMessage: mocks.signMessage }),
   useWallets: () => mocks.walletsState,
+  usePrivy: () => ({ ready: true, authenticated: true, login: vi.fn() }),
+  useIdentityToken: () => ({ identityToken: "fake-id-token" }),
 }));
 
-vi.mock("@/components/auth/use-confirmation", () => ({
-  useConfirmation: () => ({
-    pending: null,
-    error: null,
-    confirm: vi.fn(),
-    dismiss: vi.fn(),
-    handle401: vi.fn(async () => null),
-  }),
-}));
+vi.mock("@/components/auth/use-confirmation", async () => {
+  // Preserve the real `readVanaAccessCookie` — tests set document.cookie
+  // directly (`vana_access=vana-access-tok`) so the bootstrap hook flips
+  // to "ready" without needing a network round-trip mock.
+  const actual = await vi.importActual<
+    typeof import("@/components/auth/use-confirmation")
+  >("@/components/auth/use-confirmation");
+  return {
+    ...actual,
+    useConfirmation: () => ({
+      pending: null,
+      error: null,
+      confirm: vi.fn(),
+      dismiss: vi.fn(),
+      handle401: vi.fn(async () => null),
+    }),
+  };
+});
 
 import { useServer } from "./use-server";
 

--- a/connect/src/app/server/use-server.ts
+++ b/connect/src/app/server/use-server.ts
@@ -3,33 +3,13 @@
 import { useSignMessage, useWallets } from "@privy-io/react-auth";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useConfirmation } from "@/components/auth/use-confirmation";
+import {
+  useVanaSessionBootstrap,
+  vanaAuthHeaders,
+} from "@/lib/auth/vana-session-client";
 
 const MASTER_KEY_MESSAGE = "vana-master-key-v1";
 const POLL_INTERVAL_MS = 5_000;
-
-/**
- * Read the `vana_access` cookie (JS-readable companion to vana_session).
- * The browser sends this as `Authorization: Bearer <vana_access>` for any
- * state-mutating request — getVanaSession rejects cookie-only auth on
- * POST/PUT/PATCH/DELETE.
- */
-function readVanaAccessCookie(): string | null {
-  if (typeof document === "undefined") return null;
-  for (const part of document.cookie.split(";")) {
-    const eq = part.indexOf("=");
-    if (eq < 0) continue;
-    const k = part.slice(0, eq).trim();
-    if (k !== "vana_access") continue;
-    const v = part.slice(eq + 1).trim();
-    return v ? decodeURIComponent(v) : null;
-  }
-  return null;
-}
-
-function vanaAuthHeaders(): Record<string, string> {
-  const tok = readVanaAccessCookie();
-  return tok ? { Authorization: `Bearer ${tok}` } : {};
-}
 
 type ApiServer = {
   object: "server";
@@ -64,6 +44,7 @@ export function useServer() {
   const { signMessage } = useSignMessage();
   const { wallets, ready: walletsReady } = useWallets();
   const confirmation = useConfirmation();
+  const session = useVanaSessionBootstrap();
   const [server, setServer] = useState<ApiServer | null>(null);
   const [status, setStatus] = useState<ServerStatus>("loading");
   const [error, setError] = useState<string | null>(null);
@@ -216,13 +197,17 @@ export function useServer() {
     }
   }, [server, stopPolling]);
 
-  // Initial fetch once wallet is ready
+  // Initial fetch once wallet is ready AND the BFF session cookie is in
+  // place. Without the session gate, the GET /api/servers fires before
+  // /api/auth/session has minted vana_session, and the verifier 401s
+  // because state-mutating callers (provision later) need vana_access too.
   useEffect(() => {
     if (!walletsReady || !embeddedWalletAddress) return;
+    if (session.status !== "ready") return;
     if (initialFetchDone.current) return;
     initialFetchDone.current = true;
     fetchServer();
-  }, [walletsReady, embeddedWalletAddress, fetchServer]);
+  }, [walletsReady, embeddedWalletAddress, fetchServer, session.status]);
 
   // When status flips to `running`, determine whether this server is already
   // registered on the gateway and kick off registration if not.
@@ -393,5 +378,8 @@ export function useServer() {
     refresh,
     /** Surface confirmation state so the page can render the modal. */
     confirmation,
+    /** BFF session bootstrap status — page should gate mutation buttons. */
+    sessionStatus: session.status,
+    sessionError: session.error,
   };
 }

--- a/connect/src/lib/auth/vana-session-client.ts
+++ b/connect/src/lib/auth/vana-session-client.ts
@@ -1,0 +1,108 @@
+"use client";
+
+/**
+ * Client-side helper to keep the Vana session cookie populated on any page
+ * that issues authenticated requests.
+ *
+ * `getVanaSession` (the server-side verifier) accepts the `vana_session`
+ * cookie on read-only methods, but rejects cookie-only auth on POST/PUT/
+ * PATCH/DELETE — those mutations must send `Authorization: Bearer
+ * <vana_access>`. The `vana_access` cookie is the JS-readable companion
+ * issued by `/api/auth/session` at login.
+ *
+ * Pages reached via direct navigation (Hydra redirects, deep links) may not
+ * have hit `/login` since this domain's session cookies were last cleared.
+ * This hook detects that case (Privy is authenticated but `vana_access` is
+ * missing), POSTs the Privy id_token to `/api/auth/session`, and surfaces
+ * the bootstrap status to the caller so UI can gate buttons until the
+ * cookie is ready.
+ *
+ * Use this hook on any page that performs authenticated mutations against
+ * account.vana.org. Use `vanaAuthHeaders()` to attach the Bearer header.
+ */
+
+import { useIdentityToken, usePrivy } from "@privy-io/react-auth";
+import { useEffect, useState } from "react";
+import { readVanaAccessCookie } from "@/components/auth/use-confirmation";
+
+export type VanaSessionStatus =
+  | "unknown" // Privy state not yet ready
+  | "anonymous" // Privy reports not signed in
+  | "bootstrapping" // bootstrap POST in flight
+  | "ready" // vana_access cookie is set; safe to mutate
+  | "missing"; // bootstrap failed (e.g. cookies blocked, BFF error)
+
+export function useVanaSessionBootstrap(): {
+  status: VanaSessionStatus;
+  error: string | null;
+} {
+  const { ready, authenticated } = usePrivy();
+  const { identityToken } = useIdentityToken();
+  const [status, setStatus] = useState<VanaSessionStatus>("unknown");
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!ready) {
+      setStatus("unknown");
+      return;
+    }
+    if (!authenticated) {
+      setStatus("anonymous");
+      return;
+    }
+    if (readVanaAccessCookie()) {
+      setStatus("ready");
+      return;
+    }
+    if (!identityToken) {
+      setStatus("bootstrapping");
+      return;
+    }
+    let cancelled = false;
+    setStatus("bootstrapping");
+    setError(null);
+    void (async () => {
+      try {
+        const res = await fetch("/api/auth/session", {
+          method: "POST",
+          headers: { authorization: `Bearer ${identityToken}` },
+        });
+        if (cancelled) return;
+        if (!res.ok) {
+          setStatus("missing");
+          setError(
+            "Could not establish Vana session. Please sign in again from /login.",
+          );
+          return;
+        }
+        if (readVanaAccessCookie()) {
+          setStatus("ready");
+        } else {
+          setStatus("missing");
+          setError(
+            "Vana session cookie was not stored. Check your browser's third-party-cookie settings.",
+          );
+        }
+      } catch (err) {
+        if (cancelled) return;
+        setStatus("missing");
+        setError(err instanceof Error ? err.message : String(err));
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [ready, authenticated, identityToken]);
+
+  return { status, error };
+}
+
+/**
+ * Build an `Authorization: Bearer <vana_access>` header for state-mutating
+ * fetches. Returns an empty record if the cookie is absent — callers should
+ * gate the mutation on `useVanaSessionBootstrap()` returning `ready` first.
+ */
+export function vanaAuthHeaders(): Record<string, string> {
+  const tok = readVanaAccessCookie();
+  return tok ? { Authorization: `Bearer ${tok}` } : {};
+}


### PR DESCRIPTION
Class of bug we keep hitting: page assumes vana_access cookie is set. Adds a reusable hook so future pages can adopt the pattern. Closes the 401 on provision after fresh navigation.