### PR TITLE
Update Discord links to discord.gg/vanaofficial

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -195,7 +195,7 @@ rm -rf ~/.vana
 
 - [Issues](https://github.com/vana-com/cli/issues): bugs and source requests
 - [Discussions](https://github.com/vana-com/cli/discussions): questions and ideas
-- [Discord](https://discord.gg/vana): chat with the team
+- [Discord](https://discord.gg/vanaofficial): chat with the team
 - [Contributing](CONTRIBUTING.md)
 
 ## License


### PR DESCRIPTION
Replaces all old Vana Discord invite links (`vanabuilders`, `withvana`, and one-off invite codes) with the new official invite: **https://discord.gg/vanaofficial**

Requested by Art in Slack: https://vana-org.slack.com/archives/C04LQ9RLUE4/p1783037520721549

Third-party Discord links (other projects/DataDAOs) were intentionally left unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)