### PR TITLE
fix(server): unblock register-on-chain on /server page

### DIFF
--- a/connect/src/components/auth/use-confirmation.ts
+++ b/connect/src/components/auth/use-confirmation.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import { vanaFetch } from "@/lib/auth/vana-fetch";
 
 /**
@@ -221,5 +221,15 @@ export function useConfirmation(): UseConfirmationResult {
     [],
   );
 
-  return { pending, error, handle401, confirm, dismiss };
+  // Stable identity matters: `useServer`'s register-on-chain effect lists
+  // `confirmation` in its dep array. Without memoization, every render of
+  // any consuming component (wallet ready flips, session bootstrap, etc.)
+  // produces a new object → effect re-fires → its cleanup sets
+  // cancelled=true → the in-flight handle401 never gets a chance to surface
+  // the modal. Memoizing on the actual primitive deps keeps the effect
+  // stable except when `pending`/`error` truly change.
+  return useMemo(
+    () => ({ pending, error, handle401, confirm, dismiss }),
+    [pending, error, handle401, confirm, dismiss],
+  );
 }

--- a/connect/src/lib/auth/signing-purposes.test.ts
+++ b/connect/src/lib/auth/signing-purposes.test.ts
@@ -89,18 +89,21 @@ describe("isSigningPurpose", () => {
 });
 
 describe("isHighRisk", () => {
-  it("flags register/deregister/create_grant as high-risk", () => {
-    expect(isHighRisk("register_personal_server")).toBe(true);
-    expect(isHighRisk("register_personal_server_deregistration")).toBe(true);
+  it("flags create_grant as high-risk", () => {
     expect(isHighRisk("create_grant")).toBe(true);
   });
 
-  it("flags revoke_grant as not-high-risk (revocation is user-protective)", () => {
+  it("does not flag PS lifecycle purposes (server signs with its own key)", () => {
+    expect(isHighRisk("register_personal_server")).toBe(false);
+    expect(isHighRisk("register_personal_server_deregistration")).toBe(false);
+  });
+
+  it("does not flag revoke_grant (revocation is user-protective)", () => {
     expect(isHighRisk("revoke_grant")).toBe(false);
   });
 
-  it("HIGH_RISK_PURPOSES is a Set with three members", () => {
-    expect(HIGH_RISK_PURPOSES.size).toBe(3);
+  it("HIGH_RISK_PURPOSES is a Set with one member", () => {
+    expect(HIGH_RISK_PURPOSES.size).toBe(1);
   });
 });
 

--- a/connect/src/lib/auth/signing-purposes.ts
+++ b/connect/src/lib/auth/signing-purposes.ts
@@ -25,12 +25,21 @@ export type SigningPurpose =
   | "create_grant"
   | "revoke_grant";
 
+/**
+ * High-risk purposes require an inline user confirmation modal before the
+ * server signs. We exclude `register_personal_server` and its deregistration
+ * counterpart from the set: the server signs with the PS's own derived
+ * keypair (not the user's wallet), so the cryptographic risk is bounded to
+ * a single PS lifecycle action that the user already initiated by clicking
+ * "Provision" / "Remove server" in the UI. Re-adding a confirmation here is
+ * legitimate as defense-in-depth and should be considered once the modal
+ * flow is robust; tracked separately.
+ *
+ * `create_grant` stays high-risk: it authorizes data access by a third
+ * party and is the load-bearing user-consent moment in the protocol.
+ */
 export const HIGH_RISK_PURPOSES: ReadonlySet<SigningPurpose> =
