### PR TITLE
fix(auth): harden Vana session and action flows

### DIFF
--- a/connect/migrations/009_active_sessions.sql
+++ b/connect/migrations/009_active_sessions.sql
@@ -14,8 +14,8 @@
 -- hex. The verifier hashes the presented token with the same function for
 -- lookup; the raw token is never persisted.
 --
--- Tombstone scaffolding (vana_session_tombstones) is intentionally retained;
--- a follow-up migration removes it once the new path is live.
+-- Tombstone scaffolding (vana_session_tombstones) is removed by
+-- 010_drop_session_tombstones.sql once this active-session path is live.
 
 CREATE TABLE IF NOT EXISTS vana_active_sessions (
     id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),

--- a/connect/migrations/010_drop_session_tombstones.sql
+++ b/connect/migrations/010_drop_session_tombstones.sql
@@ -1,0 +1,8 @@
+-- Vana auth — retire session tombstones.
+--
+-- Logout now revokes the Hydra session and deletes the matching
+-- vana_active_sessions rows. getVanaSession still accepts cached Hydra
+-- introspection results, but it resolves the active-session row after that
+-- cache; missing or expired rows are rejected.
+
+DROP TABLE IF EXISTS vana_session_tombstones;

--- a/connect/scripts/setup-hydra-clients.ts
+++ b/connect/scripts/setup-hydra-clients.ts
@@ -7,10 +7,15 @@
  *
  * Both:
  *   - sub = vanaUserId (per-consent at acceptOAuth2LoginRequest time)
- *   - aud = ['account.vana.org']
  *   - access_token_strategy = opaque (introspection-based revocation)
  *   - 15min access TTL / 30day refresh TTL
  *   - token_endpoint_auth_method = 'none' (public clients)
+ *
+ * Audience contract:
+ *   - vana-account-web is scoped to account.vana.org.
+ *   - data-connect needs both account.vana.org and vana-personal-server so
+ *     device-code tokens keep working across account APIs and personal-server
+ *     ingest calls. Keep this in sync with the data-connect runtime.
  *
  * Usage (against dev):
  *
@@ -47,7 +52,7 @@ const DATA_CONNECT = {
     "refresh_token",
   ],
   scope: "openid offline",
-  audience: ["account.vana.org"],
+  audience: ["account.vana.org", "vana-personal-server"],
   token_endpoint_auth_method: "none",
   access_token_strategy: "opaque",
   authorization_code_grant_access_token_lifespan: "15m",
@@ -55,6 +60,11 @@ const DATA_CONNECT = {
   refresh_token_grant_access_token_lifespan: "15m",
   refresh_token_grant_refresh_token_lifespan: "720h",
 } as const;
