### PR TITLE
docs: clarify Context Gateway SDK positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-# Vana Connect SDK
+# OpenDataLabs Context Gateway JavaScript SDK
 
-Let your users bring their own data to your app.
+`@opendatalabs/connect` is the JavaScript client SDK for
+[OpenDataLabs Context Gateway](https://www.opendatalabs.com/context-gateway).
+Use it to let users connect their own data to your app.
 
 ## CLI
 

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@opendatalabs/connect",
   "version": "0.14.0",
-  "description": "SDK for integrating Vana Data Portability 'Connect data' flows",
+  "description": "JavaScript client SDK for OpenDataLabs Context Gateway",
   "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/vana-com/vana-connect.git"
   },
-  "homepage": "https://github.com/vana-com/vana-connect#readme",
+  "homepage": "https://www.opendatalabs.com/context-gateway",
   "bugs": {
     "url": "https://github.com/vana-com/vana-connect/issues"
   },


### PR DESCRIPTION
## Summary
- position @opendatalabs/connect as the OpenDataLabs Context Gateway JavaScript SDK
- point package metadata homepage at the Context Gateway product page

## Checks
- prettier --check README.md package.json