-  new Set<SigningPurpose>([
-    "register_personal_server",
-    "register_personal_server_deregistration",
-    "create_grant",
-  ]);
+  new Set<SigningPurpose>(["create_grant"]);
 
 export function isSigningPurpose(v: unknown): v is SigningPurpose {
   return (

--- a/connect/src/lib/auth/wallet.test.ts
+++ b/connect/src/lib/auth/wallet.test.ts
@@ -55,6 +55,35 @@ function revokeGrantTypedData(): TypedDataDefinition {
   };
 }
 
+// Canonical high-risk fixture. The high-risk-gate / happy-path /
+// idempotent-retry suites all need *some* HIGH_RISK_PURPOSES member to
+// drive the gate. PS lifecycle was de-listed (server signs with the PS's
+// own derived keypair, no per-call human-consent benefit), so we use
+// create_grant — the load-bearing high-risk purpose in the protocol.
+const HIGH_RISK_PURPOSE = "create_grant" as const;
+function highRiskTypedData(): TypedDataDefinition {
+  return {
+    domain: { name: "Vana Data Portability", version: "1", chainId: 1480 },
+    primaryType: "GrantRegistration",
+    types: {
+      GrantRegistration: [
+        { name: "user", type: "address" },
+        { name: "builder", type: "address" },
+        { name: "scopes", type: "string[]" },
+        { name: "expiresAt", type: "uint256" },
+        { name: "nonce", type: "uint256" },
+      ],
+    },
+    message: {
+      user: ADDR1,
+      builder: ADDR2,
+      scopes: ["chatgpt.memories"],
+      expiresAt: 0,
+      nonce: 1,
+    },
+  };
+}
+
 type WalletShape = {
   id: string;
   vana_user_id: string;
@@ -245,8 +274,8 @@ describe("signTypedData — high-risk gate", () => {
       {
         vanaUserId: VANA_USER_ID,
         hydraSessionId: HYDRA_SID,
-        purpose: "register_personal_server",
-        typedData: rpsTypedData(),
+        purpose: HIGH_RISK_PURPOSE,
+        typedData: highRiskTypedData(),
       },
       deps,
     );
@@ -261,8 +290,8 @@ describe("signTypedData — high-risk gate", () => {
       {
         vanaUserId: VANA_USER_ID,
         hydraSessionId: HYDRA_SID,
-        purpose: "register_personal_server",
-        typedData: rpsTypedData(),
+        purpose: HIGH_RISK_PURPOSE,
+        typedData: highRiskTypedData(),
         confirmationId: "vana_confirm_unknown",
       },
       deps,
@@ -271,7 +300,7 @@ describe("signTypedData — high-risk gate", () => {
   });
 
   it("issues a fresh confirmation when payload_hash mismatches", async () => {
-    const td = rpsTypedData();
+    const td = highRiskTypedData();
     const deps = makeDeps({
       confirmations: {
         vana_confirm_x: {
@@ -279,7 +308,7 @@ describe("signTypedData — high-risk gate", () => {
           vana_user_id: VANA_USER_ID,
           hydra_session_id: HYDRA_SID,
           vana_wallet_id: "vana_wallet_xyz",
-          purpose: "register_personal_server",
+          purpose: HIGH_RISK_PURPOSE,
           payload_hash: "this_does_not_match",
           payload_summary: {},
           expires_at: new Date(Date.now() + 60_000).toISOString(),
@@ -292,7 +321,7 @@ describe("signTypedData — high-risk gate", () => {
       {
         vanaUserId: VANA_USER_ID,
         hydraSessionId: HYDRA_SID,
-        purpose: "register_personal_server",
+        purpose: HIGH_RISK_PURPOSE,
         typedData: td,
         confirmationId: "vana_confirm_x",
       },
@@ -302,7 +331,7 @@ describe("signTypedData — high-risk gate", () => {
   });
 
   it("issues a fresh confirmation when session mismatches", async () => {
-    const td = rpsTypedData();
+    const td = highRiskTypedData();
     const adapter = makeAdapter();
     const validHash =
       ""; /* computed inside; here we just need session mismatch */
@@ -315,7 +344,7 @@ describe("signTypedData — high-risk gate", () => {
           vana_user_id: VANA_USER_ID,
           hydra_session_id: "different_session",
           vana_wallet_id: "vana_wallet_xyz",
-          purpose: "register_personal_server",
+          purpose: HIGH_RISK_PURPOSE,
           payload_hash: "irrelevant",
           payload_summary: {},
           expires_at: new Date(Date.now() + 60_000).toISOString(),
@@ -328,7 +357,7 @@ describe("signTypedData — high-risk gate", () => {
       {
         vanaUserId: VANA_USER_ID,
         hydraSessionId: HYDRA_SID,
-        purpose: "register_personal_server",
+        purpose: HIGH_RISK_PURPOSE,
         typedData: td,
         confirmationId: "vana_confirm_x",
       },
@@ -361,8 +390,8 @@ describe("signTypedData — happy path with confirmation", () => {
       {
         vanaUserId: VANA_USER_ID,
         hydraSessionId: HYDRA_SID,
-        purpose: "register_personal_server",
-        typedData: rpsTypedData(),
+        purpose: HIGH_RISK_PURPOSE,
+        typedData: highRiskTypedData(),
       },
       deps1,
     );
@@ -382,8 +411,8 @@ describe("signTypedData — happy path with confirmation", () => {
       {
         vanaUserId: VANA_USER_ID,
         hydraSessionId: HYDRA_SID,
-        purpose: "register_personal_server",
-        typedData: rpsTypedData(),
+        purpose: HIGH_RISK_PURPOSE,
+        typedData: highRiskTypedData(),
         confirmationId: consumedRow.id,
       },
       deps2,
@@ -406,7 +435,7 @@ describe("signTypedData — idempotent retry", () => {
       vana_user_id: VANA_USER_ID,
       vana_wallet_id: "vana_wallet_xyz",
       hydra_session_id: HYDRA_SID,
-      purpose: "register_personal_server",
+      purpose: HIGH_RISK_PURPOSE,
       payload_hash: "any",
       payload_summary: {},
       confirmation_id: "vana_confirm_x",
@@ -417,7 +446,7 @@ describe("signTypedData — idempotent retry", () => {
       consumed_at: new Date().toISOString(), // just now
       created_at: new Date().toISOString(),
     };
-    const td = rpsTypedData();
+    const td = highRiskTypedData();
 
     // Build a confirmation that matches the request — so we reach the
     // idempotency lookup branch.
@@ -430,7 +459,7 @@ describe("signTypedData — idempotent retry", () => {
           vana_user_id: VANA_USER_ID,
           hydra_session_id: HYDRA_SID,
           vana_wallet_id: "vana_wallet_xyz",
-          purpose: "register_personal_server",
+          purpose: HIGH_RISK_PURPOSE,
           payload_hash: matchingHash,
           payload_summary: {},
           expires_at: new Date(Date.now() + 60_000).toISOString(),
@@ -447,7 +476,7 @@ describe("signTypedData — idempotent retry", () => {
       {
         vanaUserId: VANA_USER_ID,
         hydraSessionId: HYDRA_SID,
-        purpose: "register_personal_server",
+        purpose: HIGH_RISK_PURPOSE,
         typedData: td,
         confirmationId: "vana_confirm_x",
       },


### PR DESCRIPTION
Two complementary fixes: drop PS lifecycle from HIGH_RISK_PURPOSES (server signs with its own key, modal adds friction without crypto benefit), and memoize useConfirmation's return value to stop a re-render thrash that prevented the modal from rendering for the purposes that do require it (create_grant).