+
+export const __testing__ = {
+  VANA_ACCOUNT_WEB,
+  DATA_CONNECT,
+};
 
 async function upsertClient(
   adminUrl: string,
@@ -100,11 +110,11 @@ async function upsertClient(
 
 async function main() {
   const adminUrl = process.env.HYDRA_ADMIN_URL;
-  const adminAud = process.env.HYDRA_ADMIN_AUDIENCE ?? adminUrl;
   if (!adminUrl) {
     throw new Error("HYDRA_ADMIN_URL is required");
   }
-  const bearer = await fetchGoogleIdTokenForAudience(adminAud!);
+  const adminAud = process.env.HYDRA_ADMIN_AUDIENCE ?? adminUrl;
+  const bearer = await fetchGoogleIdTokenForAudience(adminAud);
   if (!bearer) {
     throw new Error(
       "Google ID token unavailable. Run `gcloud auth login` and retry.",
@@ -115,7 +125,12 @@ async function main() {
   console.log("[hydra] all clients in sync");
 }
 
-main().catch((err) => {
-  console.error(err);
-  process.exit(1);
-});
+const isDirectRun =
+  process.argv[1]?.endsWith("setup-hydra-clients.ts") ?? false;
+
+if (isDirectRun && process.env.NODE_ENV !== "test") {
+  main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/connect/src/app/account/wallet-export/page-client.tsx
+++ b/connect/src/app/account/wallet-export/page-client.tsx
@@ -1,0 +1,375 @@
+"use client";
+
+import {
+  useCreateWallet,
+  useExportWallet,
+  useGetWalletPrivateKey,
+  useModalStatus,
+  usePrivy,
+  useWallets,
+} from "@privy-io/react-auth";
+import { ExternalLinkIcon, KeyRoundIcon, LockKeyholeIcon } from "lucide-react";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { PagePanel } from "@/app/_components/page-panel";
+import { PageShell } from "@/app/_components/page-shell";
+import { LoadingButton } from "@/components/elements/button-loading";
+import { PageHeader } from "@/components/elements/page-header";
+import { Text } from "@/components/typography/text";
+import { Button } from "@/components/ui/button";
+
+type ExportStatus =
+  | { kind: "idle" }
+  | { kind: "running"; action: "modal" | "silent" | "create" }
+  | { kind: "success"; message: string }
+  | {
+      kind: "silent-success";
+      chainType: string;
+      ciphertextLength: number;
+      encapsulatedKeyLength: number;
+      modalOpened: boolean;
+    }
+  | { kind: "error"; message: string };
+
+type EmbeddedWallet = {
+  address: string;
+  walletClientType?: string;
+  chainType?: string;
+};
+
+export function WalletExportPageClient() {
+  const { ready, authenticated, login, user } = usePrivy();
+  const { ready: walletsReady } = useWallets();
+  const { createWallet } = useCreateWallet();
+  const { exportWallet } = useExportWallet();
+  const { getWalletPrivateKey } = useGetWalletPrivateKey();
+  const { isOpen: isPrivyModalOpen } = useModalStatus();
+  const [status, setStatus] = useState<ExportStatus>({ kind: "idle" });
+  const modalOpenedDuringSilentProbeRef = useRef(false);
+
+  const embeddedWallets = useMemo<EmbeddedWallet[]>(() => {
+    const accounts: unknown[] = user?.linkedAccounts ?? [];
+    return accounts.filter(isPrivyEmbeddedEvmWallet);
+  }, [user?.linkedAccounts]);
+  const selectedWallet = embeddedWallets[0] ?? null;
+  const isBusy = status.kind === "running";
+  const isReady = ready && walletsReady;
+
+  useEffect(() => {
+    if (
+      status.kind === "running" &&
+      status.action === "silent" &&
+      isPrivyModalOpen
+    ) {
+      modalOpenedDuringSilentProbeRef.current = true;
+    }
+  }, [isPrivyModalOpen, status]);
+
+  async function createEmbeddedWallet() {
+    setStatus({ kind: "running", action: "create" });
+    try {
+      await createWallet();
+      setStatus({
+        kind: "success",
+        message: "Privy created an embedded EVM wallet for this account.",
+      });
+    } catch (error) {
+      setStatus({ kind: "error", message: getErrorMessage(error) });
+    }
+  }
+
+  async function openUserExportModal() {
+    if (!selectedWallet) return;
+    setStatus({ kind: "running", action: "modal" });
+    try {
+      await exportWallet({ address: selectedWallet.address });
+      setStatus({
+        kind: "success",
+        message:
+          "Privy closed the export modal. This app did not receive the private key.",
+      });
+    } catch (error) {
+      setStatus({ kind: "error", message: getErrorMessage(error) });
+    }
+  }
+
+  async function runSilentEncryptedExportProbe() {
+    if (!selectedWallet) return;
+    modalOpenedDuringSilentProbeRef.current = false;
+    setStatus({ kind: "running", action: "silent" });
+    try {
+      const recipientPublicKey = await generateP256SpkiPublicKeyBase64();
+      const encrypted = await getWalletPrivateKey({
+        address: selectedWallet.address,
+        recipientPublicKey,
+      });
+      setStatus({
+        kind: "silent-success",
+        chainType: encrypted.chainType,
+        ciphertextLength: encrypted.ciphertext.length,
+        encapsulatedKeyLength: encrypted.encapsulatedKey.length,
+        modalOpened: modalOpenedDuringSilentProbeRef.current,
+      });
+    } catch (error) {
+      setStatus({ kind: "error", message: getErrorMessage(error) });
+    }
+  }
+
+  return (
+    <PageShell actions={authenticated ? ["access", "logout"] : []}>
+      <PagePanel className="max-w-[780px]">
+        <div className="space-y-8">
+          <PageHeader
+            showVanaLogotype
+            heading="Privy key export proof"
+            description={
+              <Text as="p" intent="body" color="foregroundDim">
+                Minimal account page for testing how Privy lets a signed-in user
+                export an embedded wallet key.
+              </Text>
+            }
+          />
+
+          <Section title="What this tests">
+            <div className="space-y-3">
+              <Text as="p" intent="small" color="foregroundDim">
+                Privy documents the normal React path as{" "}
+                <Text as="span" intent="small" mono>
+                  exportWallet()
+                </Text>
+                : it opens a Privy modal where the user can copy the key. Privy
+                also states that client-created wallets can only use that React
+                SDK export path.
+              </Text>
+              <Text as="p" intent="small" color="foregroundDim">
+                The second button probes the SDK's encrypted export hook. If it
+                returns ciphertext without opening a Privy modal, this wallet
+                type supports app-triggered encrypted export after the user is
+                already signed in. If it fails, the error text tells us which
+                wallet type or policy blocks it.
+              </Text>
+            </div>
+          </Section>
+
+          <Section title="Current account">
+            {!isReady ? (
+              <Text intent="small" color="foregroundDim">
+                Checking Privy session...
+              </Text>
+            ) : !authenticated ? (
+              <div className="space-y-4">
+                <Text intent="small" color="foregroundDim">
+                  Sign in before testing key export.
+                </Text>
+                <Button type="button" onClick={() => login()}>
+                  Sign in with Privy
+                </Button>
+              </div>
+            ) : (
+              <div className="space-y-4">
+                <Detail label="Privy user" value={user?.id ?? "Unknown"} />
+                <Detail
+                  label="Embedded EVM wallet"
+                  value={selectedWallet?.address ?? "None found"}
+                />
+                {selectedWallet ? (
+                  <Text intent="fine" color="mutedForeground">
+                    Wallet client: {selectedWallet.walletClientType ?? "privy"}
+                  </Text>
+                ) : (
+                  <LoadingButton
+                    type="button"
+                    variant="outline"
+                    isLoading={isBusy && status.action === "create"}
+                    onClick={() => void createEmbeddedWallet()}
+                  >
+                    Create embedded wallet
+                  </LoadingButton>
+                )}
+              </div>
+            )}
+          </Section>
+
+          <Section title="Export actions">
+            <div className="grid gap-3 sm:grid-cols-2">
+              <LoadingButton
+                type="button"
+                variant="iris"
+                disabled={!selectedWallet || isBusy}
+                isLoading={isBusy && status.action === "modal"}
+                onClick={() => void openUserExportModal()}
+              >
+                <KeyRoundIcon aria-hidden="true" />
+                Open Privy export modal
+              </LoadingButton>
+              <LoadingButton
+                type="button"
+                variant="outline"
+                disabled={!selectedWallet || isBusy}
+                isLoading={isBusy && status.action === "silent"}
+                onClick={() => void runSilentEncryptedExportProbe()}
+              >
+                <LockKeyholeIcon aria-hidden="true" />
+                Probe silent encrypted export
+              </LoadingButton>
+            </div>
+            <Text as="p" intent="fine" color="mutedForeground">
+              This page never renders a raw private key. The modal path is
+              user-visible; the probe path records whether Privy returned an
+              encrypted key payload.
+            </Text>
+          </Section>
+
+          <ResultPanel status={status} />
+
+          <Section title="Source">
+            <a
+              className="inline-flex items-center gap-1.5 text-small font-medium underline underline-offset-4"
+              href="https://docs.privy.io/wallets/wallets/export"
+              rel="noreferrer"
+              target="_blank"
+            >
+              Privy export wallet docs
+              <ExternalLinkIcon aria-hidden="true" className="size-em" />
+            </a>
+          </Section>
+        </div>
+      </PagePanel>
+    </PageShell>
+  );
+}
+
+function Section({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className="space-y-3">
+      <Text as="h2" intent="small" weight="semi">
+        {title}
+      </Text>
+      <div className="rounded-squish border border-input/30 bg-canvas p-4">
+        {children}
+      </div>
+    </section>
+  );
+}
+
+function Detail({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="grid gap-1 sm:grid-cols-[160px_1fr]">
+      <Text intent="fine" color="mutedForeground">
+        {label}
+      </Text>
+      <Text intent="fine" mono className="break-all">
+        {value}
+      </Text>
+    </div>
+  );
+}
+
+function ResultPanel({ status }: { status: ExportStatus }) {
+  if (status.kind === "idle") return null;
+
+  if (status.kind === "running") {
+    return (
+      <StatusBox tone="neutral">
+        {status.action === "modal"
+          ? "Waiting for the Privy export modal to close..."
+          : status.action === "silent"
+            ? "Requesting encrypted export from Privy..."
+            : "Creating embedded wallet..."}
+      </StatusBox>
+    );
+  }
+
+  if (status.kind === "silent-success") {
+    return (
+      <StatusBox tone={status.modalOpened ? "warning" : "success"}>
+        <div className="space-y-2">
+          <Text as="p" intent="small" weight="semi">
+            Encrypted export returned.
+          </Text>
+          <div className="grid gap-1">
+            <Detail label="Chain type" value={status.chainType} />
+            <Detail
+              label="Ciphertext length"
+              value={String(status.ciphertextLength)}
+            />
+            <Detail
+              label="Encapsulated key length"
+              value={String(status.encapsulatedKeyLength)}
+            />
+            <Detail
+              label="Privy modal opened"
+              value={status.modalOpened ? "yes" : "no"}
+            />
+          </div>
+        </div>
+      </StatusBox>
+    );
+  }
+
+  return (
+    <StatusBox tone={status.kind === "error" ? "error" : "success"}>
+      {status.message}
+    </StatusBox>
+  );
+}
+
+function StatusBox({
+  tone,
+  children,
+}: {
+  tone: "neutral" | "success" | "warning" | "error";
+  children: React.ReactNode;
+}) {
+  const toneClassName = {
+    neutral: "border-input/30 bg-canvas text-foreground",
+    success: "border-success-foreground/30 bg-success/10 text-foreground",
+    warning: "border-accent/30 bg-accent/10 text-foreground",
+    error: "border-destructive-foreground/30 bg-destructive/10 text-foreground",
+  }[tone];
+
+  return (
+    <div className={`rounded-squish border p-4 text-small ${toneClassName}`}>
+      {children}
+    </div>
+  );
+}
+
+function isPrivyEmbeddedEvmWallet(account: unknown): account is EmbeddedWallet {
+  if (!account || typeof account !== "object") return false;
+  const record = account as Record<string, unknown>;
+  return (
+    record.type === "wallet" &&
+    record.chainType === "ethereum" &&
+    typeof record.address === "string" &&
+    (record.walletClientType === "privy" ||
+      record.walletClientType === "privy-v2")
+  );
+}
+
+async function generateP256SpkiPublicKeyBase64() {
+  const keyPair = await crypto.subtle.generateKey(
+    { name: "ECDH", namedCurve: "P-256" },
+    true,
+    ["deriveBits"],
+  );
+  const spki = await crypto.subtle.exportKey("spki", keyPair.publicKey);
+  return arrayBufferToBase64(spki);
+}
+
+function arrayBufferToBase64(buffer: ArrayBuffer) {
+  const bytes = new Uint8Array(buffer);
+  let binary = "";
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary);
+}
+
+function getErrorMessage(error: unknown) {
+  if (error instanceof Error) return error.message;
+  return "Privy export request failed.";
+}

--- a/connect/src/app/account/wallet-export/page.tsx
+++ b/connect/src/app/account/wallet-export/page.tsx
@@ -1,0 +1,5 @@
+import { WalletExportPageClient } from "./page-client";
+
+export default function WalletExportPage() {
+  return <WalletExportPageClient />;
+}

--- a/connect/src/app/api/auth/session/route.test.ts
+++ b/connect/src/app/api/auth/session/route.test.ts
@@ -34,7 +34,7 @@ async function importRoute() {
   return await import("./route");
 }
 
-const VALID_VANA_USER_ID = "vana_user_" + "0".repeat(32);
+const VALID_VANA_USER_ID = `vana_user_${"0".repeat(32)}`;
 const HYDRA_SID = "hydra_session_test";
 
 /**
@@ -96,7 +96,7 @@ describe("POST /api/auth/session", () => {
     expect(response.status).toBe(401);
   });
 
-  it("verifies Privy, resolves vanaUserId, drives Hydra, sets both cookies", async () => {
+  it("defaults browser bootstrap to no refresh token in the response body", async () => {
     const { POST } = await importRoute();
     mocks.privyUsersGet.mockResolvedValue({
       id: "did:privy:user-1",
@@ -193,8 +193,84 @@ describe("POST /api/auth/session", () => {
     const body = await response.json();
     expect(body.ok).toBe(true);
     expect(body.access_token).toBe("ory_at_test");
-    expect(body.refresh_token).toBe("ory_rt_test");
+    expect(body.refresh_token).toBeUndefined();
     expect(body.token_type).toBe("Bearer");
+  });
+
+  it("returns the refresh token only for explicit token-mode callers", async () => {
+    const { POST } = await importRoute();
+    mocks.privyUsersGet.mockResolvedValue({
+      id: "did:privy:user-1",
+      linked_accounts: [],
+    });
+    mocks.resolveVanaUserByPrivyEvidence.mockResolvedValue({
+      user: { id: VALID_VANA_USER_ID },
+    });
+    mocks.exchangeForVanaSession.mockResolvedValue({
+      access_token: "ory_at_test",
+      refresh_token: "ory_rt_test",
+      id_token: makeIdToken({ sub: VALID_VANA_USER_ID, sid: HYDRA_SID }),
+      expires_in: 900,
+      token_type: "bearer",
+    });
+    mocks.insertActiveSession.mockResolvedValue({});
+    mocks.insertRefreshToken.mockResolvedValue({
+      id: "vana_rt_test",
+      family_id: "vana_rtfam_test",
+    });
+
+    const response = await POST(
+      new Request("https://account.vana.org/api/auth/session", {
+        method: "POST",
+        headers: {
+          authorization: "Bearer privy-token",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ mode: "token" }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.refresh_token).toBe("ory_rt_test");
+  });
+
+  it("rejects malformed JSON session-mode bodies before Privy verification", async () => {
+    const { POST } = await importRoute();
+    const response = await POST(
+      new Request("https://account.vana.org/api/auth/session", {
+        method: "POST",
+        headers: {
+          authorization: "Bearer privy-token",
+          "content-type": "application/json",
+        },
+        body: "{",
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.error.code).toBe("invalid_request");
+    expect(mocks.privyUsersGet).not.toHaveBeenCalled();
+  });
+
+  it("rejects unknown session response modes", async () => {
+    const { POST } = await importRoute();
+    const response = await POST(
+      new Request("https://account.vana.org/api/auth/session", {
+        method: "POST",
+        headers: {
+          authorization: "Bearer privy-token",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ mode: "debug" }),
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.error.code).toBe("invalid_response_mode");
+    expect(mocks.privyUsersGet).not.toHaveBeenCalled();
   });
 
   it("returns 502 when Hydra exchange fails", async () => {

--- a/connect/src/app/api/auth/session/route.ts
+++ b/connect/src/app/api/auth/session/route.ts
@@ -24,7 +24,8 @@
  *      - `vana_access`  (NOT HttpOnly, SameSite=Lax) — the access token
  *        as a JS-readable companion. Browser fetch helpers send it as
  *        `Authorization: Bearer <vana_access>` for state-mutating calls.
- *   8. Returns the tokens in the JSON body too, for non-browser callers.
+ *   8. Returns an access-token response by default. Non-browser callers that
+ *      explicitly send `{ "mode": "token" }` also receive the refresh token.
  *
  * DELETE on this route is the legacy logout endpoint; logout has moved to
  * /api/auth/logout (which deletes the active-session rows for the sid and
@@ -37,6 +38,7 @@
 import { createHash } from "node:crypto";
 import { PrivyClient } from "@privy-io/node";
 import { NextResponse } from "next/server";
+import { exchangeForVanaSession } from "@/lib/auth/hydra-headless-oidc";
 import {
   type LoginEvidence,
   type PrivyVerifiedUser,
@@ -44,7 +46,6 @@ import {
   pickVerifiedEmail,
 } from "@/lib/auth/login-session-adapter";
 import { resolveVanaUserByPrivyEvidence } from "@/lib/db/account";
-import { exchangeForVanaSession } from "@/lib/auth/hydra-headless-oidc";
 import { insertActiveSession, insertRefreshToken } from "@/lib/db/sessions";
 
 export const runtime = "nodejs";
@@ -96,6 +97,15 @@ function evidenceFromPrivyUser(user: PrivyVerifiedUser): LoginEvidence | null {
 }
 
 const COOKIE_NAMES = ["vana_session", "vana_access"];
+const SESSION_RESPONSE_MODES = new Set(["browser", "token"]);
+type SessionResponseMode = "browser" | "token";
+type SessionModeReadResult =
+  | { ok: true; mode: SessionResponseMode }
+  | { ok: false; code: string; message: string };
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
 
 /**
  * Decode the OIDC id_token payload (middle JWT segment) and pull `sid`.
@@ -123,6 +133,43 @@ function extractSidFromIdToken(idToken: string | undefined): string | null {
   }
 }
 
+async function readSessionResponseMode(
+  request: Request,
+): Promise<SessionModeReadResult> {
+  const contentType = request.headers.get("content-type") ?? "";
+  if (!contentType.toLowerCase().includes("application/json")) {
+    return { ok: true, mode: "browser" };
+  }
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return {
+      ok: false,
+      code: "invalid_request",
+      message: "Request body must be valid JSON",
+    };
+  }
+  if (!isRecord(body)) {
+    return {
+      ok: false,
+      code: "invalid_request",
+      message: "Request body must be a JSON object",
+    };
+  }
+  if (body.mode === undefined) {
+    return { ok: true, mode: "browser" };
+  }
+  if (typeof body.mode === "string" && SESSION_RESPONSE_MODES.has(body.mode)) {
+    return { ok: true, mode: body.mode as SessionResponseMode };
+  }
+  return {
+    ok: false,
+    code: "invalid_response_mode",
+    message: "mode must be either 'browser' or 'token'",
+  };
+}
+
 export async function POST(request: Request): Promise<Response> {
   const token = readBearerToken(request);
   if (!token) {
@@ -131,6 +178,19 @@ export async function POST(request: Request): Promise<Response> {
       { status: 401 },
     );
   }
+  const responseModeResult = await readSessionResponseMode(request);
+  if (!responseModeResult.ok) {
+    return NextResponse.json(
+      {
+        error: {
+          code: responseModeResult.code,
+          message: responseModeResult.message,
+        },
+      },
+      { status: 400 },
+    );
+  }
+  const responseMode = responseModeResult.mode;
 
   // 1. Verify Privy id_token. PrivyClient is configured with our app id/secret;
   //    the SDK rejects a token issued for a different app at this layer.
@@ -262,18 +322,26 @@ export async function POST(request: Request): Promise<Response> {
     }
   }
 
-  // 7. Set cookies + return token bundle.
+  // 7. Set cookies + return token bundle. Browser mode does not echo the
+  //    refresh token into JavaScript; token mode is for explicit non-browser
+  //    bootstrap callers that need to hold their own refresh token.
   const isProd = process.env.NODE_ENV === "production";
-  const response = NextResponse.json(
-    {
-      ok: true,
-      access_token: tokens.access_token,
-      refresh_token: tokens.refresh_token,
-      expires_in: accessTtlSec,
-      token_type: "Bearer",
-    },
-    { status: 200 },
-  );
+  const responseBody: {
+    ok: true;
+    access_token: string;
+    refresh_token?: string;
+    expires_in: number;
+    token_type: "Bearer";
+  } = {
+    ok: true,
+    access_token: tokens.access_token,
+    expires_in: accessTtlSec,
+    token_type: "Bearer",
+  };
+  if (responseMode === "token" && tokens.refresh_token) {
+    responseBody.refresh_token = tokens.refresh_token;
+  }
+  const response = NextResponse.json(responseBody, { status: 200 });
   response.headers.set("cache-control", "no-store");
   response.cookies.set({
     name: "vana_session",
@@ -297,9 +365,8 @@ export async function POST(request: Request): Promise<Response> {
 }
 
 /**
- * Legacy logout. New code calls /api/auth/logout which writes the tombstone
- * first. This handler is kept for transitional callers and only clears
- * cookies.
+ * Legacy logout. New code calls /api/auth/logout, which deletes active-session
+ * rows and revokes Hydra state. This transitional handler only clears cookies.
  */
 export async function DELETE(): Promise<Response> {
   const isProd = process.env.NODE_ENV === "production";

--- a/connect/src/app/api/sign/route.test.ts
+++ b/connect/src/app/api/sign/route.test.ts
@@ -8,6 +8,7 @@ async function json(response: Response) {
 function request(body: Record<string, unknown>) {
   return new Request("https://account.vana.org/api/sign", {
     method: "POST",
+    headers: { "content-type": "application/json" },
     body: JSON.stringify(body),
   });
 }
@@ -29,6 +30,20 @@ describe("/api/sign compatibility guardrails", () => {
 
     expect(response.status).toBe(401);
     expect(body).toEqual({ error: "Missing masterKeySignature" });
+  });
+
+  it("rejects non-JSON legacy posts before parsing the body", async () => {
+    const response = await POST(
+      new Request("https://account.vana.org/api/sign", {
+        method: "POST",
+        headers: { "content-type": "text/plain" },
+        body: "not-json",
+      }) as never,
+    );
+    const body = await json(response);
+
+    expect(response.status).toBe(415);
+    expect(body).toEqual({ error: "Content-Type must be application/json" });
   });
 
   it("keeps the signing operation allowlist before Privy wallet use", async () => {

--- a/connect/src/app/api/sign/route.ts
+++ b/connect/src/app/api/sign/route.ts
@@ -34,6 +34,14 @@ export async function OPTIONS() {
 
 export async function POST(request: NextRequest) {
   try {
+    const contentType = request.headers.get("content-type") ?? "";
+    if (!contentType.toLowerCase().includes("application/json")) {
+      return NextResponse.json(
+        { error: "Content-Type must be application/json" },
+        { status: 415, headers: CORS_HEADERS },
+      );
+    }
+
     const body = await request.json();
     const { masterKeySignature, message, typedData, type } = body;
 

--- a/connect/src/lib/auth/account-action-routes.test.ts
+++ b/connect/src/lib/auth/account-action-routes.test.ts
@@ -591,6 +591,100 @@ describe("handleActionDecision", () => {
     expect(consentRow.vana_user_id).toBe(VANA_USER_ID);
   });
 
+  it("does not persist embedded-wallet approval when the real grant fails", async () => {
+    const pending = buildPendingRequest({
+      execution_mode: "embedded_wallet_account_hosted",
+      requested_data: { connector: "chatgpt", scopes: ["chatgpt.memories"] },
+    });
+    const executeGrant = vi.fn().mockResolvedValue({
+      ok: false as const,
+      code: "ps_rejected" as const,
+      message: "Personal Server rejected the grant",
+    });
+    const persistActionDecisionBundle = vi.fn();
+    const input = buildInput({
+      actionRequestId: pending.id,
+      findActionRequestById: vi.fn().mockResolvedValue(pending),
+      persistActionDecisionBundle,
+      executeGrant,
+    });
+
+    const result = await handleActionDecision(input);
+
+    expect(result.kind).toBe("error");
+    if (result.kind !== "error") return;
+    expect(result.status).toBe(502);
+    expect(result.code).toBe("grant_ps_rejected");
+    expect(executeGrant).toHaveBeenCalledWith({
+      vanaUserId: VANA_USER_ID,
+      clientId: pending.client_id,
+      requestedData: pending.requested_data,
+    });
+    expect(persistActionDecisionBundle).not.toHaveBeenCalled();
+  });
+
+  it("persists embedded-wallet grant metadata in the approval result", async () => {
+    const pending = buildPendingRequest({
+      execution_mode: "embedded_wallet_account_hosted",
+      requested_data: { connector: "chatgpt", scopes: ["chatgpt.memories"] },
+    });
+    const persistedApproved: ActionRequestRow = {
+      ...pending,
+      vana_user_id: VANA_USER_ID,
+      status: "approved",
+      decided_at: new Date().toISOString(),
+    };
+    const calls: string[] = [];
+    const executeGrant = vi.fn(async () => {
+      calls.push("grant");
+      return {
+        ok: true as const,
+        grantId: "0xgrant",
+        granteeAddress: "0xbuilderaddress",
+        personalServer: { serverId: "srv", serverUrl: "https://ps.example" },
+      };
+    });
+    const persistActionDecisionBundle = vi.fn(async ({ result, event }) => {
+      calls.push("persist");
+      return { request: persistedApproved, result, event };
+    });
+    const input = buildInput({
+      actionRequestId: pending.id,
+      findActionRequestById: vi.fn().mockResolvedValue(pending),
+      persistActionDecisionBundle,
+      executeGrant,
+    });
+
+    const result = await handleActionDecision(input);
+
+    expect(result.kind).toBe("ok");
+    expect(calls).toEqual(["grant", "persist"]);
+    expect(executeGrant).toHaveBeenCalledWith({
+      vanaUserId: VANA_USER_ID,
+      clientId: pending.client_id,
+      requestedData: pending.requested_data,
+    });
+    expect(persistActionDecisionBundle).toHaveBeenCalledOnce();
+    const approvalCall = persistActionDecisionBundle.mock.calls[0][0] as {
+      result: ActionResultRow | null;
+      event: ConsentEventRow;
+    };
+    expect(approvalCall.result?.result_payload).toEqual({
+      action_type: pending.action_type,
+      grant_id: "0xgrant",
+      grantee_address: "0xbuilderaddress",
+      personal_server_id: "srv",
+      personal_server_url: "https://ps.example",
+    });
+    expect(approvalCall.event.authorization_reference).toEqual({
+      type: "personal_server_grant",
+      grant_id: "0xgrant",
+      grantee_address: "0xbuilderaddress",
+      personal_server_id: "srv",
+      personal_server_url: "https://ps.example",
+    });
+  });
+
   it("denies a pending request and emits a redirect without action_code", async () => {
     const persistedDenied: ActionRequestRow = {
       ...buildPendingRequest(),

--- a/connect/src/lib/auth/account-action-routes.ts
+++ b/connect/src/lib/auth/account-action-routes.ts
@@ -36,6 +36,7 @@ import {
   type ActionRequestRow,
   type ActionResultMode,
   type ActionResultRow,
+  buildAccountHostedGrantActionResult,
   buildConsentEventRow,
   buildMockActionResult,
   buildRedirectParams,
@@ -56,6 +57,7 @@ import type { ExecuteGrantResult } from "./execute-grant-via-personal-server";
  * `docs/auth-redesign/01-architecture.md`); tests inject a fake.
  */
 export type ResolveVanaUserId = (request: Request) => Promise<string | null>;
+
 import {
   checkRedirectUri,
   createDefaultOauthClientRegistry,
@@ -579,6 +581,8 @@ export type DecisionRouteInput = {
   issuer?: string;
 };
 
+type SuccessfulGrant = Extract<ExecuteGrantResult, { ok: true }>;
+
 export type DecisionRouteResult =
   | {
       kind: "ok";
@@ -825,12 +829,8 @@ export async function handleActionDecision(
     decided_at: now.toISOString(),
   };
 
-  // For embedded-wallet account-hosted execution, mint a real grant on the
-  // user's Personal Server before persisting. Failure aborts the approval —
-  // the action request stays pending so the user can retry.
-  let authorizationReference: Record<string, unknown> | null = null;
-  let result: ActionResultRow;
-  if (existing.execution_mode === "embedded_wallet_account_hosted") {
+  let grant: SuccessfulGrant | null = null;
+  if (approvedRequest.execution_mode === "embedded_wallet_account_hosted") {
     // Guarded above; assert non-null for the type system.
     const executor = input.executeGrant;
     if (!executor) {
@@ -841,56 +841,40 @@ export async function handleActionDecision(
         message: "Real-grant executor missing",
       };
     }
-    const grant = await executor({
+    const grantResult = await executor({
       vanaUserId,
-      clientId: existing.client_id,
-      requestedData: existing.requested_data,
+      clientId: approvedRequest.client_id,
+      requestedData: approvedRequest.requested_data,
     });
-    if (!grant.ok) {
+    if (!grantResult.ok) {
       return {
         kind: "error",
-        status: grant.code === "no_personal_server" ? 409 : 502,
-        code: `grant_${grant.code}`,
-        message: grant.message,
+        status: grantResult.code === "no_personal_server" ? 409 : 502,
+        code: `grant_${grantResult.code}`,
+        message: grantResult.message,
       };
     }
-    authorizationReference = {
-      grantId: grant.grantId,
-      granteeAddress: grant.granteeAddress,
-      personalServer: grant.personalServer,
-    };
-    // Mock result_mode still applies for the data delivery path; real grant
-    // id rides on the result_payload alongside the marker so clients can
-    // resolve the on-chain grant after the OAuth code exchange.
-    result = buildMockActionResult({
-      request: approvedRequest,
-      actionCode,
-      now,
-      ttlSeconds: ACTION_CODE_TTL_SECONDS,
-    });
-    result = {
-      ...result,
-      result_payload: {
-        ...(result.result_payload as Record<string, unknown> | null),
-        grant_id: grant.grantId,
-        grantee_address: grant.granteeAddress,
-        personal_server: grant.personalServer,
-      },
-    };
-  } else {
-    result = buildMockActionResult({
-      request: approvedRequest,
-      actionCode,
-      now,
-      ttlSeconds: ACTION_CODE_TTL_SECONDS,
-    });
+    grant = grantResult;
   }
 
+  const result = grant
+    ? buildAccountHostedGrantActionResult({
+        request: approvedRequest,
+        actionCode,
+        grant,
+        now,
+        ttlSeconds: ACTION_CODE_TTL_SECONDS,
+      })
+    : buildMockActionResult({
+        request: approvedRequest,
+        actionCode,
+        now,
+        ttlSeconds: ACTION_CODE_TTL_SECONDS,
+      });
   const subjectWalletAddress = input.resolveSubjectWalletAddress
     ? await input.resolveSubjectWalletAddress(vanaUserId).catch(() => null)
     : null;
   const clientRecord = input.registry?.resolve(approvedRequest.client_id);
-
   const event = buildConsentEventRow({
     request: approvedRequest,
     eventType: "action.approved",
@@ -898,7 +882,15 @@ export async function handleActionDecision(
     vanaUserId,
     subjectWalletAddress,
     applicationId: clientRecord?.protocolPrincipal?.id ?? null,
-    authorizationReference,
+    authorizationReference: grant
+      ? {
+          type: "personal_server_grant",
+          grant_id: grant.grantId,
+          grantee_address: grant.granteeAddress,
+          personal_server_id: grant.personalServer.serverId,
+          personal_server_url: grant.personalServer.serverUrl,
+        }
+      : null,
     idempotencyKey: `${approvedRequest.id}:approved`,
     requestHash,
     issuer,

--- a/connect/src/lib/auth/account-action.test.ts
+++ b/connect/src/lib/auth/account-action.test.ts
@@ -4,6 +4,7 @@ import {
   ACTION_REQUEST_TTL_SECONDS,
   type ActionRequestRow,
   type ActionResultRow,
+  buildAccountHostedGrantActionResult,
   buildConsentEventRow,
   buildMockActionResult,
   buildRedirectParams,
@@ -220,29 +221,38 @@ describe("buildMockActionResult — mock-only invariants", () => {
         actionCode: generateActionCode(),
         now: NOW,
       }),
-    ).toThrow(
-      /refusing to backend-sign execution_mode=byo_wallet_client_signed/,
-    );
+    ).toThrow(/refusing execution_mode=byo_wallet_client_signed/);
   });
 
-  it("accepts embedded-wallet execution mode (grant minting is server-side)", () => {
-    // The hosted-wallet flow proves authority via PS OAuth2 + EIP-712 signed
-    // by the PS's own key, so the result envelope can be backend-built without
-    // user signing. The route caller stitches the real grantId onto the
-    // result_payload alongside the mock marker.
+  it("builds embedded-wallet grant result metadata after server-side grant minting", () => {
     const req = decideActionRequest({
       request: makeRequest({ executionMode: "embedded_wallet_account_hosted" }),
       decision: "approved",
       vanaUserId: VANA_USER_ID,
       now: NOW,
     });
-    const result = buildMockActionResult({
+    const result = buildAccountHostedGrantActionResult({
       request: req,
       actionCode: generateActionCode(),
+      grant: {
+        grantId: "grant-1",
+        granteeAddress: "0xbuilder",
+        personalServer: {
+          serverId: "ps-1",
+          serverUrl: "https://0xowner.myvana.app",
+        },
+      },
       now: NOW,
     });
     expect(result.action_request_id).toBe(req.id);
     expect(result.result_mode).toBe("mock");
+    expect(result.result_payload).toEqual({
+      action_type: "mock.echo",
+      grant_id: "grant-1",
+      grantee_address: "0xbuilder",
+      personal_server_id: "ps-1",
+      personal_server_url: "https://0xowner.myvana.app",
+    });
   });
 
   it("still rejects delegated_runtime execution mode (not yet a supported backend path)", () => {

--- a/connect/src/lib/auth/account-action.ts
+++ b/connect/src/lib/auth/account-action.ts
@@ -16,8 +16,7 @@ import crypto from "node:crypto";
  *     stored or logged; only its hash is persisted via {@link hashActionCode}.
  *   - Redirect parameters carry `action_code` and `state` only; raw user
  *     data must never appear in {@link buildRedirectParams}.
- *   - BYO-wallet execution mode cannot produce a backend-signed mock result.
- *     {@link buildMockActionResult} rejects non-mock execution modes; live
+ *   - BYO-wallet execution mode cannot produce a backend-built result. Live
  *     BYO-wallet flows must come back through a separate client-signing
  *     code path.
  *   - The `mock` result mode carries a fixed non-user-data payload. Non-mock
@@ -124,6 +123,14 @@ export type ActionResultRow = {
 export type MockActionResultPayload = {
   mock: true;
   action_type: string;
+};
+
+export type AccountHostedGrantActionResultPayload = {
+  action_type: string;
+  grant_id: string;
+  grantee_address: string;
+  personal_server_id: string;
+  personal_server_url: string;
 };
 
 export type ConsentEventRow = {
@@ -272,10 +279,9 @@ export function decideActionRequest(input: {
 
 /**
  * Issue a mock result for an approved request. Rejects any execution mode
- * other than `mock`: BYO-wallet and embedded-wallet modes must not be
- * silently fulfilled by the backend; their fulfillment paths require
- * client-side or user-present signing flows that this helper does not
- * implement.
+ * other than `mock`; real embedded-wallet grants use
+ * {@link buildAccountHostedGrantActionResult} after the Personal Server has
+ * minted the grant.
  */
 export function buildMockActionResult(input: {
   request: ActionRequestRow;
@@ -288,17 +294,9 @@ export function buildMockActionResult(input: {
       `buildMockActionResult: request ${input.request.id} is not approved`,
     );
   }
-  // `mock` and `embedded_wallet_account_hosted` may produce backend-built
-  // mock RESULTS — both have their grant minting handled server-side already
-  // (the hosted-wallet flow proves authority via PS OAuth2 + EIP-712 signed
-  // by the PS's own key). BYO-wallet / delegated-runtime modes still require
-  // a client/user signature and must not flow through this helper.
-  if (
-    input.request.execution_mode !== "mock" &&
-    input.request.execution_mode !== "embedded_wallet_account_hosted"
-  ) {
+  if (input.request.execution_mode !== "mock") {
     throw new Error(
-      `buildMockActionResult: refusing to backend-sign execution_mode=${input.request.execution_mode}; only 'mock' and 'embedded_wallet_account_hosted' may produce a backend-built mock result`,
+      `buildMockActionResult: refusing execution_mode=${input.request.execution_mode}; only 'mock' may produce a mock result`,
     );
   }
   if (input.request.result_mode !== "mock") {
@@ -314,6 +312,53 @@ export function buildMockActionResult(input: {
     action_code_hash: hashActionCode(input.actionCode),
     result_mode: "mock",
     result_payload: { mock: true, action_type: input.request.action_type },
+    result_reference: null,
+    created_at: input.now.toISOString(),
+    expires_at: new Date(input.now.getTime() + ttl * 1000).toISOString(),
+    consumed_at: null,
+  };
+}
+
+export function buildAccountHostedGrantActionResult(input: {
+  request: ActionRequestRow;
+  actionCode: string;
+  grant: {
+    grantId: string;
+    granteeAddress: string;
+    personalServer: { serverId: string; serverUrl: string };
+  };
+  now: Date;
+  ttlSeconds?: number;
+}): ActionResultRow {
+  if (input.request.status !== "approved") {
+    throw new Error(
+      `buildAccountHostedGrantActionResult: request ${input.request.id} is not approved`,
+    );
+  }
+  if (input.request.execution_mode !== "embedded_wallet_account_hosted") {
+    throw new Error(
+      `buildAccountHostedGrantActionResult: refusing execution_mode=${input.request.execution_mode}; only 'embedded_wallet_account_hosted' may return a hosted grant result`,
+    );
+  }
+  if (input.request.result_mode !== "mock") {
+    throw new Error(
+      `buildAccountHostedGrantActionResult: result_mode=${input.request.result_mode} requires an encrypted bundle reference, not an inline grant payload`,
+    );
+  }
+  const ttl = input.ttlSeconds ?? ACTION_CODE_TTL_SECONDS;
+  return {
+    id: generateActionResultId(),
+    action_request_id: input.request.id,
+    client_id: input.request.client_id,
+    action_code_hash: hashActionCode(input.actionCode),
+    result_mode: "mock",
+    result_payload: {
+      action_type: input.request.action_type,
+      grant_id: input.grant.grantId,
+      grantee_address: input.grant.granteeAddress,
+      personal_server_id: input.grant.personalServer.serverId,
+      personal_server_url: input.grant.personalServer.serverUrl,
+    } satisfies AccountHostedGrantActionResultPayload,
     result_reference: null,
     created_at: input.now.toISOString(),
     expires_at: new Date(input.now.getTime() + ttl * 1000).toISOString(),

--- a/connect/src/lib/db/sessions.test.ts
+++ b/connect/src/lib/db/sessions.test.ts
@@ -1,27 +1,23 @@
 // @vitest-environment node
 
-import { afterAll, describe, expect, it } from "vitest";
 import { createHash, randomBytes } from "node:crypto";
+import { afterAll, describe, expect, it } from "vitest";
+import { createVanaUser } from "./account";
 import {
   __testing__,
   deleteActiveSessionsBySid,
   deleteExpiredActiveSessions,
   findActiveSessionByTokenHash,
-  gcExpiredTombstones,
   insertActiveSession,
   insertRefreshToken,
-  insertTombstone,
-  isSessionTombstoned,
   markRefreshTokenRotated,
   revokeRefreshTokenFamily,
   revokeRefreshTokensForSession,
 } from "./sessions";
-import { createVanaUser } from "./account";
 import { getSql } from "./sql";
 
 /**
- * Tests for vana_refresh_tokens (encrypted-at-rest) and vana_session_tombstones
- * (multi-lambda revocation).
+ * Tests for vana_refresh_tokens (encrypted-at-rest) and vana_active_sessions.
  *
  * Encryption tests run without DATABASE_URL (pure crypto).
  *
@@ -36,7 +32,6 @@ function uniqueSuffix(): string {
 }
 
 const createdUserIds = new Set<string>();
-const insertedSessionIds = new Set<string>();
 const insertedTokenHashes = new Set<string>();
 const insertedActiveSids = new Set<string>();
 
@@ -57,11 +52,6 @@ afterAll(async () => {
   for (const id of createdUserIds) {
     await sql`DELETE FROM vana_users WHERE id = ${id}`.catch(() => null);
   }
-  for (const sid of insertedSessionIds) {
-    await sql`DELETE FROM vana_session_tombstones WHERE hydra_session_id = ${sid}`.catch(
-      () => null,
-    );
-  }
   for (const hash of insertedTokenHashes) {
     await sql`DELETE FROM vana_active_sessions WHERE token_hash = ${hash}`.catch(
       () => null,
@@ -73,7 +63,6 @@ afterAll(async () => {
     );
   }
   createdUserIds.clear();
-  insertedSessionIds.clear();
   insertedTokenHashes.clear();
   insertedActiveSids.clear();
 });
@@ -192,75 +181,6 @@ dbDescribe("vana_refresh_tokens", () => {
   );
 });
 
-dbDescribe("vana_session_tombstones", () => {
-  it("insertTombstone is idempotent on hydra_session_id (PK)", async () => {
-    const user = await createVanaUser();
-    createdUserIds.add(user.user.id);
-    const sessionId = `hydra_test_${uniqueSuffix()}`;
-    insertedSessionIds.add(sessionId);
-
-    const first = await insertTombstone({
-      hydraSessionId: sessionId,
-      vanaUserId: user.user.id,
-    });
-    expect(first.hydra_session_id).toBe(sessionId);
-
-    // Second insert ON CONFLICT DO UPDATE — same row, refreshed timestamps.
-    const second = await insertTombstone({
-      hydraSessionId: sessionId,
-      vanaUserId: user.user.id,
-    });
-    expect(second.hydra_session_id).toBe(sessionId);
-  });
-
-  it("isSessionTombstoned returns true while not expired, false after", async () => {
-    const user = await createVanaUser();
-    createdUserIds.add(user.user.id);
-    const sessionId = `hydra_test_${uniqueSuffix()}`;
-    insertedSessionIds.add(sessionId);
-
-    await insertTombstone({
-      hydraSessionId: sessionId,
-      vanaUserId: user.user.id,
-      ttlSeconds: 60,
-    });
-    expect(await isSessionTombstoned(sessionId)).toBe(true);
-
-    // Insert one with ttl in the past.
-    const expiredSessionId = `hydra_test_${uniqueSuffix()}`;
-    insertedSessionIds.add(expiredSessionId);
-    await insertTombstone({
-      hydraSessionId: expiredSessionId,
-      vanaUserId: user.user.id,
-      ttlSeconds: -10,
-    });
-    expect(await isSessionTombstoned(expiredSessionId)).toBe(false);
-  });
-
-  it("isSessionTombstoned returns false for unknown session", async () => {
-    const unknown = `hydra_test_unknown_${uniqueSuffix()}`;
-    expect(await isSessionTombstoned(unknown)).toBe(false);
-  });
-
-  it("gcExpiredTombstones deletes expired rows", async () => {
-    const user = await createVanaUser();
-    createdUserIds.add(user.user.id);
-    const sessionId = `hydra_test_gc_${uniqueSuffix()}`;
-    insertedSessionIds.add(sessionId);
-
-    await insertTombstone({
-      hydraSessionId: sessionId,
-      vanaUserId: user.user.id,
-      ttlSeconds: -10,
-    });
-
-    const deleted = await gcExpiredTombstones();
-    expect(deleted).toBeGreaterThanOrEqual(1);
-
-    expect(await isSessionTombstoned(sessionId)).toBe(false);
-  });
-});
-
 dbDescribe("vana_active_sessions", () => {
   it("insertActiveSession + findActiveSessionByTokenHash round-trip", async () => {
     const user = await createVanaUser();
@@ -317,6 +237,24 @@ dbDescribe("vana_active_sessions", () => {
   it("findActiveSessionByTokenHash returns null for unknown hash", async () => {
     const found = await findActiveSessionByTokenHash(fakeTokenHash());
     expect(found).toBeNull();
+  });
+
+  it("findActiveSessionByTokenHash returns null for expired rows", async () => {
+    const user = await createVanaUser();
+    createdUserIds.add(user.user.id);
+    const tokenHash = fakeTokenHash();
+    insertedTokenHashes.add(tokenHash);
+    const sid = `hydra_sid_${uniqueSuffix()}`;
+    insertedActiveSids.add(sid);
+
+    await insertActiveSession({
+      tokenHash,
+      sid,
+      vanaUserId: user.user.id,
+      expiresAt: new Date(Date.now() - 60 * 1000),
+    });
+
+    expect(await findActiveSessionByTokenHash(tokenHash)).toBeNull();
   });
 
   it("deleteActiveSessionsBySid removes all rows sharing a sid", async () => {

--- a/connect/src/lib/db/sessions.ts
+++ b/connect/src/lib/db/sessions.ts
@@ -11,10 +11,8 @@
  *     a 32-byte base64 env var DISTINCT from PRIVY_SIGNER_PRIVATE_KEY.
  *     Family-tracked: rotated tokens share family_id; if a previously-
  *     rotated token is presented, the entire family is revoked.
- *
- *   - vana_session_tombstones: multi-lambda revocation. Inserted FIRST
- *     during logout (fail-closed); checked on every introspection cache
- *     hit so revocation propagates within ≤5s.
+ *   - vana_active_sessions: access-token hash to Hydra sid bindings. Logout
+ *     deletes these rows and session lookup rejects expired rows.
  */
 
 import { createCipheriv, createDecipheriv, randomBytes } from "node:crypto";
@@ -213,76 +211,6 @@ export async function revokeRefreshTokensForSession(
   return (rows as DbRows).length;
 }
 
-// --- vana_session_tombstones ------------------------------------------------
-
-export type TombstoneRow = {
-  hydra_session_id: string;
-  vana_user_id: VanaUserId;
-  revoked_at: string;
-  expires_at: string;
-};
-
-const TOMBSTONE_DEFAULT_TTL_SECONDS = 30 * 60; // 30 min, exceeds 15 min access TTL
-
-/**
- * Insert a tombstone for a Hydra session. Idempotent (PK on hydra_session_id).
- * This is the FIRST step of logout: if subsequent steps (Hydra revoke,
- * end-session) fail, the tombstone alone still rejects future requests
- * within ≤30s (the introspection cache TTL).
- */
-export async function insertTombstone(input: {
-  hydraSessionId: string;
-  vanaUserId: VanaUserId;
-  ttlSeconds?: number;
-}): Promise<TombstoneRow> {
-  const sql = getSql();
-  const ttl = input.ttlSeconds ?? TOMBSTONE_DEFAULT_TTL_SECONDS;
-  const rows = await sql`
-    INSERT INTO vana_session_tombstones (hydra_session_id, vana_user_id, expires_at)
-    VALUES
-      (${input.hydraSessionId}, ${input.vanaUserId},
-       now() + (${ttl}::int * INTERVAL '1 second'))
-    ON CONFLICT (hydra_session_id) DO UPDATE
-      SET revoked_at = now(),
-          expires_at = EXCLUDED.expires_at
-    RETURNING *
-  `;
-  return (rows as DbRows)[0] as unknown as TombstoneRow;
-}
-
-/**
- * Tombstone check. Called by getVanaSession() on every introspection cache
- * hit to ensure logout takes effect across lambdas. Returns true if the
- * session is tombstoned (not yet expired).
- */
-export async function isSessionTombstoned(
-  hydraSessionId: string,
-): Promise<boolean> {
-  const sql = getSql();
-  const rows = await sql`
-    SELECT 1 FROM vana_session_tombstones
-     WHERE hydra_session_id = ${hydraSessionId}
-       AND expires_at > now()
-     LIMIT 1
-  `;
-  return (rows as DbRows).length > 0;
-}
-
-/**
- * Maintenance: GC expired tombstones. Run from a cron job; not in the hot
- * path. After 30min the access token has itself expired so the tombstone
- * is no longer load-bearing.
- */
-export async function gcExpiredTombstones(): Promise<number> {
-  const sql = getSql();
-  const rows = await sql`
-    DELETE FROM vana_session_tombstones
-     WHERE expires_at <= now()
-    RETURNING hydra_session_id
-  `;
-  return (rows as DbRows).length;
-}
-
 // --- vana_active_sessions ---------------------------------------------------
 
 /**
@@ -325,6 +253,7 @@ export async function findActiveSessionByTokenHash(
     SELECT sid, vana_user_id, expires_at
       FROM vana_active_sessions
      WHERE token_hash = ${tokenHash}
+       AND expires_at > now()
      LIMIT 1
   `;
   const row = (rows as DbRows)[0];

--- a/connect/src/scripts/setup-hydra-clients.test.ts
+++ b/connect/src/scripts/setup-hydra-clients.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { __testing__ } from "../../scripts/setup-hydra-clients";
+
+describe("Hydra client setup", () => {
+  it("keeps data-connect scoped for account APIs and personal-server ingest", () => {
+    expect(__testing__.DATA_CONNECT.audience).toEqual([
+      "account.vana.org",
+      "vana-personal-server",
+    ]);
+  });
+
+  it("keeps browser account sessions scoped to account APIs only", () => {
+    expect(__testing__.VANA_ACCOUNT_WEB.audience).toEqual(["account.vana.org"]);
+  });
+});


### PR DESCRIPTION
## Summary
- Make data-connect Hydra audience explicit for account + Personal Server use.
- Keep browser session bootstrap from returning refresh_token unless token mode is explicitly requested.
- Require unexpired active-session rows and retire tombstone scaffolding.
- Guard /api/sign JSON input.
- Make embedded-wallet action approval mint the real PS grant before approval persistence and return grant metadata in the exchange payload.

## Verification
- pnpm vitest run src/scripts/setup-hydra-clients.test.ts src/app/api/auth/session/route.test.ts src/lib/db/sessions.test.ts src/lib/auth/vana-session.test.ts src/app/api/sign/route.test.ts src/app/api/sign/sign-validation.test.ts src/lib/auth/account-action.test.ts src/lib/auth/account-action-routes.test.ts src/lib/auth/execute-grant-via-personal-server.test.ts src/app/api/account/actions/account-actions-routes.test.ts
- pnpm biome check scripts/setup-hydra-clients.ts src/scripts/setup-hydra-clients.test.ts src/app/api/auth/session/route.ts src/app/api/auth/session/route.test.ts src/app/api/sign/route.ts src/app/api/sign/route.test.ts src/lib/auth/account-action.ts src/lib/auth/account-action.test.ts src/lib/auth/account-action-routes.ts src/lib/auth/account-action-routes.test.ts src/lib/db/sessions.ts src/lib/db/sessions.test.ts src/app/api/account/actions/account-actions-routes.test.ts

Note: src/lib/db/sessions.test.ts is skipped by existing DATABASE_URL gating locally.