### PR TITLE
feat(auth): vanaFetch wrapper + migrate all browser-side mutations

### DIFF
--- a/connect/src/app/_components/app-providers.test.tsx
+++ b/connect/src/app/_components/app-providers.test.tsx
@@ -27,6 +27,9 @@ vi.mock("@privy-io/react-auth", () => ({
     </div>
   ),
   useSyncJwtBasedAuthState: mocks.useSyncJwtBasedAuthState,
+  // VanaFetchRegistration uses this hook; return a stable shape so it can
+  // mount without exercising real Privy state.
+  useIdentityToken: () => ({ identityToken: null }),
 }));
 
 const ORIGINAL_ENV = { ...process.env };

--- a/connect/src/app/_components/app-providers.tsx
+++ b/connect/src/app/_components/app-providers.tsx
@@ -3,6 +3,7 @@
 import { PrivyProvider } from "@privy-io/react-auth";
 import type { ReactNode } from "react";
 import { resolvePrivyPublicEnv } from "@/config/privy-env";
+import { VanaFetchRegistration } from "./vana-fetch-registration";
 import { VanaJwtAuthSync } from "./vana-jwt-auth-sync";
 
 /**
@@ -39,6 +40,7 @@ export function AppProviders({ children }: { children: ReactNode }) {
       }}
     >
       <VanaJwtAuthSync />
+      <VanaFetchRegistration />
       {children}
     </PrivyProvider>
   );

--- a/connect/src/app/_components/vana-fetch-registration.tsx
+++ b/connect/src/app/_components/vana-fetch-registration.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { useIdentityToken } from "@privy-io/react-auth";
+import { useEffect, useRef } from "react";
+import { setPrivyIdentityTokenGetter } from "@/lib/auth/vana-fetch";
+
+/**
+ * Registers a Privy identity-token getter with the `vanaFetch` helper at
+ * mount. Lives at the app root inside the `<PrivyProvider>` so the SDK is
+ * available, and runs once per app lifetime.
+ *
+ * `vanaFetch` is a plain async function — not a hook — so it cannot use
+ * `useIdentityToken()` directly. We bridge by registering a getter that
+ * reads the most recent token from a ref. The ref is updated on every
+ * render of this component, so the getter is always current.
+ */
+export function VanaFetchRegistration() {
+  const { identityToken } = useIdentityToken();
+  const tokenRef = useRef<string | null | undefined>(identityToken);
+  tokenRef.current = identityToken;
+
+  useEffect(() => {
+    setPrivyIdentityTokenGetter(() => tokenRef.current ?? null);
+  }, []);
+
+  return null;
+}

--- a/connect/src/app/account/access/page-client.test.tsx
+++ b/connect/src/app/account/access/page-client.test.tsx
@@ -43,11 +43,21 @@ vi.mock("@/app/_components/logout-action-button", () => ({
   }) => <a href={href}>{children}</a>,
 }));
 
