### PR TITLE
fix(connect): honest mobile hand-off instead of dead-end vana:// link (BUI-449)

### DIFF
--- a/connect/src/app/(handoff)/connect/_components/connect-page-states.test.tsx
+++ b/connect/src/app/(handoff)/connect/_components/connect-page-states.test.tsx
@@ -1,7 +1,10 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { APP_ROUTES } from "@/app/routes";
-import { ConnectNoSessionFallbackState } from "./connect-page-states";
+import {
+  ConnectNoSessionFallbackState,
+  ConnectReadyState,
+} from "./connect-page-states";
 
 vi.mock("next/link", () => ({
   default: ({
@@ -14,6 +17,63 @@ vi.mock("next/link", () => ({
     </a>
   ),
 }));
+
+const APP = {
+  displayName: "Discover Weekly Archive",
+  iconUrls: [],
+  fallbackLabel: "D",
+  iconBg: "#E8EBF0",
+  iconFg: "#101114",
+};
+
+describe("ConnectReadyState", () => {
+  it("shows the desktop deep-link CTA on desktop", () => {
+    render(
+      <ConnectReadyState
+        app={APP}
+        requestedDataLabel="Spotify"
+        deepLinkUrl="vana://connect?sessionId=s1&masterKeySig=abc"
+        downloadDataConnectHref="/download"
+        isMobile={false}
+      />,
+    );
+
+    expect(
+      screen
+        .getByRole("link", { name: /Open DataConnect/i })
+        .getAttribute("href"),
+    ).toBe("vana://connect?sessionId=s1&masterKeySig=abc");
+  });
+
+  it("does NOT render the vana:// deep link on mobile (scheme dead-ends)", () => {
+    render(
+      <ConnectReadyState
+        app={APP}
+        requestedDataLabel="Spotify"
+        deepLinkUrl="vana://connect?sessionId=s1&masterKeySig=abc"
+        downloadDataConnectHref="/download"
+        isMobile={true}
+      />,
+    );
+
+    expect(document.querySelector('a[href^="vana://"]')).toBeNull();
+  });
+
+  it("offers a finish-on-a-computer hand-off on mobile", () => {
+    render(
+      <ConnectReadyState
+        app={APP}
+        requestedDataLabel="Spotify"
+        deepLinkUrl="vana://connect?sessionId=s1&masterKeySig=abc"
+        downloadDataConnectHref="/download"
+        isMobile={true}
+      />,
+    );
+
+    expect(screen.getByText(/on your desktop to finish/i)).toBeTruthy();
+    expect(screen.getByRole("button", { name: /copy link/i })).toBeTruthy();
+  });
+});
 
 describe("ConnectNoSessionFallbackState", () => {
   it("links to the internal download route", () => {

--- a/connect/src/app/(handoff)/connect/_components/connect-page-states.test.tsx
+++ b/connect/src/app/(handoff)/connect/_components/connect-page-states.test.tsx
@@ -70,8 +70,37 @@ describe("ConnectReadyState", () => {
       />,
     );
 
-    expect(screen.getByText(/on your desktop to finish/i)).toBeTruthy();
+    expect(screen.getByText(/open it on your desktop/i)).toBeTruthy();
     expect(screen.getByRole("button", { name: /copy link/i })).toBeTruthy();
+  });
+
+  it("does NOT offer the desktop-app download on mobile", () => {
+    render(
+      <ConnectReadyState
+        app={APP}
+        requestedDataLabel="Spotify"
+        deepLinkUrl="vana://connect?sessionId=s1&masterKeySig=abc"
+        downloadDataConnectHref="/download"
+        isMobile={true}
+      />,
+    );
+
+    expect(screen.queryByText(/Don't have it\?/i)).toBeNull();
+    expect(screen.queryByText(/Get DataConnect/i)).toBeNull();
+  });
+
+  it("keeps the desktop-app download on desktop", () => {
+    render(
+      <ConnectReadyState
+        app={APP}
+        requestedDataLabel="Spotify"
+        deepLinkUrl="vana://connect?sessionId=s1&masterKeySig=abc"
+        downloadDataConnectHref="/download"
+        isMobile={false}
+      />,
+    );
+
+    expect(screen.getByText(/Get DataConnect/i)).toBeTruthy();
   });
 });
 

--- a/connect/src/app/(handoff)/connect/_components/connect-page-states.tsx
+++ b/connect/src/app/(handoff)/connect/_components/connect-page-states.tsx
@@ -1,12 +1,13 @@
 "use client";
 
 import { ArrowUpRightIcon, RotateCcwIcon, XIcon } from "lucide-react";
-import { useEffect } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { APP_ROUTES } from "@/app/routes";
 import { Spinner } from "@/components/elements/spinner";
 import { Text } from "@/components/typography/text";
 import { ButtonArrow } from "@/components/ui/button";
 import type { ConnectAppMetadata } from "../_lib/app-registry";
+import { resolveConnectReadyMode } from "../_lib/ready-mode";
 import {
   ConnectLaunchSection,
   DefaultDownloadSecondary,
@@ -118,16 +119,23 @@ export function ConnectReadyState({
   deepLinkUrl,
   downloadDataConnectHref,
   isLocalServerAuthFromDataConnect = false,
+  isMobile = false,
 }: {
   app: ConnectAppMetadata;
   requestedDataLabel: string | null;
   deepLinkUrl: string;
   downloadDataConnectHref: string;
   isLocalServerAuthFromDataConnect?: boolean;
+  isMobile?: boolean;
 }) {
   const isHttpsRedirect = deepLinkUrl.startsWith("https://");
   const resolvedRequestedDataLabel =
     resolveRequestedDataLabel(requestedDataLabel);
+  const mode = resolveConnectReadyMode({
+    isHttpsRedirect,
+    isMobile,
+    isLocalServerAuthFromDataConnect,
+  });
 
   useEffect(() => {
     if (isHttpsRedirect) {
@@ -135,7 +143,7 @@ export function ConnectReadyState({
     }
   }, [isHttpsRedirect, deepLinkUrl]);
 
-  if (isHttpsRedirect) {
+  if (mode === "https-redirect") {
     return (
       <ConnectStateFrame
         app={app}
@@ -149,6 +157,34 @@ export function ConnectReadyState({
           <Text as="h1" intent="xlarge" dim>
             Redirecting back to your application.
           </Text>
+        }
+      />
+    );
+  }
+
+  // Mobile on the vana:// path: the scheme is desktop-only, so the deep-link
+  // button opens the wrong app or nothing (BUI-449). Offer a cross-device
+  // hand-off instead of a dead-end. `requestedDataLabel`/title are unchanged so
+  // the user still sees what they're approving.
+  if (mode === "mobile-handoff") {
+    return (
+      <ConnectStateFrame
+        app={app}
+        title={
+          <Text as="h1" intent="title">
+            {`${app.displayName} wants access to your ${resolvedRequestedDataLabel}`}
+          </Text>
+        }
+        subtitle={
+          <Text as="p" intent="large" dim balance>
+            Approving this needs DataConnect, which runs on a computer. Open
+            this page on your desktop to finish.
+          </Text>
+        }
+        content={
+          <ConnectMobileHandoffContent
+            downloadDataConnectHref={downloadDataConnectHref}
+          />
         }
       />
     );
@@ -186,6 +222,39 @@ export function ConnectReadyState({
             )
           }
         />
+      }
+    />
+  );
+}
+
+function ConnectMobileHandoffContent({
+  downloadDataConnectHref,
+}: {
+  downloadDataConnectHref: string;
+}) {
+  const [copied, setCopied] = useState(false);
+
+  const onCopy = useCallback(() => {
+    const link = typeof window === "undefined" ? "" : window.location.href;
+    const clipboard =
+      typeof navigator === "undefined" ? undefined : navigator.clipboard;
+    if (clipboard?.writeText) {
+      clipboard.writeText(link).then(
+        () => setCopied(true),
+        () => setCopied(false),
+      );
+    }
+  }, []);
+
+  return (
+    <ConnectLaunchSection
+      primaryAction={{
+        kind: "button",
+        onClick: onCopy,
+        label: copied ? "Link copied" : "Copy link",
+      }}
+      secondaryContent={
+        <DefaultDownloadSecondary href={downloadDataConnectHref} />
       }
     />
   );

--- a/connect/src/app/(handoff)/connect/_components/connect-page-states.tsx
+++ b/connect/src/app/(handoff)/connect/_components/connect-page-states.tsx
@@ -177,15 +177,11 @@ export function ConnectReadyState({
         }
         subtitle={
           <Text as="p" intent="large" dim balance>
-            Approving this needs DataConnect, which runs on a computer. Open
-            this page on your desktop to finish.
+            Approving this needs DataConnect, which runs on a computer. Copy
+            this link, open it on your desktop, and finish there.
           </Text>
         }
-        content={
-          <ConnectMobileHandoffContent
-            downloadDataConnectHref={downloadDataConnectHref}
-          />
-        }
+        content={<ConnectMobileHandoffContent />}
       />
     );
   }
@@ -227,11 +223,7 @@ export function ConnectReadyState({
   );
 }
 
-function ConnectMobileHandoffContent({
-  downloadDataConnectHref,
-}: {
-  downloadDataConnectHref: string;
-}) {
+function ConnectMobileHandoffContent() {
   const [copied, setCopied] = useState(false);
 
   const onCopy = useCallback(() => {
@@ -246,15 +238,20 @@ function ConnectMobileHandoffContent({
     }
   }, []);
 
+  // No "Get DataConnect" download link here: DataConnect is desktop-only, so
+  // pointing a phone at a desktop installer is a dead end (BUI-449). The hand-off
+  // is "take this link to a computer", not "install something here".
   return (
     <ConnectLaunchSection
       primaryAction={{
         kind: "button",
         onClick: onCopy,
-        label: copied ? "Link copied" : "Copy link",
+        label: copied ? "Link copied — open it on your computer" : "Copy link",
       }}
       secondaryContent={
-        <DefaultDownloadSecondary href={downloadDataConnectHref} />
+        <Text as="p" intent="small" muted>
+          Send the link to yourself and open it on a computer to finish.
+        </Text>
       }
     />
   );

--- a/connect/src/app/(handoff)/connect/_lib/ready-mode.test.ts
+++ b/connect/src/app/(handoff)/connect/_lib/ready-mode.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { resolveConnectReadyMode } from "./ready-mode";
+
+describe("resolveConnectReadyMode", () => {
+  it("redirects OAuth/HTTPS flows regardless of device", () => {
+    expect(
+      resolveConnectReadyMode({
+        isHttpsRedirect: true,
+        isMobile: true,
+        isLocalServerAuthFromDataConnect: false,
+      }),
+    ).toBe("https-redirect");
+  });
+
+  it("hands off on mobile for the vana:// path", () => {
+    expect(
+      resolveConnectReadyMode({
+        isHttpsRedirect: false,
+        isMobile: true,
+        isLocalServerAuthFromDataConnect: false,
+      }),
+    ).toBe("mobile-handoff");
+  });
+
+  it("keeps the deep-link CTA on desktop", () => {
+    expect(
+      resolveConnectReadyMode({
+        isHttpsRedirect: false,
+        isMobile: false,
+        isLocalServerAuthFromDataConnect: false,
+      }),
+    ).toBe("desktop-deep-link");
+  });
+
+  it("keeps the deep-link CTA for local-server-auth even on mobile (DataConnect owns vana://)", () => {
+    expect(
+      resolveConnectReadyMode({
+        isHttpsRedirect: false,
+        isMobile: true,
+        isLocalServerAuthFromDataConnect: true,
+      }),
+    ).toBe("desktop-deep-link");
+  });
+});

--- a/connect/src/app/(handoff)/connect/_lib/ready-mode.ts
+++ b/connect/src/app/(handoff)/connect/_lib/ready-mode.ts
@@ -1,0 +1,34 @@
+/**
+ * Which variant of the "ready" handoff screen to show.
+ *
+ * - `https-redirect`  — OAuth flow: the deep link is an HTTPS callback, auto-redirect.
+ * - `mobile-handoff`  — phone/tablet on the `vana://` path: the scheme is desktop-only
+ *                       (BUI-449), so offer a "finish on a computer" hand-off instead of
+ *                       a button that opens the wrong app / nothing.
+ * - `desktop-deep-link` — desktop on the `vana://` path: the existing "Open DataConnect" CTA.
+ *
+ * Local-server-auth-from-DataConnect always uses the deep-link CTA: it only ever
+ * happens inside DataConnect itself, which owns `vana://`, so it is never a dead-end.
+ */
+export type ConnectReadyMode =
+  | "https-redirect"
+  | "mobile-handoff"
+  | "desktop-deep-link";
+
+export function resolveConnectReadyMode({
+  isHttpsRedirect,
+  isMobile,
+  isLocalServerAuthFromDataConnect,
+}: {
+  isHttpsRedirect: boolean;
+  isMobile: boolean;
+  isLocalServerAuthFromDataConnect: boolean;
+}): ConnectReadyMode {
+  if (isHttpsRedirect) {
+    return "https-redirect";
+  }
+  if (isMobile && !isLocalServerAuthFromDataConnect) {
+    return "mobile-handoff";
+  }
+  return "desktop-deep-link";
+}

--- a/connect/src/app/(handoff)/connect/connect-page-client.tsx
+++ b/connect/src/app/(handoff)/connect/connect-page-client.tsx
@@ -2,9 +2,10 @@
 
 import dynamic from "next/dynamic";
 import { useSearchParams } from "next/navigation";
-import type { ComponentType } from "react";
+import { type ComponentType, useEffect, useState } from "react";
 import { PagePanel } from "@/app/_components/page-panel";
 import { PageShell } from "@/app/_components/page-shell";
+import { isMobileDevice } from "@/lib/platform";
 import {
   ConnectErrorState,
   ConnectLoadingState,
@@ -67,6 +68,7 @@ export function ConnectPageClient({
   emptyFooter: React.ReactNode;
 }) {
   const searchParams = useSearchParams();
+  const isMobile = useIsMobile();
   const debug = resolveConnectPageUiDebugConfig(searchParams);
   const {
     view,
@@ -141,6 +143,7 @@ export function ConnectPageClient({
                 isLocalServerAuthFromDataConnect={
                   isLocalServerAuthFromDataConnect
                 }
+                isMobile={isMobile}
               />
             ) : null}
 
@@ -158,4 +161,19 @@ export function ConnectPageClient({
       <ConnectPageUiDebugPanel />
     </>
   );
+}
+
+/**
+ * Hydration-safe mobile detection. Returns false during SSR and the first
+ * client render (so server and client markup match), then re-renders with the
+ * real value after mount. The handoff CTA flips to the mobile path one frame
+ * later — acceptable, and avoids a hydration mismatch from reading navigator
+ * during render.
+ */
+function useIsMobile(): boolean {
+  const [isMobile, setIsMobile] = useState(false);
+  useEffect(() => {
+    setIsMobile(isMobileDevice());
+  }, []);
+  return isMobile;
 }

--- a/connect/src/lib/platform.test.ts
+++ b/connect/src/lib/platform.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { isMobileUserAgent } from "./platform";
+
+const IPHONE =
+  "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1";
+const ANDROID =
+  "Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Mobile Safari/537.36";
+const IPAD_OS13 =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15";
+const MAC_DESKTOP =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36";
+const WINDOWS_DESKTOP =
+  "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36";
+
+describe("isMobileUserAgent", () => {
+  it("detects iPhone", () => {
+    expect(isMobileUserAgent(IPHONE)).toBe(true);
+  });
+
+  it("detects Android phones", () => {
+    expect(isMobileUserAgent(ANDROID)).toBe(true);
+  });
+
+  it("detects iPadOS reporting a desktop Safari UA via touch points", () => {
+    expect(isMobileUserAgent(IPAD_OS13, 5)).toBe(true);
+  });
+
+  it("does not flag a real Mac with no touch", () => {
+    expect(isMobileUserAgent(MAC_DESKTOP, 0)).toBe(false);
+  });
+
+  it("does not flag Windows desktop", () => {
+    expect(isMobileUserAgent(WINDOWS_DESKTOP, 0)).toBe(false);
+  });
+});

--- a/connect/src/lib/platform.ts
+++ b/connect/src/lib/platform.ts
@@ -13,3 +13,26 @@ export function getDownloadPlatformLabel(): string {
   const os = detectOS();
   return os === "unknown" ? "your OS" : os;
 }
+
+// Phones and tablets. The DCR handoff hands a `vana://` deep link to the OS,
+// but `vana://` is owned by the desktop DataConnect/Vana Tauri apps — there is
+// no mobile DataConnect, so on a phone the link is claimed by the native Vana
+// app (or nothing) and the approval dead-ends (BUI-449). Detect mobile so the
+// handoff can offer a "finish on a computer" path instead of a broken button.
+// iPadOS ≥13 reports a desktop Safari UA, so also treat touch-capable "Mac" as
+// mobile (real Macs are not multi-touch).
+export function isMobileUserAgent(ua: string, maxTouchPoints = 0): boolean {
+  if (/Android|iPhone|iPad|iPod|Mobile|Windows Phone/i.test(ua)) {
+    return true;
+  }
+  // iPadOS masquerading as macOS Safari.
+  if (/Macintosh/.test(ua) && maxTouchPoints > 1) {
+    return true;
+  }
+  return false;
+}
+
+export function isMobileDevice(): boolean {
+  if (typeof navigator === "undefined") return false;
+  return isMobileUserAgent(navigator.userAgent, navigator.maxTouchPoints ?? 0);
+}


### PR DESCRIPTION
Fixes the deep-link mismatch in [BUI-449](https://linear.app/vana-team/issue/BUI-449) (Oshin's mobile testing: "it says Open DataConnect but it opens the Vana app").

## Root cause

`resolveConnectLaunchUrl` hands every non-HTTPS DCR a `vana://connect?...` link, and `ConnectReadyState` labels it "Open DataConnect". But `vana://` is registered by the **desktop** DataConnect/Vana Tauri apps — there is no mobile DataConnect. On a phone the OS hands the link to the native Vana app (or nothing), approval dead-ends, and the partner app silently waits out the 15-min Session Relay TTL. There was zero UA detection in the handoff page.

## Fix (frontend-only, no backend)

Detect mobile and, on the `vana://` path, swap the broken CTA for an honest cross-device hand-off:

- Title unchanged (`{app} wants access to your {data}`) so the user still sees what they're approving.
- Subtitle explains it needs a computer.
- **Copy link** button so they can open the same `/connect?...` URL on desktop, where DataConnect owns `vana://` and the flow completes.
- Desktop, OAuth/HTTPS-redirect, and local-server-auth-from-DataConnect paths are **unchanged** (verified by tests).

This kills the silent dead-end. It does **not** let mobile users complete on the phone — that's the separate product call (web-writable scopes / ODL Cloud) tracked in the BUI-449 options memo; this is the no-regrets fix to ship before the next partner demo.

## Changes

- `lib/platform.ts`: `isMobileUserAgent` (pure, handles iPadOS-reports-as-desktop via touch points) + `isMobileDevice`
- `_lib/ready-mode.ts`: pure `resolveConnectReadyMode` → `https-redirect | mobile-handoff | desktop-deep-link`
- `ConnectReadyState`: `isMobile` prop + mobile-handoff branch that renders **no** `vana://` link
- `useIsMobile()` in the client: hydration-safe (false on SSR/first render, real value after mount)

## Tests

- TDD: mobile cases failed red first (vana:// link present, no hand-off), then green.
- 9 pure tests (platform UA matrix, mode resolver) + 3 component tests (desktop keeps deep link; mobile drops it; mobile shows hand-off + Copy link).
- All 34 handoff/platform tests pass. Biome clean on touched files.
- Note: 7 failures in `use-login-page.test.ts` are **pre-existing on `main`** (verified on a clean checkout), unrelated to this diff.

## Follow-ups (not in this PR)

- QR code alongside Copy link (needs a QR dep decision).
- Partner-side: SDK has no "needs desktop / in progress" state — session only flips to `expired` after 15 min with no reason (BUI-449 scope item 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)