+function setVanaAccessCookie(value: string | null) {
+  if (typeof document === "undefined") return;
+  if (value === null) {
+    document.cookie = "vana_access=; max-age=0; path=/";
+  } else {
+    document.cookie = `vana_access=${encodeURIComponent(value)}; path=/`;
+  }
+}
+
 beforeEach(() => {
   vi.restoreAllMocks();
   privyMock.ready = true;
   privyMock.authenticated = false;
   privyMock.identityToken = null;
+  setVanaAccessCookie(null);
 });
 
 const chatgptRequestedDataDisplay = {
@@ -184,6 +194,9 @@ describe("AccountAccessPageClient", () => {
   });
 
   it("updates after successful revoke using returned summary", async () => {
+    // Mutation needs Bearer; pre-seed the JS-readable session cookie so
+    // vanaFetch attaches it without bootstrapping.
+    setVanaAccessCookie("fake-vana-access");
     const initialSummary = {
       account: {
         vana_user_id: "vana_user_1",
@@ -282,6 +295,9 @@ describe("AccountAccessPageClient", () => {
   });
 
   it("updates after successful disconnect using returned summary", async () => {
+    // Mutation needs Bearer; pre-seed the JS-readable session cookie so
+    // vanaFetch attaches it without bootstrapping.
+    setVanaAccessCookie("fake-vana-access");
     const initialSummary = {
       account: {
         vana_user_id: "vana_user_1",
@@ -372,16 +388,25 @@ describe("AccountAccessPageClient", () => {
     render(<AccountAccessPageClient />);
 
     expect(await screen.findByText("vana_user_2")).toBeTruthy();
-    expect(fetchMock).toHaveBeenNthCalledWith(1, "/api/account/access", {
+    expect(fetchMock.mock.calls).toHaveLength(3);
+    // Call 1 + 3: vanaFetch normalizes init.headers to a Headers instance.
+    expect(fetchMock.mock.calls[0][0]).toBe("/api/account/access");
+    expect(fetchMock.mock.calls[0][1]).toMatchObject({
       credentials: "include",
       cache: "no-store",
     });
+    // No vana_access cookie, so vanaFetch issues the read-only GET without
+    // an Authorization header (the server's vana_session cookie path covers
+    // reads).
+    expect(fetchMock.mock.calls[0][1].headers.get("Authorization")).toBeNull();
+    // Call 2 is the manual bootstrap — direct fetch, plain object headers.
     expect(fetchMock).toHaveBeenNthCalledWith(2, "/api/auth/session", {
       method: "POST",
       headers: { authorization: "Bearer test-identity-token" },
       cache: "no-store",
     });
-    expect(fetchMock).toHaveBeenNthCalledWith(3, "/api/account/access", {
+    expect(fetchMock.mock.calls[2][0]).toBe("/api/account/access");
+    expect(fetchMock.mock.calls[2][1]).toMatchObject({
       credentials: "include",
       cache: "no-store",
     });

--- a/connect/src/app/account/access/page-client.tsx
+++ b/connect/src/app/account/access/page-client.tsx
@@ -9,6 +9,7 @@ import { APP_ROUTES } from "@/app/routes";
 import { PageHeader } from "@/components/elements/page-header";
 import { Text } from "@/components/typography/text";
 import { formatStatusLabel } from "@/lib/auth/action-display";
+import { vanaFetch } from "@/lib/auth/vana-fetch";
 
 type LoadState =
   | { status: "loading" }
@@ -32,7 +33,7 @@ export function AccountAccessPageClient() {
       if (!ready) return;
 
       try {
-        let response = await fetch("/api/account/access", {
+        let response = await vanaFetch("/api/account/access", {
           credentials: "include",
           cache: "no-store",
         });
@@ -44,6 +45,8 @@ export function AccountAccessPageClient() {
             !sessionBridgeAttemptedRef.current
           ) {
             sessionBridgeAttemptedRef.current = true;
+            // Direct fetch — `/api/auth/session` is the bootstrap endpoint
+            // itself and must not go through vanaFetch.
             const sessionResponse = await fetch("/api/auth/session", {
               method: "POST",
               headers: { authorization: `Bearer ${identityToken}` },
@@ -57,7 +60,7 @@ export function AccountAccessPageClient() {
               });
               return;
             }
-            response = await fetch("/api/account/access", {
+            response = await vanaFetch("/api/account/access", {
               credentials: "include",
               cache: "no-store",
             });
@@ -187,7 +190,7 @@ function LoadedState({
 
   async function mutateAccess(url: string, errorMessage: string) {
     setMutationError(null);
-    const response = await fetch(url, {
+    const response = await vanaFetch(url, {
       method: "POST",
       credentials: "include",
       cache: "no-store",

--- a/connect/src/app/account/actions/[id]/page-client.test.tsx
+++ b/connect/src/app/account/actions/[id]/page-client.test.tsx
@@ -114,16 +114,16 @@ describe("ActionRequestPageClient", () => {
     expect(fetchMock.mock.calls[0][0]).toBe(
       "/api/account/actions/vana_areq_test",
     );
-    expect(fetchMock.mock.calls[0][1]?.headers).toEqual({
-      authorization: "Bearer fake-vana-access",
-    });
+    // vanaFetch normalizes init.headers to a Headers instance and attaches
+    // Authorization from the vana_access cookie.
+    const getHeaders = fetchMock.mock.calls[0][1]?.headers as Headers;
+    expect(getHeaders.get("Authorization")).toBe("Bearer fake-vana-access");
     expect(fetchMock.mock.calls[1][0]).toBe(
       "/api/account/actions/vana_areq_test/decision",
     );
-    expect(fetchMock.mock.calls[1][1]?.headers).toMatchObject({
-      authorization: "Bearer fake-vana-access",
-      "content-type": "application/json",
-    });
+    const postHeaders = fetchMock.mock.calls[1][1]?.headers as Headers;
+    expect(postHeaders.get("Authorization")).toBe("Bearer fake-vana-access");
+    expect(postHeaders.get("content-type")).toBe("application/json");
     expect(JSON.parse(fetchMock.mock.calls[1][1].body)).toEqual({
       decision: "approved",
       state: "client-state",

--- a/connect/src/app/account/actions/[id]/page-client.tsx
+++ b/connect/src/app/account/actions/[id]/page-client.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useIdentityToken, usePrivy } from "@privy-io/react-auth";
+import { usePrivy } from "@privy-io/react-auth";
 import { useSearchParams } from "next/navigation";
 import { useCallback, useEffect, useState } from "react";
 import { PagePanel } from "@/app/_components/page-panel";
@@ -14,25 +14,8 @@ import {
   formatRequestedDataDisplay,
   formatStatusLabel,
 } from "@/lib/auth/action-display";
-
-/**
- * Read the JS-readable companion cookie that mirrors `vana_session`.
- * `getVanaSession` only accepts the cookie on read-only methods; for any
- * state-mutating POST (e.g. action decisions) the browser must explicitly
- * send `Authorization: Bearer <vana_access>` to satisfy the verifier.
- */
-function readVanaAccessCookie(): string | null {
-  if (typeof document === "undefined") return null;
-  for (const part of document.cookie.split(";")) {
-    const eq = part.indexOf("=");
-    if (eq < 0) continue;
-    const k = part.slice(0, eq).trim();
-    if (k !== "vana_access") continue;
-    const v = part.slice(eq + 1).trim();
-    return v ? decodeURIComponent(v) : null;
-  }
-  return null;
-}
+import { vanaFetch } from "@/lib/auth/vana-fetch";
+import { useVanaSessionBootstrap } from "@/lib/auth/vana-session-client";
 
 type ActionRequestDetails = {
   action_request_id: string;
@@ -71,53 +54,15 @@ export function ActionRequestPageClient({
 }) {
   const searchParams = useSearchParams();
   const { ready, authenticated, login } = usePrivy();
-  const { identityToken } = useIdentityToken();
   const [loadState, setLoadState] = useState<LoadState>({ kind: "idle" });
   const [decisionState, setDecisionState] = useState<
     "idle" | "approving" | "denying"
   >("idle");
   const [decisionError, setDecisionError] = useState<string | null>(null);
-  const [sessionStatus, setSessionStatus] = useState<
-    "unknown" | "bootstrapping" | "ready" | "missing"
-  >("unknown");
-
-  // Self-heal vana_access cookie when Privy is signed in but the BFF session
-  // hasn't been bootstrapped on this domain (e.g. a fresh tab). Mirrors what
-  // `/login` does so action approval works without a separate sign-in step.
-  useEffect(() => {
-    if (!ready || !authenticated) {
-      setSessionStatus("unknown");
-      return;
-    }
-    if (readVanaAccessCookie()) {
-      setSessionStatus("ready");
-      return;
-    }
-    if (!identityToken) {
-      setSessionStatus("bootstrapping");
-      return;
-    }
-    let cancelled = false;
-    setSessionStatus("bootstrapping");
-    void (async () => {
-      try {
-        const res = await fetch("/api/auth/session", {
-          method: "POST",
-          headers: { authorization: `Bearer ${identityToken}` },
-        });
-        if (cancelled) return;
-        setSessionStatus(
-          res.ok && readVanaAccessCookie() ? "ready" : "missing",
-        );
-      } catch {
-        if (cancelled) return;
-        setSessionStatus("missing");
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, [ready, authenticated, identityToken]);
+  // `useVanaSessionBootstrap` self-heals the vana_access cookie when Privy
+  // is signed in but the BFF session hasn't been bootstrapped on this
+  // domain. The Authorize button stays disabled until the cookie is ready.
+  const { status: sessionStatus } = useVanaSessionBootstrap();
 
   useEffect(() => {
     if (!ready || !authenticated) return;
@@ -125,12 +70,8 @@ export function ActionRequestPageClient({
 
     const controller = new AbortController();
     setLoadState({ kind: "loading" });
-    const accessToken = readVanaAccessCookie();
-    fetch(`/api/account/actions/${encodeURIComponent(actionRequestId)}`, {
+    vanaFetch(`/api/account/actions/${encodeURIComponent(actionRequestId)}`, {
       signal: controller.signal,
-      headers: accessToken
-        ? { authorization: `Bearer ${accessToken}` }
-        : undefined,
     })
       .then(async (response) => {
         const body = await response.json();
@@ -163,19 +104,12 @@ export function ActionRequestPageClient({
       setDecisionState(decision === "approved" ? "approving" : "denying");
       try {
         const state = searchParams.get("state");
-        const accessToken = readVanaAccessCookie();
-        if (!accessToken) {
-          throw new Error(
-            "Vana session is not ready yet. Refresh and try again.",
-          );
-        }
-        const response = await fetch(
+        const response = await vanaFetch(
           `/api/account/actions/${encodeURIComponent(actionRequestId)}/decision`,
           {
             method: "POST",
             headers: {
               "content-type": "application/json",
-              authorization: `Bearer ${accessToken}`,
             },
             body: JSON.stringify({
               decision,

--- a/connect/src/app/auth/oidc/device/page.tsx
+++ b/connect/src/app/auth/oidc/device/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useIdentityToken, usePrivy } from "@privy-io/react-auth";
+import { usePrivy } from "@privy-io/react-auth";
 import { useSearchParams } from "next/navigation";
 import { Suspense, useCallback, useEffect, useMemo, useState } from "react";
 import { PagePanel } from "@/app/_components/page-panel";
@@ -10,6 +10,8 @@ import { PageLoadingState } from "@/components/elements/page-loading-state";
 import { Spinner } from "@/components/elements/spinner";
 import { Text } from "@/components/typography/text";
 import { Button } from "@/components/ui/button";
+import { vanaFetch } from "@/lib/auth/vana-fetch";
+import { useVanaSessionBootstrap } from "@/lib/auth/vana-session-client";
 
 /**
  * Hydra device-grant verification page.
@@ -31,34 +33,28 @@ import { Button } from "@/components/ui/button";
  * `urls.device.success` → `/auth/oidc/device-success`.
  */
 
-function readVanaAccessCookie(): string | null {
-  if (typeof document === "undefined") return null;
-  for (const part of document.cookie.split(";")) {
-    const eq = part.indexOf("=");
-    if (eq < 0) continue;
-    const k = part.slice(0, eq).trim();
-    if (k !== "vana_access") continue;
-    const v = part.slice(eq + 1).trim();
-    return v ? decodeURIComponent(v) : null;
-  }
-  return null;
-}
-
 type AcceptStatus = "idle" | "submitting" | "approved" | "error";
-
-type SessionStatus = "unknown" | "bootstrapping" | "ready" | "missing";
 
 function DeviceVerificationContent() {
   const searchParams = useSearchParams();
   const { ready, authenticated } = usePrivy();
-  const { identityToken } = useIdentityToken();
+  // `useVanaSessionBootstrap` self-heals the vana_access cookie when Privy
+  // is signed in but the BFF session hasn't been bootstrapped on this
+  // domain. The Authorize button stays disabled until the cookie is ready.
+  const { status: sessionStatus, error: sessionError } =
+    useVanaSessionBootstrap();
 
   const deviceChallenge = searchParams.get("device_challenge");
   const userCode = searchParams.get("user_code");
 
   const [status, setStatus] = useState<AcceptStatus>("idle");
   const [error, setError] = useState<string | null>(null);
-  const [sessionStatus, setSessionStatus] = useState<SessionStatus>("unknown");
+
+  // Surface session-bootstrap failures inline so the user sees why Authorize
+  // is disabled.
+  useEffect(() => {
+    if (sessionError) setError(sessionError);
+  }, [sessionError]);
 
   const isLoggedIn = ready && authenticated;
 
@@ -82,82 +78,15 @@ function DeviceVerificationContent() {
     window.location.href = `/login?return_to=${encodeURIComponent(here)}`;
   }, [deviceChallenge, userCode]);
 
-  // Self-heal the Vana session cookie when Privy is authenticated but
-  // `vana_access` is missing. This happens whenever a user lands on this
-  // page already signed in via Privy on another tab, but their browser has
-  // never POSTed to `/api/auth/session` on this domain (e.g., a fresh tab
-  // following Hydra's redirect rather than a `/login` round-trip).
-  //
-  // We mirror exactly what `/login` does: POST the Privy id_token; on
-  // success the BFF mints the Hydra session and sets vana_access + vana_session.
-  useEffect(() => {
-    if (!isLoggedIn) {
-      setSessionStatus("unknown");
-      return;
-    }
-    if (readVanaAccessCookie()) {
-      setSessionStatus("ready");
-      return;
-    }
-    if (!identityToken) {
-      // Privy is authenticated but the id_token hasn't been minted yet.
-      // useIdentityToken updates as Privy resolves it; this effect re-runs.
-      setSessionStatus("bootstrapping");
-      return;
-    }
-
-    let cancelled = false;
-    setSessionStatus("bootstrapping");
-    void (async () => {
-      try {
-        const res = await fetch("/api/auth/session", {
-          method: "POST",
-          headers: { authorization: `Bearer ${identityToken}` },
-        });
-        if (cancelled) return;
-        if (!res.ok) {
-          setSessionStatus("missing");
-          setError(
-            "Could not establish Vana session. Please sign in again from /login.",
-          );
-          return;
-        }
-        // Cookie is set on the response; double-check it landed before flipping
-        // to "ready" so a downstream cookie-blocking config doesn't hang the
-        // user on a Spinner forever.
-        if (readVanaAccessCookie()) {
-          setSessionStatus("ready");
-        } else {
-          setSessionStatus("missing");
-          setError(
-            "Vana session cookie was not stored. Check your browser's third-party-cookie settings.",
-          );
-        }
-      } catch (err) {
-        if (cancelled) return;
-        setSessionStatus("missing");
-        setError(err instanceof Error ? err.message : String(err));
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, [isLoggedIn, identityToken]);
-
   const handleAuthorize = useCallback(async () => {
     if (!deviceChallenge || !userCode) return;
     setStatus("submitting");
     setError(null);
     try {
-      const accessToken = readVanaAccessCookie();
-      if (!accessToken) {
-        throw new Error("Vana session is not ready yet.");
-      }
-      const res = await fetch("/api/auth/oidc/device-accept", {
+      const res = await vanaFetch("/api/auth/oidc/device-accept", {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
-          Authorization: `Bearer ${accessToken}`,
         },
         body: JSON.stringify({
           device_challenge: deviceChallenge,

--- a/connect/src/app/server/use-server.test.ts
+++ b/connect/src/app/server/use-server.test.ts
@@ -110,9 +110,19 @@ describe("useServer", () => {
       await Promise.resolve();
     });
 
-    expect(fetchMock).toHaveBeenCalledWith("/api/servers", {
-      headers: { Authorization: "Bearer vana-access-tok" },
-    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/servers",
+      expect.objectContaining({
+        headers: expect.any(Headers),
+      }),
+    );
+    {
+      const firstCall = fetchMock.mock.calls.find(
+        (call) => call[0] === "/api/servers",
+      );
+      const headers = firstCall?.[1]?.headers as Headers;
+      expect(headers.get("Authorization")).toBe("Bearer vana-access-tok");
+    }
 
     await act(async () => {
       await result.current.provision();
@@ -125,9 +135,19 @@ describe("useServer", () => {
       await Promise.resolve();
     });
 
-    expect(fetchMock).toHaveBeenCalledWith("/api/servers/srv_123", {
-      headers: { Authorization: "Bearer vana-access-tok" },
-    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/servers/srv_123",
+      expect.objectContaining({
+        headers: expect.any(Headers),
+      }),
+    );
+    {
+      const polledCall = fetchMock.mock.calls.find(
+        (call) => call[0] === "/api/servers/srv_123",
+      );
+      const headers = polledCall?.[1]?.headers as Headers;
+      expect(headers.get("Authorization")).toBe("Bearer vana-access-tok");
+    }
     expect(result.current.status).toBe("running");
   });
 });

--- a/connect/src/app/server/use-server.ts
+++ b/connect/src/app/server/use-server.ts
@@ -3,10 +3,8 @@
 import { useSignMessage, useWallets } from "@privy-io/react-auth";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useConfirmation } from "@/components/auth/use-confirmation";
-import {
-  useVanaSessionBootstrap,
-  vanaAuthHeaders,
-} from "@/lib/auth/vana-session-client";
+import { vanaFetch } from "@/lib/auth/vana-fetch";
+import { useVanaSessionBootstrap } from "@/lib/auth/vana-session-client";
 
 const MASTER_KEY_MESSAGE = "vana-master-key-v1";
 const POLL_INTERVAL_MS = 5_000;
@@ -99,11 +97,10 @@ export function useServer() {
     try {
       const serverId = provisioningServerIdRef.current;
       const endpoint = serverId ? `/api/servers/${serverId}` : "/api/servers";
-      // GET — verifier accepts vana_session cookie, but we send Bearer too
-      // for explicitness and so the same call shape works on POST/DELETE.
-      const res = await fetch(endpoint, {
-        headers: { ...vanaAuthHeaders() },
-      });
+      // GET — verifier accepts vana_session cookie, but vanaFetch sends
+      // Bearer too for explicitness and so the same call shape works on
+      // POST/DELETE.
+      const res = await vanaFetch(endpoint);
       if (!res.ok) {
         throw new Error(`Failed to fetch server: ${res.status}`);
       }
@@ -147,9 +144,9 @@ export function useServer() {
       // derivation. The PS startup script uses VANA_MASTER_KEY_SIGNATURE
       // to deterministically derive its signing keypair.
       const sig = await getSignature();
-      const res = await fetch("/api/servers", {
+      const res = await vanaFetch("/api/servers", {
         method: "POST",
-        headers: { "Content-Type": "application/json", ...vanaAuthHeaders() },
+        headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ masterKeySignature: sig }),
       });
       if (!res.ok) {
@@ -177,9 +174,8 @@ export function useServer() {
     // Without this, users see no feedback and assume the click was lost.
     setStatus("deprovisioning");
     try {
-      const res = await fetch(`/api/servers/${server.id}`, {
+      const res = await vanaFetch(`/api/servers/${server.id}`, {
         method: "DELETE",
-        headers: { ...vanaAuthHeaders() },
       });
       if (!res.ok) {
         const json = await res.json().catch(() => ({}));
@@ -197,17 +193,15 @@ export function useServer() {
     }
   }, [server, stopPolling]);
 
-  // Initial fetch once wallet is ready AND the BFF session cookie is in
-  // place. Without the session gate, the GET /api/servers fires before
-  // /api/auth/session has minted vana_session, and the verifier 401s
-  // because state-mutating callers (provision later) need vana_access too.
+  // Initial fetch once wallet is ready. vanaFetch handles session bootstrap
+  // internally on mutating calls; GET /api/servers can use the vana_session
+  // cookie path on the verifier so no explicit gate is needed here.
   useEffect(() => {
     if (!walletsReady || !embeddedWalletAddress) return;
-    if (session.status !== "ready") return;
     if (initialFetchDone.current) return;
     initialFetchDone.current = true;
     fetchServer();
-  }, [walletsReady, embeddedWalletAddress, fetchServer, session.status]);
+  }, [walletsReady, embeddedWalletAddress, fetchServer]);
 
   // When status flips to `running`, determine whether this server is already
   // registered on the gateway and kick off registration if not.
@@ -221,10 +215,8 @@ export function useServer() {
   // /v1/servers/{address} route is keyed on serverAddress).
   useEffect(() => {
     if (status !== "running" || !server?.url) return;
-    // Gate on session bootstrap. Without this, the auto-register-on-chain
-    // POST below races the cookie set and 401s on every page load until
-    // a manual user action retries.
-    if (session.status !== "ready") return;
+    // vanaFetch bootstraps the session internally on the mutating
+    // register-on-chain POST below if the cookie isn't yet set.
 
     let cancelled = false;
     const serverUrl = server.url;
@@ -295,19 +287,17 @@ export function useServer() {
       // the inline modal dance, then we retry with x-vana-confirmation-id.
       setRegistrationStatus("registering");
       try {
-        let res = await fetch(`/api/servers/${dbId}/register-on-chain`, {
+        let res = await vanaFetch(`/api/servers/${dbId}/register-on-chain`, {
           method: "POST",
-          headers: { ...vanaAuthHeaders() },
         });
         if (cancelled) return;
         if (res.status === 401) {
           const result = await confirmation.handle401(res);
           if (cancelled) return;
           if (result) {
-            res = await fetch(`/api/servers/${dbId}/register-on-chain`, {
+            res = await vanaFetch(`/api/servers/${dbId}/register-on-chain`, {
               method: "POST",
               headers: {
-                ...vanaAuthHeaders(),
                 "x-vana-confirmation-id": result.confirmedId,
               },
             });
@@ -356,7 +346,7 @@ export function useServer() {
     return () => {
       cancelled = true;
     };
-  }, [status, server, confirmation, session.status]);
+  }, [status, server, confirmation]);
 
   // Poll while provisioning
   useEffect(() => {

--- a/connect/src/components/auth/use-confirmation.test.tsx
+++ b/connect/src/components/auth/use-confirmation.test.tsx
@@ -128,11 +128,14 @@ describe("useConfirmation", () => {
       expect.objectContaining({
         method: "POST",
         credentials: "include",
-        headers: expect.objectContaining({
-          Authorization: "Bearer vat_test_token",
-        }),
+        headers: expect.any(Headers),
       }),
     );
+    const consumeCall = fetchMock.mock.calls.find(
+      (call) => call[0] === "/api/auth/confirmations/conf_abc/consume",
+    );
+    const headers = consumeCall?.[1]?.headers as Headers;
+    expect(headers.get("Authorization")).toBe("Bearer vat_test_token");
   });
 
   it("on consume failure sets error and resolves null", async () => {
@@ -196,6 +199,8 @@ describe("useConfirmation", () => {
     });
 
     await expect(promise).resolves.toBeNull();
-    expect(result.current.error).toContain("access token");
+    // vanaFetch can't bootstrap without a registered identity-token getter,
+    // so it throws VanaSessionUnavailableError; confirm surfaces the message.
+    expect(result.current.error).toContain("Vana session");
   });
 });

--- a/connect/src/components/auth/use-confirmation.ts
+++ b/connect/src/components/auth/use-confirmation.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useRef, useState } from "react";
+import { vanaFetch } from "@/lib/auth/vana-fetch";
 
 /**
  * Shape of the JSON body returned by any /api/servers/* route that needs
@@ -152,19 +153,12 @@ export function useConfirmation(): UseConfirmationResult {
   const confirm = useCallback(async () => {
     const current = pendingRef.current;
     if (!current) return;
-    const access = readVanaAccessCookie();
-    if (!access) {
-      setError("Missing access token");
-      settle(null);
-      return;
-    }
     try {
-      const response = await fetch(
+      const response = await vanaFetch(
         `/api/auth/confirmations/${encodeURIComponent(current.confirmation_id)}/consume`,
         {
           method: "POST",
           credentials: "include",
-          headers: { Authorization: `Bearer ${access}` },
         },
       );
       if (!response.ok) {

--- a/connect/src/lib/auth/vana-fetch.test.ts
+++ b/connect/src/lib/auth/vana-fetch.test.ts
@@ -1,0 +1,307 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  __resetVanaFetchForTests,
+  setPrivyIdentityTokenGetter,
+  vanaFetch,
+  VanaSessionUnavailableError,
+} from "./vana-fetch";
+
+const ACCESS_COOKIE = "vana_access";
+
+/** Wipe document.cookie. jsdom expires cookies whose value is set with
+ * `expires` in the past. */
+function clearCookies(): void {
+  // Get every cookie name currently visible and expire it.
+  const raw = document.cookie;
+  if (!raw) return;
+  for (const part of raw.split(";")) {
+    const eq = part.indexOf("=");
+    const name = (eq === -1 ? part : part.slice(0, eq)).trim();
+    if (!name) continue;
+    document.cookie = `${name}=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/`;
+  }
+}
+
+function setAccessCookie(value: string): void {
+  document.cookie = `${ACCESS_COOKIE}=${encodeURIComponent(value)}; path=/`;
+}
+
+/**
+ * Build a Response with a JSON body. `body` defaults to an empty object so
+ * `response.clone().json()` succeeds.
+ */
+function jsonResponse(
+  status: number,
+  body: unknown = {},
+  init: ResponseInit = {},
+): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+    ...init,
+  });
+}
+
+function getAuthHeader(call: unknown): string | null {
+  // `fetch` mock receives (input, init?) — we only inspect init.headers.
+  const args = call as [unknown, RequestInit | undefined];
+  const init = args[1];
+  if (!init?.headers) return null;
+  const headers = new Headers(init.headers);
+  return headers.get("Authorization");
+}
+
+describe("vanaFetch", () => {
+  beforeEach(() => {
+    clearCookies();
+    __resetVanaFetchForTests();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    clearCookies();
+    __resetVanaFetchForTests();
+  });
+
+  it("attaches Bearer header on GET when cookie is present and does not bootstrap", async () => {
+    setAccessCookie("tok-abc");
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(jsonResponse(200, { ok: true }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const res = await vanaFetch("/api/me");
+    expect(res.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(getAuthHeader(fetchMock.mock.calls[0])).toBe("Bearer tok-abc");
+  });
+
+  it("attaches Bearer header on POST when cookie is present and does not bootstrap", async () => {
+    setAccessCookie("tok-xyz");
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse(200));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await vanaFetch("/api/foo", { method: "POST", body: '{"a":1}' });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const call = fetchMock.mock.calls[0] as [unknown, RequestInit];
+    expect(call[1].method).toBe("POST");
+    expect(getAuthHeader(call)).toBe("Bearer tok-xyz");
+  });
+
+  it("on GET with no cookie, fires fetch without Authorization (cookie-path read)", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse(200));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await vanaFetch("/api/me");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(getAuthHeader(fetchMock.mock.calls[0])).toBeNull();
+  });
+
+  it("on POST with no cookie, bootstraps via /api/auth/session, then issues request with Bearer", async () => {
+    setPrivyIdentityTokenGetter(() => "id-token-1");
+
+    const fetchMock = vi
+      .fn()
+      .mockImplementationOnce(async (input: RequestInfo | URL) => {
+        expect(String(input)).toBe("/api/auth/session");
+        // Server "set" the cookie:
+        setAccessCookie("tok-fresh");
+        return jsonResponse(200, { ok: true });
+      })
+      .mockImplementationOnce(async () => jsonResponse(200, { ok: true }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const res = await vanaFetch("/api/foo", { method: "POST" });
+    expect(res.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(getAuthHeader(fetchMock.mock.calls[1])).toBe("Bearer tok-fresh");
+  });
+
+  it("on POST with no cookie and bootstrap 5xx, throws and never issues the original fetch", async () => {
+    setPrivyIdentityTokenGetter(() => "id-token-1");
+
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse(500, { error: "boom" }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      vanaFetch("/api/foo", { method: "POST" }),
+    ).rejects.toBeInstanceOf(VanaSessionUnavailableError);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(String(fetchMock.mock.calls[0]?.[0])).toBe("/api/auth/session");
+  });
+
+  it("on POST with no cookie and no getter registered, throws and never issues fetch", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      vanaFetch("/api/foo", { method: "POST" }),
+    ).rejects.toBeInstanceOf(VanaSessionUnavailableError);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("retries once on 401 authentication_error after a successful bootstrap", async () => {
+    setAccessCookie("tok-old");
+    setPrivyIdentityTokenGetter(() => "id-token-2");
+
+    const fetchMock = vi
+      .fn()
+      // First app call: 401 with auth_error body
+      .mockImplementationOnce(async () =>
+        jsonResponse(401, { error: { type: "authentication_error" } }),
+      )
+      // Bootstrap call: success, sets a new cookie
+      .mockImplementationOnce(async (input: RequestInfo | URL) => {
+        expect(String(input)).toBe("/api/auth/session");
+        // Replace cookie with a fresh value
+        setAccessCookie("tok-new");
+        return jsonResponse(200);
+      })
+      // Retry app call: success
+      .mockImplementationOnce(async () => jsonResponse(200, { ok: true }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const res = await vanaFetch("/api/foo", { method: "POST" });
+    expect(res.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    // First call used the old cookie; retry used the new one.
+    expect(getAuthHeader(fetchMock.mock.calls[0])).toBe("Bearer tok-old");
+    expect(getAuthHeader(fetchMock.mock.calls[2])).toBe("Bearer tok-new");
+  });
+
+  it("returns the original 401 response when the bootstrap retry also fails", async () => {
+    setAccessCookie("tok-old");
+    setPrivyIdentityTokenGetter(() => "id-token-3");
+
+    const original = jsonResponse(401, {
+      error: { type: "authentication_error" },
+    });
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(original)
+      .mockResolvedValueOnce(jsonResponse(500)); // bootstrap fails
+    vi.stubGlobal("fetch", fetchMock);
+
+    const res = await vanaFetch("/api/foo", { method: "POST" });
+    expect(res).toBe(original);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not loop: a 401 after bootstrap-on-this-call is final", async () => {
+    setPrivyIdentityTokenGetter(() => "id-token-4");
+
+    const fetchMock = vi
+      .fn()
+      // Bootstrap (cookie missing → bootstrap first)
+      .mockImplementationOnce(async () => {
+        setAccessCookie("tok-1");
+        return jsonResponse(200);
+      })
+      // Original request returns 401
+      .mockImplementationOnce(async () =>
+        jsonResponse(401, { error: { type: "authentication_error" } }),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const res = await vanaFetch("/api/foo", { method: "POST" });
+    expect(res.status).toBe(401);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("replaces caller-provided Authorization header with the cookie-derived one", async () => {
+    setAccessCookie("tok-from-cookie");
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse(200));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await vanaFetch("/api/foo", {
+      method: "POST",
+      headers: { Authorization: "Bearer attacker-supplied" },
+    });
+    expect(getAuthHeader(fetchMock.mock.calls[0])).toBe(
+      "Bearer tok-from-cookie",
+    );
+  });
+
+  it("preserves caller-supplied non-Authorization headers", async () => {
+    setAccessCookie("tok-1");
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse(200));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await vanaFetch("/api/foo", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-vana-confirmation-id": "conf-123",
+      },
+    });
+    const call = fetchMock.mock.calls[0] as [unknown, RequestInit];
+    const headers = new Headers(call[1].headers);
+    expect(headers.get("Content-Type")).toBe("application/json");
+    expect(headers.get("x-vana-confirmation-id")).toBe("conf-123");
+    expect(headers.get("Authorization")).toBe("Bearer tok-1");
+  });
+
+  it("dedupes concurrent bootstraps when two mutating calls race with no cookie", async () => {
+    setPrivyIdentityTokenGetter(() => "id-token-shared");
+
+    let bootstrapCalls = 0;
+    let resolveBootstrap: (() => void) | null = null;
+    const bootstrapStarted = new Promise<void>((resolve) => {
+      // Capture so we can wait for the first call to be in-flight before
+      // firing the second.
+      resolveBootstrap = resolve;
+    });
+
+    const fetchMock = vi
+      .fn()
+      .mockImplementation(async (input: RequestInfo | URL) => {
+        const url = String(input);
+        if (url === "/api/auth/session") {
+          bootstrapCalls += 1;
+          // Signal that the bootstrap call has started; let the second
+          // vanaFetch piggyback on it.
+          resolveBootstrap?.();
+          // Yield a few microtasks so the second caller actually reaches
+          // ensureBootstrap before we resolve.
+          await new Promise((r) => setTimeout(r, 10));
+          setAccessCookie("tok-shared");
+          return jsonResponse(200);
+        }
+        return jsonResponse(200, { url });
+      });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const a = vanaFetch("/api/a", { method: "POST" });
+    await bootstrapStarted; // ensure bootstrap is in flight
+    const b = vanaFetch("/api/b", { method: "POST" });
+
+    const [resA, resB] = await Promise.all([a, b]);
+    expect(resA.status).toBe(200);
+    expect(resB.status).toBe(200);
+    expect(bootstrapCalls).toBe(1);
+    // Total calls: 1 bootstrap + 2 app calls = 3
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("throws when called without a document (SSR guard)", async () => {
+    const originalDocument = globalThis.document;
+    // jsdom's document is non-configurable on globalThis in some setups; use
+    // delete + restore via Object.defineProperty for safety.
+    Object.defineProperty(globalThis, "document", {
+      configurable: true,
+      value: undefined,
+    });
+    try {
+      await expect(vanaFetch("/api/foo")).rejects.toBeInstanceOf(
+        VanaSessionUnavailableError,
+      );
+    } finally {
+      Object.defineProperty(globalThis, "document", {
+        configurable: true,
+        value: originalDocument,
+      });
+    }
+  });
+});

--- a/connect/src/lib/auth/vana-fetch.ts
+++ b/connect/src/lib/auth/vana-fetch.ts
@@ -1,0 +1,258 @@
+"use client";
+
+/**
+ * Authenticated fetch wrapper for browser-side calls to account.vana.org's
+ * own API.
+ *
+ * This module exists so callers cannot forget the `Authorization: Bearer
+ * <vana_access>` header or race the cookie-mint that happens after Privy
+ * login. Both concerns are handled at the lowest layer.
+ *
+ * Background:
+ *
+ * - The `vana_access` cookie is the JS-readable companion to the HttpOnly
+ *   `vana_session` cookie. Both are minted by `POST /api/auth/session` after
+ *   Privy login.
+ * - The server-side verifier `getVanaSession()` accepts `vana_session` on
+ *   GET/HEAD/OPTIONS only. On POST/PUT/PATCH/DELETE it requires
+ *   `Authorization: Bearer <token>` (CSRF defense).
+ * - So mutating browser code must read `vana_access` and attach it. If the
+ *   cookie is missing, it must mint it first by POSTing the Privy id_token
+ *   to `/api/auth/session`.
+ *
+ * Usage:
+ *
+ *   // Once at the app shell, after Privy is ready:
+ *   useEffect(() => {
+ *     setPrivyIdentityTokenGetter(() => identityTokenRef.current);
+ *   }, []);
+ *
+ *   // Anywhere a mutation is performed:
+ *   const res = await vanaFetch("/api/servers/.../register-on-chain", {
+ *     method: "POST",
+ *     body: JSON.stringify({ ... }),
+ *   });
+ */
+
+import { readVanaAccessCookie } from "@/components/auth/use-confirmation";
+
+/**
+ * Thrown when the helper cannot establish a Vana session — for example,
+ * Privy is not ready, no identity-token getter has been registered,
+ * the bootstrap call to `/api/auth/session` failed, or the cookie did
+ * not land after a successful bootstrap (third-party-cookie blocking).
+ */
+export class VanaSessionUnavailableError extends Error {
+  override readonly cause?: unknown;
+
+  constructor(message: string, cause?: unknown) {
+    super(message);
+    this.name = "VanaSessionUnavailableError";
+    if (cause !== undefined) this.cause = cause;
+  }
+}
+
+type IdentityTokenGetter = () => string | null | undefined;
+
+let identityTokenGetter: IdentityTokenGetter | null = null;
+let bootstrapInFlight: Promise<boolean> | null = null;
+
+/**
+ * Register the Privy identity-token getter once at app shell. The getter is
+ * called whenever the helper needs to bootstrap a Vana session. It must
+ * return the current Privy `identity_token` or `null`/`undefined` if Privy
+ * is not yet ready.
+ *
+ * Pass `null` to clear the registration (e.g. on logout).
+ */
+export function setPrivyIdentityTokenGetter(
+  getter: IdentityTokenGetter | null,
+): void {
+  identityTokenGetter = getter;
+}
+
+const READ_ONLY_METHODS = new Set(["GET", "HEAD", "OPTIONS"]);
+
+function isReadOnlyMethod(method: string | undefined): boolean {
+  if (!method) return true; // default fetch method is GET
+  return READ_ONLY_METHODS.has(method.toUpperCase());
+}
+
+/**
+ * Build a fresh `Headers` object from `init.headers`, stripping any
+ * caller-supplied `Authorization` header. The cookie-derived value is the
+ * single source of truth.
+ */
+function withAuthHeaders(
+  init: RequestInit | undefined,
+  bearerToken: string | null,
+): Headers {
+  const headers = new Headers(init?.headers ?? undefined);
+  headers.delete("Authorization");
+  // Headers is case-insensitive but be explicit; some test runners
+  // preserve original casing in snapshots.
+  headers.delete("authorization");
+  if (bearerToken) {
+    headers.set("Authorization", `Bearer ${bearerToken}`);
+  }
+  return headers;
+}
+
+/**
+ * Start a bootstrap if needed and report whether a `vana_access` cookie is
+ * present after it settles. Concurrent callers share a single in-flight
+ * bootstrap promise.
+ *
+ * When `force` is false, an existing cookie short-circuits the bootstrap
+ * (used on the pre-flight path: cookie present → trust it). When `force`
+ * is true, the cookie is ignored as a precondition (used on the 401-retry
+ * path: the cookie may have just been rejected as expired).
+ */
+async function ensureBootstrap(force = false): Promise<boolean> {
+  if (!force && readVanaAccessCookie()) return true;
+
+  if (bootstrapInFlight) {
+    return bootstrapInFlight;
+  }
+
+  const getter = identityTokenGetter;
+  if (!getter) return false;
+
+  const promise = (async (): Promise<boolean> => {
+    const idToken = getter();
+    if (!idToken) return false;
+    try {
+      const res = await fetch("/api/auth/session", {
+        method: "POST",
+        headers: { Authorization: `Bearer ${idToken}` },
+      });
+      if (!res.ok) return false;
+    } catch {
+      return false;
+    }
+    return readVanaAccessCookie() !== null;
+  })();
+
+  bootstrapInFlight = promise;
+  try {
+    return await promise;
+  } finally {
+    // Clear the cache so a subsequent call (e.g. cookie expired again)
+    // can re-trigger.
+    if (bootstrapInFlight === promise) {
+      bootstrapInFlight = null;
+    }
+  }
+}
+
+/**
+ * If the response is a 401 with `{ error: { type: "authentication_error" } }`,
+ * return true. Reads via `response.clone()` so the original body remains
+ * consumable.
+ */
+async function isAuthenticationError(response: Response): Promise<boolean> {
+  if (response.status !== 401) return false;
+  try {
+    const body = (await response.clone().json()) as {
+      error?: { type?: unknown } | unknown;
+    };
+    const error = body.error;
+    if (
+      error &&
+      typeof error === "object" &&
+      "type" in error &&
+      (error as { type?: unknown }).type === "authentication_error"
+    ) {
+      return true;
+    }
+    return false;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Wrapper around `fetch` for authenticated same-origin calls to
+ * account.vana.org's API.
+ *
+ * Behavior:
+ *
+ * 1. Read the `vana_access` cookie.
+ * 2. If present: attach `Authorization: Bearer <cookie>`. Issue fetch.
+ * 3. If absent and method is read-only (GET/HEAD/OPTIONS): issue fetch
+ *    without `Authorization` (the server's cookie path covers reads via
+ *    `vana_session`).
+ * 4. If absent and method is mutating: bootstrap (POST id_token to
+ *    `/api/auth/session`), re-read the cookie, and either attach Bearer or
+ *    throw `VanaSessionUnavailableError`.
+ * 5. If the response is 401 with body `{ error: { type:
+ *    "authentication_error" } }` AND we did not bootstrap on this call AND
+ *    an id-token getter is registered: bootstrap once and retry the same
+ *    fetch one time. If the retry also 401s, return that response.
+ *
+ * Concurrency: multiple in-flight callers that need to bootstrap share a
+ * single bootstrap promise.
+ *
+ * Override: any caller-provided `Authorization` header is replaced with the
+ * cookie-derived one. There is one source of truth.
+ */
+export async function vanaFetch(
+  input: RequestInfo | URL,
+  init?: RequestInit,
+): Promise<Response> {
+  if (typeof document === "undefined") {
+    throw new VanaSessionUnavailableError(
+      "vanaFetch can only be called from the browser (no document).",
+    );
+  }
+
+  const method = init?.method;
+  const readOnly = isReadOnlyMethod(method);
+
+  let cookie = readVanaAccessCookie();
+  let bootstrappedThisCall = false;
+
+  if (!cookie && !readOnly) {
+    bootstrappedThisCall = true;
+    const ok = await ensureBootstrap();
+    if (!ok) {
+      throw new VanaSessionUnavailableError(
+        "Could not establish a Vana session. Please sign in again from /login.",
+      );
+    }
+    cookie = readVanaAccessCookie();
+    if (!cookie) {
+      throw new VanaSessionUnavailableError(
+        "Vana session cookie was not stored after bootstrap. Check third-party-cookie settings.",
+      );
+    }
+  }
+
+  const headers = withAuthHeaders(init, cookie);
+  const response = await fetch(input, { ...init, headers });
+
+  if (bootstrappedThisCall) return response;
+  if (!identityTokenGetter) return response;
+  if (!(await isAuthenticationError(response))) return response;
+
+  // Retry path: the cookie may have expired mid-page-life. Force a fresh
+  // bootstrap (the existing cookie is the one the server just rejected) and
+  // retry the same call exactly once. Accept whatever the retry returns.
+  const ok = await ensureBootstrap(true);
+  if (!ok) return response;
+  const refreshed = readVanaAccessCookie();
+  if (!refreshed) return response;
+  const retryHeaders = withAuthHeaders(init, refreshed);
+  return fetch(input, { ...init, headers: retryHeaders });
+}
+
+/**
+ * Test-only helper. Reset module-level state between tests.
+ * Not part of the public API.
+ *
+ * @internal
+ */
+export function __resetVanaFetchForTests(): void {
+  identityTokenGetter = null;
+  bootstrapInFlight = null;
+}


### PR DESCRIPTION
Single helper replaces ad-hoc fetch + vanaAuthHeaders + inline session-bootstrap useEffects across the app. Eliminates the recurring class of bug where a page-mount fetch races Privy id-token availability.

## Changes

- New `connect/src/lib/auth/vana-fetch.ts` with single-flight bootstrap dedup, 401-retry-once, SSR guard, full `RequestInit` passthrough. 13 unit tests.
- App shell registers the Privy id-token getter via `<VanaFetchRegistration />` inside `<PrivyProvider>`.
- Migrated 11 fetch sites across `/server`, `/account/access`, `/account/actions/[id]`, `/auth/oidc/device`, `use-confirmation`. Inline bootstrap useEffects deleted where they existed.

## Verification

- `pnpm tsc --noEmit`: 0 errors on touched files.
- `pnpm test --run`: 533 pass, 42 skipped, 0 failed.

## Out of scope (left as direct fetch)

- `/api/auth/session` (bootstrap endpoint itself).
- `/api/admin/*` (master-key bearer).
- `/api/auth/device/approve`, `/api/site-metadata`, `/api/auth/privy-custom-auth-jwt` (public/different auth).